### PR TITLE
CAT-207 Fix select first criterion tab as active in assessment wizard

### DIFF
--- a/src/pages/assessments/AssessmentEdit.tsx
+++ b/src/pages/assessments/AssessmentEdit.tsx
@@ -54,6 +54,11 @@ const AssessmentEdit = ({ createMode = true }: AssessmentEditProps) => {
   // with templateId: 1 (pid policy) and actorId: 6 (for pid owner)
   // this will be replaced in time with dynamic code
 
+  // signal used in the third step of the wizard in order to trigger
+  // a refresh in the criteria sub-tab component and select the first
+  // criterion as an active sub-tab
+  const [resetCriterionTab, setResetCriterionTab] = useState(false);
+
   const validationID = valID !== undefined ? valID : "";
   const [vldid, setVldid] = useState<string>();
   const qValidation = useGetValidationDetails({
@@ -141,6 +146,10 @@ const AssessmentEdit = ({ createMode = true }: AssessmentEditProps) => {
     asmtID,
   );
 
+  function handleResetCriterionTabComplete() {
+    setResetCriterionTab(false);
+  }
+
   function handleCreateAssessment() {
     if (templateId && vldid && assessment) {
       mutationCreateAssessment.mutate({
@@ -151,15 +160,27 @@ const AssessmentEdit = ({ createMode = true }: AssessmentEditProps) => {
     }
   }
 
+  // handle tab changes in wizard
+  function handleChangeTab(tabKey: number) {
+    // if user selects the last step in the wizard (assessment)
+    // triger the reset criterion tab signal so as to select the first
+    // available criterion as the active sub-tab inside assessment
+    if (tabKey == 3) {
+      setResetCriterionTab(true);
+    }
+    // set the active tab in the wizard
+    setActiveTab(tabKey);
+  }
+
   function handleNextTab() {
     if (activeTab < 3) {
-      setActiveTab(activeTab + 1);
+      handleChangeTab(activeTab + 1);
     }
   }
 
   function handlePrevTab() {
     if (activeTab > 1) {
-      setActiveTab(activeTab - 1);
+      handleChangeTab(activeTab - 1);
     }
   }
 
@@ -366,8 +387,7 @@ const AssessmentEdit = ({ createMode = true }: AssessmentEditProps) => {
         activeKey={"step-" + activeTab.toString()}
         onSelect={(key) => {
           if (key) {
-            console.log(key);
-            setActiveTab(parseInt(key.replace("step-", "")) || 1);
+            handleChangeTab(parseInt(key.replace("step-", "")) || 1);
           }
         }}
       >
@@ -449,7 +469,9 @@ const AssessmentEdit = ({ createMode = true }: AssessmentEditProps) => {
                 )}
                 <CriteriaTabs
                   principles={assessment?.principles || []}
+                  resetActiveTab={resetCriterionTab}
                   onTestChange={handleCriterionChange}
+                  onResetActiveTab={handleResetCriterionTabComplete}
                 />
               </Tab.Pane>
             </Tab.Content>

--- a/src/pages/assessments/components/CriteriaTabs.tsx
+++ b/src/pages/assessments/components/CriteriaTabs.tsx
@@ -23,6 +23,8 @@ import { useEffect, useState } from "react";
 
 type CriteriaTabsProps = {
   principles: Principle[];
+  resetActiveTab: boolean;
+  onResetActiveTab(): void;
   onTestChange(
     principleId: string,
     criterionId: string,
@@ -37,15 +39,20 @@ export function CriteriaTabs(props: CriteriaTabsProps) {
   const [activeKey, setActiveKey] = useState("");
 
   useEffect(() => {
+    // if resetActiveTab signal is set to true try to find the first criterion
+    // and set it as an active tab
     if (
-      !activeKey &&
+      props.resetActiveTab &&
       props.principles.length > 0 &&
       props.principles[0].criteria.length > 0
     ) {
       const firstCriterion = props.principles[0].criteria[0].id;
+      console.log("active tab:", firstCriterion);
       setActiveKey(firstCriterion);
+      // when you set the active tab reset the signal to false
+      props.onResetActiveTab();
     }
-  }, [props.principles, activeKey]);
+  }, [props]);
 
   props.principles.forEach((principle) => {
     // push principle lable to navigation list


### PR DESCRIPTION
# ❌ Issue:
Step 1. In create assessment wizard > first tab (actor) select an actor/org to start assessing
Step 2. While in first tab select again a different actor/org that loads a new assessment
Step 3. Go to the third step (assessment view). The first criterion is not selected by default

# 💊 Fix:
- [x] When we select tab3 (assessment view) this will trigger the inner component that renders the criteria to recheck and select the first criterion as default
- [x] Implement a resetCriteriaTab state variable in parent wizard component
- [x] Add a handleChangeTab wrapper function in parent wizard component that checks if we land in tab3 (assessment) and triggers a select active criterion tab procedure by sending a signal prop to the child component
- [x] In the child component trigger the select first criterion as default and run the callback so that the parent can turn of the resetCriteriaTab signal state
