### PR TITLE
CAT-208 update ui with new backend paths for public assessments and a…

### DIFF
--- a/src/api/services/actors.ts
+++ b/src/api/services/actors.ts
@@ -1,40 +1,15 @@
 import { AxiosError } from "axios";
-import { ActorListResponse, ApiOptions, ApiPaginationOptions } from "@/types";
+import { ActorListResponse, ApiPaginationOptions } from "@/types";
 import { APIClient } from "@/api";
 import { useQuery } from "@tanstack/react-query";
 import { handleBackendError } from "@/utils";
 
-export const useGetActors = ({
-  size,
-  page,
-  sortBy,
-  token,
-  isRegistered,
-}: ApiOptions) =>
-  useQuery({
-    queryKey: ["actors", { size, page, sortBy }],
-    queryFn: async () => {
-      const response = await APIClient(token).get<ActorListResponse>(
-        `/codelist/actors?size=${size}&page=${page}&sortby=${sortBy}`,
-      );
-      return response.data;
-    },
-    onError: (error: AxiosError) => {
-      return handleBackendError(error);
-    },
-    enabled: !!token && isRegistered,
-  });
-
-export const useGetPublicActors = ({
-  size,
-  page,
-  sortBy,
-}: ApiPaginationOptions) =>
+export const useGetActors = ({ size, page, sortBy }: ApiPaginationOptions) =>
   useQuery({
     queryKey: ["actors", { size, page, sortBy }],
     queryFn: async () => {
       const response = await APIClient("").get<ActorListResponse>(
-        `/public/actors?size=${size}&page=${page}&sortby=${sortBy}`,
+        `/codelist/actors?size=${size}&page=${page}&sortby=${sortBy}`,
       );
       return response.data;
     },

--- a/src/api/services/assessments.ts
+++ b/src/api/services/assessments.ts
@@ -85,7 +85,7 @@ export function useGetPublicAssessments({
     queryKey: ["public-owner-assessments", { size, page, sortBy }],
     queryFn: async () => {
       const response = await APIClient().get<AssessmentListResponse>(
-        `/public/assessments/by-type/${assessmentTypeId}/by-actor/${actorId}?size=${size}&page=${page}&sortby=${sortBy}`,
+        `/assessments/by-type/${assessmentTypeId}/by-actor/${actorId}?size=${size}&page=${page}&sortby=${sortBy}`,
       );
       return response.data;
     },

--- a/src/pages/Validations.tsx
+++ b/src/pages/Validations.tsx
@@ -69,11 +69,9 @@ function RequestValidation() {
   }, [profileData]);
 
   const { data: actorsData } = useGetActors({
-    size: 20,
+    size: 100,
     page: 1,
     sortBy: "asc",
-    token: keycloak?.token || "",
-    isRegistered: registered,
   });
 
   const [actors, setActors] = useState<Actor[]>();

--- a/src/pages/assessments/Assessments.tsx
+++ b/src/pages/assessments/Assessments.tsx
@@ -5,7 +5,7 @@ import authImg from "@/assets/thumb_auth.png";
 import serviceImg from "@/assets/thumb_service.png";
 import manageImg from "@/assets/thumb_manage.png";
 import ownersImg from "@/assets/thumb_user.png";
-import { useGetPublicActors } from "@/api";
+import { useGetActors } from "@/api";
 import { Col, Row } from "react-bootstrap";
 import { ActorCard } from "./components/ActorCard";
 
@@ -20,7 +20,7 @@ interface CardProps {
 
 function Assessments() {
   // get the actors
-  const actorsData = useGetPublicActors({
+  const actorsData = useGetActors({
     size: 100,
     page: 1,
     sortBy: "asc",


### PR DESCRIPTION
…ctors

API paths have changed:
```
/v1/public/actors -> /v1/codelist/actors
/v1/public/assessments/by-type/{type-id}/by-actor/{actor-id} -> /v1/assessments/by-type/{type-id}/by-actor/{actor-id}
```
Update the relevant ui backend calls accordingly (for actors and public assessments)
