### PR TITLE
Fix bug with assessment id on edit

### DIFF
--- a/src/api/services/Assessment.ts
+++ b/src/api/services/Assessment.ts
@@ -59,7 +59,7 @@ export function useGetAssessments({ size, page, sortBy, token, isRegistered }: A
 }
 
 
-export function useGetAssessment({ id, token, isRegistered }: {id:number, token:string, isRegistered:boolean}){
+export function useGetAssessment({ id, token, isRegistered }: {id:string, token:string, isRegistered:boolean}){
     return useQuery<AssessmentDetailsResponse, any>({
       queryKey: ["assessment", id],
       queryFn: async () => {
@@ -72,6 +72,6 @@ export function useGetAssessment({ id, token, isRegistered }: {id:number, token:
         console.log(error.response);
         return error.response as ApiServiceErr;
       },
-      enabled: !!token && isRegistered && !isNaN(id),
+      enabled: !!token && isRegistered && id !== "",
     })
 }

--- a/src/pages/AssessmentEdit.tsx
+++ b/src/pages/AssessmentEdit.tsx
@@ -37,7 +37,7 @@ const AssessmentEdit = ({ createMode = true }: AssessmentEditProps) => {
   const qTemplate = TemplateAPI.useGetTemplate(
     1, qValidation.data?.actor_id , keycloak?.token, registered)
 
-  const asmtNumID = asmtID !== undefined ? parseInt(asmtID) : NaN
+  const asmtNumID = asmtID !== undefined ? asmtID : ""
 
   const qAssessment = useGetAssessment(
     { id: asmtNumID, token: keycloak?.token, isRegistered: registered }


### PR DESCRIPTION
Assessment IDs are stored as a UUID, but frontend assumes a number. This PR fixes the bugs that occur from this outdated assumption.