### PR TITLE
CAT-152 update assessment actor/assessment_type field schemas to use …

### DIFF
--- a/src/pages/AssessmentEdit.tsx
+++ b/src/pages/AssessmentEdit.tsx
@@ -59,8 +59,8 @@ const AssessmentEdit = ({ createMode = true }: AssessmentEditProps) => {
           <AssessmentInfo 
             id={assessment.id}
             name={assessment.name} 
-            actor={assessment.actor}
-            type={assessment.assessment_type}
+            actor={assessment.actor.name}
+            type={assessment.assessment_type.name}
             org={assessment.organisation.name}
             orgId={assessment.organisation.id}
           />

--- a/src/types/assessment.ts
+++ b/src/types/assessment.ts
@@ -27,13 +27,22 @@ export interface Assessment {
   status: AssessmentStatus;
   timestamp: string;
   subject: Subject;
-  assessment_type: string;
-  actor: string;
+  assessment_type: AssessmentType;
+  actor: AssessmentActor;
   organisation: AssessmentOrg;
   result: AssessmentResult;
   principles: Principle[];
 
 }
+/** Reference with numerical id */
+export interface RefNumID {
+  id: number;
+  name: string;
+}
+
+export interface AssessmentActor extends RefNumID {}
+export interface AssessmentType extends RefNumID{}
+
 /** Assessment subject */
 export interface Subject {
   id: string;


### PR DESCRIPTION
…both ids and names

Assessment JSON now displays actor and assessment type not as strings but as objects with id and name
example:
```json
{
  "actor": {
    "name": "type of actor",
    "id": 1
  },
  "assessment_type": {
    "name": "type of assessment",
    "id": 1
  }
}
```
- Add a new generic interface for fields that have both ids:number and name:string value
- extend the interface for AssessmentType and AssessmentActor

update Assessment form fields to use the name part