### PR TITLE
CAT-103 Add functionality to store/update an assessment. 

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -98,3 +98,6 @@ footer a{
 }
 
 
+.cat-text-faded {
+  color:lightgrey;
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,7 @@ import { Home, Profile, RequestValidation, Validations, Users, ProfileUpdate, Va
 
 import './App.css';
 import AssessmentEdit from './pages/AssessmentEdit';
+import Assessments from './pages/Assessments';
 
 const queryClient = new QueryClient();
 
@@ -32,8 +33,15 @@ function App() {
             <Container>
               <Routes>
                 <Route path="/" element={<Home />} />
-                <Route path="/assessment/:valID" element={<ProtectedRoute />} >
+                <Route path="/assessments/create/:valID" element={<ProtectedRoute />} >
                   <Route index element={<AssessmentEdit />} />
+                </Route>
+                <Route path="/assessments/:asmtID" element={<ProtectedRoute />} >
+                  {/* Use AssessmentEdit component with create mode = false to configure the view for update */}
+                  <Route index element={<AssessmentEdit createMode={false} />} />
+                </Route>
+                <Route path="/assessments" element={<ProtectedRoute />} >
+                  <Route index element={<Assessments />} />
                 </Route>
                 <Route path="/profile" element={<ProtectedRoute />} >
                   <Route index element={<Profile />} />

--- a/src/api/services/Assessment.ts
+++ b/src/api/services/Assessment.ts
@@ -1,0 +1,69 @@
+import { useNavigate } from "react-router-dom";
+import Client from "../client";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { ApiOptions, ApiServiceErr, Assessment, AssessmentDetailsResponse, AssessmentListResponse } from "../../types";
+
+
+export function useCreateAssessment (token: string) {
+    const navigate = useNavigate();
+    return useMutation({
+        mutationFn: (postData:{validation_id: number, template_id:number, assessment_doc:Assessment}) => {
+            return Client(token).post("/assessments",postData)
+        },
+        // for the time being redirect to assessment list
+        onSuccess: () => {
+            navigate("/assessments")
+        }
+    })
+}
+
+export function useUpdateAssessment (token: string, assessmentID: string| undefined) {
+    const queryClient = useQueryClient();
+    const navigate = useNavigate();
+    return useMutation({
+        mutationFn: (putData:{assessment_doc:Assessment}) => {
+            return Client(token).put(`/assessments/${assessmentID}`,putData)
+        },
+        // for the time being redirect to assessment list
+        onSuccess: () => {
+            queryClient.invalidateQueries(["assessment", { assessmentID }])
+            navigate("/assessments")
+        }
+    })
+}
+
+
+export function useGetAssessments({ size, page, sortBy, token, isRegistered }: ApiOptions){
+    return useQuery<AssessmentListResponse, any>({
+      queryKey: ["assessments", { size, page, sortBy }],
+      queryFn: async () => {
+        const response = await Client(token).get<AssessmentListResponse>(
+          `/assessments?size=${size}&page=${page}&sortby=${sortBy}`
+        );
+        return response.data;
+      },
+      onError: (error) => {
+        console.log(error.response);
+        return error.response as ApiServiceErr;
+      },
+      enabled: !!token && isRegistered,
+    })
+}
+
+
+export function useGetAssessment({ id, token, isRegistered }: {id:number, token:string, isRegistered:boolean}){
+    return useQuery<AssessmentDetailsResponse, any>({
+      queryKey: ["assessment", { id }],
+      queryFn: async () => {
+        const response = await Client(token).get<AssessmentDetailsResponse>(
+          `/assessments/${id}`
+        );
+        return response.data;
+      },
+      onError: (error) => {
+        console.log(error.response);
+        return error.response as ApiServiceErr;
+      },
+      enabled: !!token && isRegistered && !isNaN(id),
+    })
+}

--- a/src/api/services/Validation.ts
+++ b/src/api/services/Validation.ts
@@ -57,6 +57,7 @@ const Validation = {
     useQuery<ValidationResponse, any>({
       queryKey: ["validation_details"],
       queryFn: async () => {
+       
         const jwt = JSON.stringify(decode(token));
         let response = null;
         if (jwt.includes("admin")) {
@@ -74,7 +75,7 @@ const Validation = {
         console.log(error);
         return error.response as ApiServiceErr;
       },
-      enabled: !!token && isRegistered && (validation_id !== ""),
+      enabled: !!token && isRegistered && (validation_id !== "" && validation_id !== undefined),
     }),
   useValidationRequest: ({
     organisation_role,

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -79,13 +79,13 @@ function Header() {
             <Link to="/" className="cat-nav-link">HOME</Link>
           </NavItem>
           <NavItem>
-            <Link to="/" className="cat-nav-link">SEARCH</Link>
+            <Link to="/" className="cat-nav-link cat-text-faded">SEARCH</Link>
           </NavItem>
           <NavItem>
-            <Link to="/validations" className="cat-nav-link">ASSESS</Link>
+            <Link to="/assessments" className="cat-nav-link">ASSESS</Link>
           </NavItem>
           <NavItem>
-            <Link to="/" className="cat-nav-link">RESOURCES</Link>
+            <Link to="#" className="cat-nav-link cat-text-faded">RESOURCES</Link>
           </NavItem>
           
           {authenticated && userProfile?.id &&
@@ -95,7 +95,7 @@ function Header() {
           </NavItem>
 
           <NavItem>
-            <Link to="/" className="cat-nav-link"><FaCog /></Link>
+            <Link to="/" className="cat-nav-link cat-text-faded"><FaCog /></Link>
           </NavItem>
           </>
           }

--- a/src/components/tests/TestBinary.tsx
+++ b/src/components/tests/TestBinary.tsx
@@ -49,6 +49,7 @@ export const TestBinary = (props:AssessmentTestProps) => {
                     name="test-input-group"
                     type="radio"
                     id="test-check-yes"
+                    checked={props.test.value===1}
                     onChange={handleValueChange}
                 />
                 <Form.Check
@@ -58,6 +59,7 @@ export const TestBinary = (props:AssessmentTestProps) => {
                     name="test-input-group"
                     type="radio"
                     id="test-check-no"
+                    checked={props.test.value===0}
                     onChange={handleValueChange}
                 />
                 </div>

--- a/src/pages/Assessments.tsx
+++ b/src/pages/Assessments.tsx
@@ -1,0 +1,81 @@
+import { useMemo } from 'react';
+import {
+    ColumnDef,
+} from '@tanstack/react-table'
+import { Table } from '../components/Table';
+import { FaCheckCircle, FaEdit, FaPlus } from 'react-icons/fa';
+import { AssessmentListItem} from '../types';
+import { useGetAssessments } from '../api/services/Assessment';
+import { Link } from 'react-router-dom';
+
+
+function Assessments() {
+
+    const cols = useMemo<ColumnDef<AssessmentListItem>[]>(
+        () => [
+            {
+                header: ' ',
+                footer: props => props.column.id,
+                columns: [
+                    {
+                        accessorKey: 'id',
+                        header: () => <span>ID</span>,
+                        cell: info => info.getValue(),
+                        footer: props => props.column.id,
+                    },
+                    {
+                        accessorFn: row => row.created_on,
+                        id: 'created_on',
+                        cell: info => info.getValue(),
+                        header: () => <span>Created On</span>,
+                        footer: props => props.column.id,
+                    },
+                    {
+                        accessorFn: row => row.validationId,
+                        id: 'validation_id',
+                        cell: info => info.getValue(),
+                        header: () => <span>Validation ID</span>,
+                        footer: props => props.column.id,
+                    },
+                    {
+                        accessorFn: row => row.templateId,
+                        id: 'template_id',
+                        cell: info => info.getValue(),
+                        header: () => <span>Template ID</span>,
+                        footer: props => props.column.id,
+                    },
+                    {
+                        id: "action",
+                        header: () => <span>Actions</span>,
+                        cell: (props) => {
+                          
+                            return (
+                              <div className="edit-buttons btn-group shadow">
+                                <Link
+                                  className="btn btn-secondary cat-action-view-link btn-sm "
+                                  to={`/assessments/${props.row.original.id}`}>
+                                  <FaEdit />
+                                </Link>
+                              </div>
+                            )
+                          
+                        }
+                    }
+                ],
+            },
+        ],
+        []
+    )
+
+    return (
+        <div className="mt-4">
+             <div className="d-flex justify-content-between my-2 container">
+             <h3 className="cat-view-heading"><FaCheckCircle className="me-1"/> assessments</h3>
+                 <Link to="/validations" className="btn btn-light border-black mx-3" ><FaPlus /> Create New</Link>
+            </div>
+            <Table columns={cols} data_source={useGetAssessments} />
+        </div>
+    );
+}
+
+export default Assessments;

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,13 +1,6 @@
-import { useContext } from 'react';
-import { UserAPI } from '../api';
-import { AuthContext } from '../auth/AuthContext';
+
 
 function Home() {
-  const { keycloak, registered } = useContext(AuthContext)!;
-  const { data } = UserAPI.useGetUsers(
-    { size: 10, page: 1, sortBy: "asc", token: keycloak?.token, isRegistered: registered },
-  );
-  console.log(data);
   return (
     <div className="page-center">
       <h2>Welcome to Compliance Assesment Tool</h2>

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -92,7 +92,11 @@ function Profile() {
             } 
             { (userProfile?.user_type === "Validated" || userProfile?.user_type === "Admin") &&
             <>
-              <div className="text-muted">View your current assesments or create a new one.<br/><span className="badge bg-info">Under construction</span></div>
+              <div>View your current assessments or create a new one.</div>
+              <div className="mt-4">
+                <Link to="/assessments" className="btn btn-light border-black" >View List</Link>
+                <Link to="/validations" className="btn btn-light border-black mx-3" ><FaPlus /> Create New</Link>
+              </div>
 
             </>
             }

--- a/src/pages/Users.tsx
+++ b/src/pages/Users.tsx
@@ -35,7 +35,7 @@ function Users() {
                         cell: info => info.getValue(),
                         header: () => <span>Registered On</span>,
                         footer: props => props.column.id,
-                    },
+                    }
                 ],
             },
         ],

--- a/src/pages/Validations.tsx
+++ b/src/pages/Validations.tsx
@@ -423,7 +423,7 @@ function Validations(props: ValidationProps) {
                   {props.row.original.status === "APPROVED" &&
                       <Link
                         className="btn btn-secondary cat-action-approve-link btn-sm "
-                        to={`/assessment/${props.row.original.id}`}>
+                        to={`/assessments/create/${props.row.original.id}`}>
                         <FaPlus /> Assessment
                       </Link>
                   }

--- a/src/types/assessment.ts
+++ b/src/types/assessment.ts
@@ -1,6 +1,8 @@
+import { ResponsePage } from "./common";
+
 /** API response when requesting a template */
 export interface TemplateResponse {
-  id: string;
+  id: number;
   type: AssessmentType;
   actor: ActorType;
   template_doc: Assessment;
@@ -146,4 +148,20 @@ export interface ResultStats {
   optionalFilled: number,
   mandatory: number,
   optional: number
+}
+
+export interface AssessmentListItem {
+  id: number,
+  user_id: string,
+  validationId: number
+  created_on: number,
+  updated_on: string,
+  templateId: number,
+}
+
+export type AssessmentListResponse = ResponsePage<AssessmentListItem[]>;
+
+export interface AssessmentDetailsResponse {
+  id: number
+  assessmentDoc: Assessment
 }


### PR DESCRIPTION
... Add simple assessment list

# 🎯 Goal
Allow the user to create a new assessment or update an existing one. After creating / updating the user will be redirected to a list of assessments view

# 🏗️ Implementation
- [x] Implement useGetAssessments query hook
- [x] Implement useGetAssessment query hook
- [x] Implement useCreateAssessment mutation
- [x] Implement useUpdateAssessment mutation
- [x] Implement handleCreateAssessment handler in AssessmentEdit component
- [x] Implement handleUpdateAssessment handler in AssessmentEdit component