### PR TITLE
CAT-98 Display assessment header information

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,7 +32,7 @@ function App() {
             <Container>
               <Routes>
                 <Route path="/" element={<Home />} />
-                <Route path="/assessment" element={<ProtectedRoute />} >
+                <Route path="/assessment/:valID" element={<ProtectedRoute />} >
                   <Route index element={<AssessmentEdit />} />
                 </Route>
                 <Route path="/profile" element={<ProtectedRoute />} >
@@ -66,7 +66,6 @@ function App() {
             </main>
             <Footer/>
           </BrowserRouter>
-         
         </QueryClientProvider>
       </AuthProvider>
     </div>

--- a/src/api/services/Template.ts
+++ b/src/api/services/Template.ts
@@ -6,6 +6,7 @@ import { useQuery } from "@tanstack/react-query";
 const Template = {
   useGetTemplate: (templateTypeId: number, actorId: number, token: string, isRegistered: boolean ) =>
     useQuery<TemplateResponse, any>({
+      queryKey: ["template"],
       queryFn: async () => {
         const response = await Client(token).get<TemplateResponse>(
           `/templates/by-type/${templateTypeId}/by-actor/${actorId}`

--- a/src/api/services/Validation.ts
+++ b/src/api/services/Validation.ts
@@ -74,7 +74,7 @@ const Validation = {
         console.log(error);
         return error.response as ApiServiceErr;
       },
-      enabled: !!token && isRegistered,
+      enabled: !!token && isRegistered && (validation_id !== ""),
     }),
   useValidationRequest: ({
     organisation_role,

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -82,7 +82,7 @@ function Header() {
             <Link to="/" className="cat-nav-link">SEARCH</Link>
           </NavItem>
           <NavItem>
-            <Link to="/assessment" className="cat-nav-link">ASSESS</Link>
+            <Link to="/validations" className="cat-nav-link">ASSESS</Link>
           </NavItem>
           <NavItem>
             <Link to="/" className="cat-nav-link">RESOURCES</Link>

--- a/src/components/assessment/AssessmentInfo.tsx
+++ b/src/components/assessment/AssessmentInfo.tsx
@@ -1,0 +1,75 @@
+/**
+ * Component to display and edit the assessment info 
+ */
+
+import { InputGroup, Form, Col, Row } from "react-bootstrap"
+
+interface AssessmentInfoProps {
+    id?: string
+    name: string
+    actor: string
+    type: string
+    org: string
+    orgId: string
+}
+
+export const AssessmentInfo = (props: AssessmentInfoProps) => {
+    return (
+        <div>
+            {props.id && <div><strong>Assesment id:</strong> {props.id}</div>}
+            <Row>
+                {props.id &&
+                    <Col>
+                        <InputGroup className="mb-3">
+                            <InputGroup.Text id="label-info-name">
+                                Id:
+                            </InputGroup.Text>
+                            <Form.Control id="input-info-name" placeholder={props.id} aria-describedby="label-info-name" readOnly />
+                        </InputGroup>
+                    </Col>
+                }
+                <Col>
+                    <InputGroup className="mb-3">
+                        <InputGroup.Text id="label-info-name">
+                            Name:
+                        </InputGroup.Text>
+                        <Form.Control id="input-info-name" aria-describedby="label-info-name" />
+                    </InputGroup>
+                </Col>
+            </Row>
+
+            <Row>
+                <Col>
+                    <InputGroup className="mb-3" size="sm">
+                        <InputGroup.Text id="label-info-type">
+                            Type:
+                        </InputGroup.Text>
+                        <Form.Control id="input-info-type" placeholder={props.type} aria-describedby="label-info-type" readOnly />
+                    </InputGroup>
+                </Col>
+                <Col>
+                    <InputGroup className="mb-3" size="sm">
+                        <InputGroup.Text id="label-info-actor">
+                            Actor:
+                        </InputGroup.Text>
+                        <Form.Control id="input-info-actor" placeholder={props.actor} aria-describedby="label-info-actor" readOnly />
+                    </InputGroup>
+                </Col>
+                <Col xs={6}>
+                    <InputGroup className="mb-3" size="sm">
+                        <InputGroup.Text id="label-info-org">
+                            Organisation:
+                        </InputGroup.Text>
+                        <Form.Control id="input-info-org" placeholder={props.org} aria-describedby="label-info-org" readOnly />
+                        <InputGroup.Text className="text-white bg-secondary"><span className="me-2">id: </span><strong>{props.orgId}</strong></InputGroup.Text>
+                    </InputGroup>
+
+
+                </Col>
+
+            </Row>
+
+        </div>
+
+    );
+}

--- a/src/pages/AssessmentEdit.tsx
+++ b/src/pages/AssessmentEdit.tsx
@@ -1,37 +1,116 @@
 import { useEffect, useState, useContext } from 'react';
 import { AuthContext } from '../auth/AuthContext';
-import { TemplateAPI } from '../api';
+import { TemplateAPI, ValidationAPI } from '../api';
 import { Assessment } from '../types';
+import { useParams } from "react-router";
+import { Tab, Row, Col, Nav } from 'react-bootstrap';
+import { AssessmentInfo } from '../components/assessment/AssessmentInfo';
+
+type AssessmentEditProps = {
+  createMode?: boolean;
+}
+
 
 /** AssessmentEdit page that holds the main body of an assessment */
-function AssessmentEdit() {
-    const { keycloak, registered } = useContext(AuthContext)!;
-    const [assessment,setAssesment] = useState<Assessment>();
+const AssessmentEdit = ({ createMode = true }: AssessmentEditProps) => {
+  const { keycloak, registered } = useContext(AuthContext)!;
+  const [assessment, setAssesment] = useState<Assessment>();
 
-    // for the time being get the only one assessment template supported
-    // with templateId: 1 (pid policy) and actorId: 6 (for pid owner)
-    // this will be replaced in time with dynamic code
-    const {data, isLoading } =  TemplateAPI.useGetTemplate(
-      1, 6, keycloak?.token, registered)
+  const [debug, setDebug] = useState<boolean>(false);
+
+  const { valID } = useParams()
   
-    // save the template_doc into the assessment state variable
-    useEffect(() => {
-        if (data) {
-          setAssesment(data?.template_doc);
-        }
-       
-      }, [data]);
 
-    return (
-      <div className="mt-4">
-        <h2>Create Assessment</h2>
-        { isLoading 
-          ? <p>Loading Assessment Body...</p> 
-          : <code>{JSON.stringify(assessment)}</code>
-        }
-      </div>
-    );
- 
+  // for the time being get the only one assessment template supported
+  // with templateId: 1 (pid policy) and actorId: 6 (for pid owner)
+  // this will be replaced in time with dynamic code
+  const qTemplate = TemplateAPI.useGetTemplate(
+    1, 6, keycloak?.token, registered)
+
+  const qValidation = ValidationAPI.useGetValidationDetails(
+    { validation_id: valID!, token: keycloak?.token, isRegistered: registered }
+  );
+
+  // save the template_doc into the assessment state variable
+  useEffect(() => {
+    if (qTemplate.data && qValidation.data) {
+      const data = qTemplate.data.template_doc;
+      data.organisation.id = qValidation.data.organisation_id;
+      data.organisation.name = qValidation.data.organisation_name;
+      setAssesment(data);
+    }
+
+  }, [qTemplate.data, qValidation]);
+
+
+
+  console.log(assessment?.assessment_type)
+
+  return (
+    <div className="mt-4">
+      <h2> {(createMode ? "Create" : "Edit") + " Assessment"}</h2>
+      <br/>
+      {/* when template data hasn't loaded yet */}
+      {qTemplate.isLoading || qValidation.isLoading || !assessment
+        ? <p>Loading Assessment Body...</p>
+        :
+        <>
+          {/* Display the Assessment header info */}
+          <AssessmentInfo 
+            id={assessment.id}
+            name={assessment.name} 
+            actor={assessment.actor}
+            type={assessment.assessment_type}
+            org={assessment.organisation.name}
+            orgId={assessment.organisation.id}
+          />
+
+          <hr/>
+
+          <Tab.Container id="left-tabs-example" defaultActiveKey="first">
+            <Row>
+              <Col sm={3}>
+                <Nav variant="pills" className="flex-column">
+                  <Nav.Item>
+                    <Nav.Link eventKey="first">Criterion 1
+                </Nav.Link>
+                  </Nav.Item>
+                  <Nav.Item>
+                    <Nav.Link eventKey="second">Criterion 2</Nav.Link>
+                  </Nav.Item>
+                </Nav>
+              </Col>
+              <Col sm={9}>
+                <Tab.Content className="text-dark">
+                  <Tab.Pane eventKey="first"><p>Tests for Criterion 1</p></Tab.Pane>
+                  <Tab.Pane eventKey="second">Tests for Criterion 2</Tab.Pane>
+                </Tab.Content>
+              </Col>
+            </Row>
+          </Tab.Container>
+
+
+          {/* Debug info here - display assessment json */}
+
+          <div className="mt-5">
+            <button type="button" className="btn btn-warning btn-sm"
+            onClick={()=>setDebug(!debug)}
+            >Debug JSON</button>
+            <br />
+            { debug &&
+              <pre className="p-2 bg-dark text-white"><code>{JSON.stringify(assessment, null, 2)}</code></pre>
+            }
+            </div>
+
+
+
+
+
+        </>
+      }
+    </div>
+  );
+
 }
 
 export default AssessmentEdit;

--- a/src/pages/Validations.tsx
+++ b/src/pages/Validations.tsx
@@ -10,7 +10,7 @@ import {
 import { Link, useParams, useNavigate } from "react-router-dom";
 import {
   FaCheck, FaList, FaTimes, FaExclamationTriangle, FaPlus,
-  FaRegCheckSquare, FaGlasses
+  FaRegCheckSquare, FaGlasses, FaCross
 } from 'react-icons/fa';
 import decode from 'jwt-decode';
 import { Table } from '../components/Table';
@@ -411,11 +411,20 @@ function Validations(props: ValidationProps) {
               }
               else {
                 return (
+                  <div className="edit-buttons btn-group shadow">
                   <Link
                     className="btn btn-secondary btn-sm "
                     to={`/validations/${props.row.original.id}`}>
                     <FaList />
                   </Link>
+                  {props.row.original.status === "APPROVED" &&
+                      <Link
+                        className="btn btn-secondary cat-action-approve-link btn-sm "
+                        to={`/assessment/${props.row.original.id}`}>
+                        <FaPlus /> Assessment
+                      </Link>
+                  }
+                  </div>
                 )
               }
             },

--- a/src/types/assessment.ts
+++ b/src/types/assessment.ts
@@ -56,7 +56,7 @@ export interface AssessmentOrg {
 /** An assessment has a definite result wether compliance is met or not and a ranking score */
 export interface AssessmentResult {
   compliance: boolean;
-
+  ranking: number;
 }
 
 /** An assessment contains a list of principles */


### PR DESCRIPTION
# 🎯 Goal
Add a new view to the ui allowing the user to create a new assessment. For the time being the process is initiated from the Validation list view. Each approved validation has a `+ Assessment` button that redirects to the new create assessment view. The view displays a header with general information for the assessment such as id, name, organisation, type. This view is implemented as a separate component with all the required props and it is used by the AssessmentEdit page 

# 🏗️ Implementation
- [x] Update validation list view and add the create assessment button
- [x] Update AssessmentEdit view and accept a validation id prop based on which a new assessment will be created. AssessmentEdit view contacts the backend with the validation id and gets all the appropriate information for starting the new assessment (such as actor, organisation etc)
- [x] Add the AssessmentInfo component which displays the assessment header information with stuff like name, id, organisation, type 
- [x] Use the AssessmentInfo component in the AssessmentEdit page passing the correct props
- [x] Add a placeholder layout component with tabs to prepare space for displaying the different criteria and tests
- [x] Make debug json button clickable allowing the dev to view the underlying assessment json (this will be removed in the final version)