### PR TITLE
CAT-Add dynamic evaluation of assessment and provide statistics

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -29,7 +29,9 @@
   background-color: rgb(220, 220, 220);
 }
 
-
+.cat-metric-tooltip .tooltip.show p{
+ text-align: left;
+}
 
 .cat-nav-link {
   -moz-transition: all .2s ease-in;
@@ -94,3 +96,5 @@ footer a{
   vertical-align: top;
   margin-left: -1px;
 }
+
+

--- a/src/components/assessment/AssessmentTabs.tsx
+++ b/src/components/assessment/AssessmentTabs.tsx
@@ -1,0 +1,152 @@
+import { Alert, Col, ListGroup, Nav, OverlayTrigger, Row, Tab, Tooltip } from "react-bootstrap"
+import { AssessmentTest, CriterionImperative, MetricAlgorithm, Principle } from "../../types"
+import { TestBinary } from "../tests/TestBinary"
+import { FaInfoCircle } from "react-icons/fa"
+
+type AssessmentTabsProps = {
+    principles: Principle[],
+    onTestChange(principleId: string, criterionId: string, newTest: AssessmentTest): void
+  }
+  
+/** AssessmentTabs holds the tabs and test content for different criteria */
+export default function AssessmentTabs(props: AssessmentTabsProps){
+  
+    const navs: JSX.Element[] = []
+    const tabs: JSX.Element[] = []
+  
+    let firstCriterionId = ""
+  
+    props.principles.forEach(principle => {
+  
+  
+  
+      // push principle lable to navigation list
+      navs.push(<span className="mb-2" key={principle.id}>{principle.id} - {principle.name}:</span>)
+  
+      principle.criteria.forEach(criterion => {
+        // grab first criterion id to make it by default active
+        if (!firstCriterionId) {
+          firstCriterionId = criterion.id
+        }
+        navs.push(<Nav.Item key={criterion.id}><Nav.Link eventKey={criterion.id}>{criterion.id} - {criterion.name}</Nav.Link></Nav.Item>)
+  
+        // tests for each criterion
+        let testList: JSX.Element[] = [];
+  
+        // store state of test results
+        criterion.metric.tests.forEach(test => {
+          if (test.type === "binary") {
+            testList.push(
+              <ListGroup.Item key={test.id}>
+                <TestBinary
+                  test={test}
+                  onTestChange={props.onTestChange}
+                  criterionId={criterion.id}
+                  principleId={principle.id}
+                />
+              </ListGroup.Item>)
+          }
+        })
+  
+        // add criterion content
+        tabs.push(
+          <Tab.Pane key={criterion.id} className="text-dark" eventKey={criterion.id}>
+            {/* add a principle info box before criterion content */}
+            <Alert variant="light">
+              <h6>Principle {principle.id}: {principle.name}</h6>
+              <small className="text-small">{principle.description}</small>
+            </Alert>
+            <div>
+            <Alert variant='light'>
+              <Row>
+                <Col>
+                <h5>Criterion {criterion.id}: {criterion.name} 
+              { criterion.imperative === CriterionImperative.Should 
+                ? <span className="badge bg-success bg-small ms-2">Should</span>
+                : <span className="badge bg-warning bg-small ms-2">May</span>
+              }
+              </h5>
+              <p>{criterion.description}</p>
+                </Col>
+                <Col xs={3}>
+                  <div className="text-end">
+                  
+                  Metric:{criterion.metric.result === null
+                  ? <span className="badge bg-secondary ms-2">UNKNOWN</span>  
+                  : (criterion.metric.result > 0)
+                    ? <span className="badge bg-success ms-2">PASS</span> 
+                    : <span className="badge bg-danger ms-2">FAIL</span> 
+                  }
+  
+                  <OverlayTrigger overlay={<Tooltip className="cat-metric-tooltip" id="info-metric">
+                    <p>
+                      The final <em>result</em> of this metric is a <code>{criterion.metric.type}</code>.
+                      { criterion.metric.type === "number" &&
+                      <>
+                        <br/>
+                        - <em>result</em> of <code>0</code> indicates a <span className="text-success">PASS</span>.
+                        <br/>
+                        - <em>result</em> of <code>0</code> indicates a <span className="text-danger">FAIL</span>.
+                        <br/>
+                      </>
+                      }
+                      { criterion.metric.algorithm === MetricAlgorithm.Single  &&
+                      <>
+                        The <em>result</em> is based on the <em>value</em> of the single test.
+                        <br/>
+                      </>
+                      }
+                      { criterion.metric.algorithm === MetricAlgorithm.Sum  &&
+                      <>
+                        The <em>result</em> is based on the <strong>value</strong> calculated from summing the result values of all included tests.
+                        <br/>
+                      </>
+                      }
+                      { "equal_greater_than" in criterion.metric.benchmark  &&
+                      <>
+                        This <em>value</em> should be <code>&gt;= {criterion.metric.benchmark["equal_greater_than"]} </code>
+                        <br/>
+                      </>
+                      }
+                    </p>
+                    
+                  </Tooltip>}>
+                      <span><FaInfoCircle className="ms-2" title="tootltip"/></span>
+                  </OverlayTrigger>
+                  
+                  </div>
+                  
+  
+                </Col>
+              </Row>
+              
+              
+              </Alert>
+              <ListGroup>
+                {testList}
+              </ListGroup>
+            </div>
+          </Tab.Pane>
+        )
+      })
+  
+    })
+  
+    return (
+      <Tab.Container id="left-tabs-example" defaultActiveKey={firstCriterionId}>
+        <Row>
+          <Col sm={3}>
+            <Nav variant="pills" className="flex-column">
+              {navs}
+            </Nav>
+          </Col>
+          <Col sm={9}>
+            <Tab.Content >
+              {tabs}
+            </Tab.Content>
+          </Col>
+        </Row>
+      </Tab.Container>
+    )
+  }
+  

--- a/src/components/tests/TestBinary.tsx
+++ b/src/components/tests/TestBinary.tsx
@@ -67,7 +67,14 @@ export const TestBinary = (props:AssessmentTestProps) => {
                     onListChange={onURLChange}
                 />
 
-                <div className="text-muted mt-2 border-top align-right"><span><em>Test Result: </em><strong>{props.test.value}</strong></span></div>
+                <div className="text-muted mt-2 border-top align-right">
+                    <small><em>Test Result: </em>
+                    { props.test.value !== null
+                    ? <strong>{props.test.value}</strong>
+                    : <span><strong>Unknown</strong> - Please answer the question above</span>
+                    }
+                    </small>
+                </div>
             </Form>
            
         </div>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 import 'bootstrap/dist/css/bootstrap.css';

--- a/src/types/assessment.ts
+++ b/src/types/assessment.ts
@@ -33,8 +33,9 @@ export interface Assessment {
   result: AssessmentResult;
   principles: Principle[];
   published: boolean;
-
 }
+
+
 /** Reference with numerical id */
 export interface RefNumID {
   id: number;
@@ -65,8 +66,8 @@ export interface AssessmentOrg {
 
 /** An assessment has a definite result wether compliance is met or not and a ranking score */
 export interface AssessmentResult {
-  compliance: boolean;
-  ranking: number;
+  compliance: boolean| null;
+  ranking: number | null;
 }
 
 /** An assessment contains a list of principles */
@@ -81,15 +82,15 @@ export interface Principle {
 export interface Criterion {
   id: string;
   name: string;
-  type: CriterionType
+  imperative: CriterionImperative
   metric: Metric;
   description?: string;
 }
 
 /** Each criterion can be either mandatory or optional */
-export enum CriterionType {
-  Mandatory = "mandatory",
-  Optional = "optional"
+export enum CriterionImperative {
+  May = "may",
+  Should = "should"
 }
 
 /** Each criterion includes a SINGLE metric */
@@ -97,8 +98,8 @@ export interface Metric {
   type: MetricType;
   algorithm: MetricAlgorithm;
   benchmark: Benchmark
-  value: number;
-  result: number;
+  value: number | null;
+  result: number | null;
   tests: AssessmentTest[];
 }
 
@@ -107,9 +108,10 @@ export enum MetricType {
   Number = "number"
 }
 
-/** Each metric has an algorithm. For now, we only deal with algorithm: sum  */
+/** Each metric has an algorithm. For now, we only deal with algorithms: single and sum  */
 export enum MetricAlgorithm {
-  Sum = "sum"
+  Sum = "sum",
+  Single = "single"
 }
 
 /** Each metric includes a benchmark. For now, we only deal with equal than greater kind  */
@@ -130,11 +132,18 @@ export interface TestBinary {
   guidance? :string; 
   type: "binary";
   text: string;
-  value: 0 | 1;
+  value: 0 | 1 | null;
   evidence_url: string[]
 }
 
 /** Each assessment test will gonna have different types - right now only one type: binary test is supported  */
 export type AssessmentTest = TestBinary
 
-
+export interface ResultStats {
+  totalMandatory: number,
+  totalOptional: number,
+  mandatoryFilled: number,
+  optionalFilled: number,
+  mandatory: number,
+  optional: number
+}

--- a/src/utils/Assessment.tsx
+++ b/src/utils/Assessment.tsx
@@ -1,0 +1,66 @@
+/** Helper  */
+
+import { Assessment, CriterionImperative, Metric, ResultStats, TestBinary } from "../types";
+
+
+/** Evaluates all tests of a metric if the metric is number */
+export function evalMetric(metric: Metric): {result:number|null, value:number|null } {
+    // Usage only for metrics of type number
+    let value:number|null = null, result:number|null = null;
+    if (metric.type !== "number") return {result:result, value:value};
+    
+    // if metric algo indicates sum calculate the sum of test scores
+    if (metric.algorithm === "sum" || metric.algorithm === "single") {
+        // if one of the tests in not filled yet the result of the metric should be -1 (unresolved)
+        value = metric.tests.reduce((sum: (number|null),item: TestBinary)=>
+        {
+            // if any of the test values are null (not filled-in) designate the whole metric value/result as null
+            if (sum === null || item.value === null) return null;
+            return sum+item.value
+        },0)
+    }
+    // if all the tests are filled-in and a value has been produced calculate also the rating
+    if (value !== null) {
+        if ("equal_greater_than" in metric.benchmark) {
+            result = (value && value >= metric.benchmark["equal_greater_than"]) ? 1 : 0
+        }
+    }
+    
+    return ({result:result, value:value})
+}
+
+/** Evaluates compliance, ranking and stats for the Assessment provided by checking all the included criteria */
+export function evalAssessment(assessment: Assessment | undefined | null ): ResultStats | null{
+    
+    if (!assessment) return null;
+    
+    let mandatory: (number|null)[] = []
+    let optional: (number|null)[] = []
+
+    assessment.principles.forEach(principle =>{
+        principle.criteria.forEach(criterion =>{
+            if (criterion.imperative === CriterionImperative.Should) {
+                mandatory.push(criterion.metric.result)
+            } else {
+                optional.push(criterion.metric.result)
+            }
+        })
+    })
+
+    const mandatoryFilledCount = mandatory.filter(result => result !== null).length;
+    const optionalFilledCount = optional.filter(result => result !== null).length;
+    const mandatoryCount = mandatory.filter(result => result !== null && result > 0).length;
+    const optionalCount = optional.filter(number => number !==null && number >0 ).length;
+
+    return {
+        totalMandatory: mandatory.length,
+        totalOptional: optional.length,
+        mandatoryFilled: mandatoryFilledCount,
+        optionalFilled: optionalFilledCount,
+        mandatory: mandatoryCount,
+        optional: optionalCount
+    }
+    
+}
+
+                         


### PR DESCRIPTION
# 🎯 Goal
Give the ability to evaluate criteria metrics and the whole assessment compliance and ranking while the user interacts and fills-in the tests

# 🏗️ Implementation

- [x] Create two helper functions in `utils`:
- `evalMetric` accepts a criterion metric and the included tests and calculates its value based on the algorithm and benchmark provided. ⚡ this Function is called when handling changes in the assessment state
- `evalCriteria` accepts an assessment and calculates the compliance and the ranking (and some stats) by examining all included criteria. ⚡ this Function is called before rendering the assessment view
- [x] Display results in metric section (for metric) and provide also a tooltip with thorough explanation how the metric was calculated
- [x] Display results in assessment view (compliance, ranking and stats)
- [x] Reorganise AssessmentTabs component into its own file
- [x] Update Assessment types so input values from user in tests and metrics are nullable numbers

