### PR TITLE
CAT-258 Format exported JSON

### DIFF
--- a/src/pages/assessments/AssessmentsList.tsx
+++ b/src/pages/assessments/AssessmentsList.tsx
@@ -131,7 +131,7 @@ function AssessmentsList({ listPublic = false }: AssessmentListProps) {
   useEffect(() => {
     if (qAssessment.data) {
       const jsonString = `data:text/json;chatset=utf-8,${encodeURIComponent(
-        JSON.stringify(qAssessment.data),
+        JSON.stringify(qAssessment.data, null, 2),
       )}`;
       const link = document.createElement("a");
       link.href = jsonString;


### PR DESCRIPTION
Format text when exporting JSON so that you'll get something like:
```
{
  "id": "901aa669-fa8e-4736-a3f9-cadc281d9f54",
  "user_id": "alice_voperson_id",
  "validation_id": 31,
  "created_on": "2023-11-14 14:54:39.515812",
  "updated_on": "",
  "template_id": 4,
  "assessment_doc": {
    "name": "cvcvcvcv",
    "version": "",
    "status": "",
    ...
```
instead of a compressed single line output like:
```
{ "id": "901aa669-fa8e-4736-a3f9-cadc281d9f54", "user_id": "alice_voperson_id", ...
```