### PR TITLE
CAT-226 Implement delete assessment

### DIFF
--- a/src/api/services/assessments.ts
+++ b/src/api/services/assessments.ts
@@ -29,6 +29,19 @@ export function useCreateAssessment(token: string) {
   });
 }
 
+export function useDeleteAssessment(token: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (assessmentId: string) => {
+      return APIClient(token).delete(`/assessments/${assessmentId}`);
+    },
+    // on success refresh assessments query (so that the deleted assessment dissapears from list)
+    onSuccess: () => {
+      queryClient.invalidateQueries(["assessments"]);
+    },
+  });
+}
+
 export function useUpdateAssessment(
   token: string,
   assessmentID: string | undefined,

--- a/src/components/DeleteModal.tsx
+++ b/src/components/DeleteModal.tsx
@@ -1,0 +1,56 @@
+import { Modal, Button, ListGroup, ListGroupItem } from "react-bootstrap";
+import { FaTimes } from "react-icons/fa";
+
+interface DeleteModalProps {
+  title: string;
+  message: string;
+  itemId: string;
+  itemName: string;
+  show: boolean;
+  onHide: () => void;
+  onDelete: () => void;
+}
+/**
+ * Implements a simple component that displays a modal (popup window) when
+ * the user needs to confirm the deletion of an item. Modal accepts a list of
+ * properties such as a title, message, itemId and itemName.
+ * Also it accepts two callback functions: onHide (what to do when modal closes)
+ * and onDelete (what to do when user clicks Confirm Delete button)
+ */
+export function DeleteModal(props: DeleteModalProps) {
+  return (
+    <Modal
+      {...props}
+      size="lg"
+      aria-labelledby="contained-modal-title-vcenter"
+      centered
+    >
+      <Modal.Header className="bg-danger text-white" closeButton>
+        <Modal.Title id="contained-modal-title-vcenter">
+          <FaTimes className="me-2" /> {props.title}
+        </Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        <p>{props.message}</p>
+        <ListGroup>
+          <ListGroupItem>
+            <strong>Name: </strong>
+            {props.itemName}
+          </ListGroupItem>
+          <ListGroupItem>
+            <strong>ID: </strong>
+            {props.itemId}
+          </ListGroupItem>
+        </ListGroup>
+      </Modal.Body>
+      <Modal.Footer className="d-flex justify-content-between">
+        <Button className="btn-danger me-4" onClick={props.onDelete}>
+          Confirm Delete
+        </Button>
+        <Button className="btn-secondary" onClick={props.onHide}>
+          Cancel
+        </Button>
+      </Modal.Footer>
+    </Modal>
+  );
+}

--- a/src/types/assessment.ts
+++ b/src/types/assessment.ts
@@ -177,12 +177,13 @@ export type ActorOrganisationMapping = {
 };
 
 export interface AssessmentListItem {
-  id: number;
+  id: string;
   user_id: string;
   validation_id: number;
   created_on: number;
   updated_on: string;
   template_id: number;
+  published: boolean;
 }
 
 export type AssessmentListResponse = ResponsePage<AssessmentListItem[]>;


### PR DESCRIPTION
Implement Assessment deletion

- [x] Add a new hook to call delete assessment on backend (using react query mutation)
- [x] Add a new react-bootstrap modal component to implement a pop up window that asks for deletion confirmation: `DeleteModal`
- [x] Update assessment list view to add a delete button in assessment table when assessment is private. When user clicks the button the DeleteModal appears. 
- [x] Add new state variable `deleteModalConfig` in assessment view. This state variable object holds info about wether to show/hide the delete modal window, it's message, title as well an itemID and itemName (if the user selected an assessment to be deleted)
- [x] Implement handler for clicking to delete something so that the delete modal window pops up
- [x] Implement handler for canceling deletion (so that the delete modal window hides)
- [x] Implement handler for confirming deletion (so that the delete assessment backend call triggers and the modal window closes on success)
- [x] Add react-toaster methods to display feedback when something is deleted