### PR TITLE
CAT-61 Use local backend and keycloak by default

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -1,6 +1,6 @@
 {
   "api": {
-    "base_url": "https://api.cat.argo.grnet.gr",
+    "base_url": "http://localhost:8080",
     "version": "v1"
   }
 }

--- a/src/keycloak.json
+++ b/src/keycloak.json
@@ -1,9 +1,9 @@
 {
-    "realm": "",
-    "url": "",
+    "realm": "quarkus",
+    "url": "http://localhost:58080/",
     "ssl-required": "external",
-    "resource": "",
+    "resource": "frontend-service",
     "public-client": true,
-    "confidential-port": 999999,
-    "clientId": ""
+    "confidential-port": 0,
+    "clientId": "frontend-service"
 }


### PR DESCRIPTION
# 🎯 Goal
Make cat-ui by default to work with local backend (cat-api at 8080) and local keycloak (58080 with default quarkus realm config)

- [x] Change config.json to use localhost backend
- [x] Change keycloak.json to user localhost keycloak and quarkus realm