### PR TITLE
Restrict the assessment creation only to PID Owners

### DIFF
--- a/src/pages/Validations.tsx
+++ b/src/pages/Validations.tsx
@@ -369,10 +369,10 @@ function Validations(props: ValidationProps) {
             footer: props => props.column.id,
           },
           {
-            accessorFn: row => row.actor_id,
-            id: 'actor_id',
+            accessorFn: row => row.actor_name,
+            id: 'actor_name',
             cell: info => info.getValue(),
-            header: () => <span>Actor ID</span>,
+            header: () => <span>Actor</span>,
             footer: props => props.column.id,
           },
           {
@@ -420,7 +420,7 @@ function Validations(props: ValidationProps) {
                     to={`/validations/${props.row.original.id}`}>
                     <FaList />
                   </Link>
-                  {props.row.original.status === "APPROVED" &&
+                  {props.row.original.status === "APPROVED" && props.row.original.actor_id === 6 &&
                       <Link
                         className="btn btn-secondary cat-action-approve-link btn-sm "
                         to={`/assessments/create/${props.row.original.id}`}>


### PR DESCRIPTION
- Hide assessment creation button from actors different than PID Owners
- Display Actor Name instead of Actor ID on validations table