### PR TITLE
CAT-200 Fix assessment update regression due to changes in assessment id

### DIFF
--- a/src/api/services/assessments.ts
+++ b/src/api/services/assessments.ts
@@ -41,10 +41,7 @@ export function useUpdateAssessment(
     onMutate: (newData) => {
       // Optimistically update the cache with the new data
       if (assessmentID) {
-        queryClient.setQueryData(
-          ["assessment", parseInt(assessmentID)],
-          newData,
-        );
+        queryClient.setQueryData(["assessment", assessmentID], newData);
       }
     },
     // for the time being redirect to assessment list


### PR DESCRIPTION
# Issue
A user tries to update an assessment. The updated changes are not reflected instantly in the ui due to caching issues. This is caused because the assessment id has changed from integer to string and the update backend process handles it wrongly. 

# Fix
During the update backend call, handle the assessment id as a string when issuing a cache key for react query