### PR TITLE
CAT-230 Save/Submit functionality in assessment

### DIFF
--- a/src/api/services/assessments.ts
+++ b/src/api/services/assessments.ts
@@ -34,7 +34,6 @@ export function useUpdateAssessment(
   assessmentID: string | undefined,
 ) {
   const queryClient = useQueryClient();
-  const navigate = useNavigate();
   return useMutation({
     mutationFn: (putData: { assessment_doc: Assessment }) => {
       return APIClient(token).put(`/assessments/${assessmentID}`, putData);
@@ -49,7 +48,6 @@ export function useUpdateAssessment(
     // for the time being redirect to assessment list
     onSuccess: () => {
       queryClient.invalidateQueries(["assessment", { assessmentID }]);
-      navigate("/assessments");
     },
   });
 }

--- a/src/pages/assessments/AssessmentEdit.tsx
+++ b/src/pages/assessments/AssessmentEdit.tsx
@@ -28,7 +28,7 @@ import {
   useGetAssessment,
   useUpdateAssessment,
 } from "@/api";
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import { AssessmentEvalStats } from "./components/AssessmentEvalStats";
 import { DebugJSON } from "./components/DebugJSON";
 import { AssessmentSelectActor } from "./components/AssessmentSelectActor";
@@ -63,6 +63,8 @@ const AssessmentEdit = ({ createMode = true }: AssessmentEditProps) => {
   });
   const [templateData, setTemplateData] = useState<Assessment>();
   const { valID, asmtID } = useParams();
+
+  const navigate = useNavigate();
   // const [actorId, setActorId] = useState<number>();
   // for the time being get the only one assessment template supported
   // with templateId: 1 (pid policy) and actorId: 6 (for pid owner)
@@ -152,6 +154,7 @@ const AssessmentEdit = ({ createMode = true }: AssessmentEditProps) => {
   }, [validations]);
 
   const mutationCreateAssessment = useCreateAssessment(keycloak?.token || "");
+
   const mutationUpdateAssessment = useUpdateAssessment(
     keycloak?.token || "",
     asmtID,
@@ -212,7 +215,7 @@ const AssessmentEdit = ({ createMode = true }: AssessmentEditProps) => {
     }
   }
 
-  function handleUpdateAssessment() {
+  function handleUpdateAssessment(exit: boolean) {
     if (assessment && asmtID) {
       const promise = mutationUpdateAssessment
         .mutateAsync({
@@ -228,6 +231,9 @@ const AssessmentEdit = ({ createMode = true }: AssessmentEditProps) => {
           alert.current = {
             message: "Assessment succesfully updated.",
           };
+          if (exit) {
+            navigate("/assessments");
+          }
         });
       toast.promise(promise, {
         loading: "Updating",
@@ -551,21 +557,47 @@ const AssessmentEdit = ({ createMode = true }: AssessmentEditProps) => {
             </div>
             {/* Add SAVE button here and cancel */}
             <div>
-              <Button
-                disabled={!wizardTabActive}
-                className="ms-5 btn btn-success px-5"
-                onClick={() => {
-                  if (createMode) {
+              {createMode ? (
+                <Button
+                  disabled={!wizardTabActive}
+                  className="ms-5 btn btn-success px-5"
+                  onClick={() => {
                     handleCreateAssessment();
-                  } else {
-                    handleUpdateAssessment();
-                  }
-                }}
-              >
-                Save
-              </Button>
+                  }}
+                >
+                  Create
+                </Button>
+              ) : (
+                <>
+                  <Button
+                    disabled={!wizardTabActive}
+                    className="ms-2 btn btn-success px-5"
+                    onClick={() => {
+                      handleUpdateAssessment(false);
+                    }}
+                  >
+                    Save
+                  </Button>
+
+                  <Button
+                    disabled={
+                      !(
+                        assessment &&
+                        assessment.result &&
+                        assessment.result.compliance !== null
+                      )
+                    }
+                    className="ms-2 btn btn-success px-5"
+                    onClick={() => {
+                      handleUpdateAssessment(true);
+                    }}
+                  >
+                    Submit
+                  </Button>
+                </>
+              )}
               <Link
-                className="btn btn-secondary ms-2 px-4"
+                className="btn btn-secondary ms-5 px-4"
                 to={createMode ? "/assess" : "/assessments"}
               >
                 Cancel

--- a/src/pages/assessments/AssessmentsList.tsx
+++ b/src/pages/assessments/AssessmentsList.tsx
@@ -180,7 +180,7 @@ function AssessmentsList({ listPublic = false }: AssessmentListProps) {
                 enableColumnFilter: false,
               },
               {
-                accessorKey: "access",
+                accessorKey: "published",
                 header: () => <span>access</span>,
                 cell: (info) => {
                   return info.getValue() === true ? "Public" : "Private";


### PR DESCRIPTION
Added requested functionality to have a Save button that saves the assessment without exiting the view and a Submit button that is activated when all fields are filled-out and compliance has been calculated. The Submit button saves the assessment and redirects to the assessment list view

On the creation process we have replaced the Save button with Create because it needs to do a create action that will generate the new assessment and assign it a new id. Then the user can move on to edit it and have the save/submit button capability

Implementation
- [x] Remove redirect capability from backend calls
- [x] Add an extra parameter to handleAssessmentUpdate to enable redirects or not
- [x] When user creates a new assessment display a "Create" Button
- [x] When user edits an existing assessment display a "Save" and "Submit" Button, Submit button is enabled when all required fields for compliance are filled-in