### PR TITLE
[CAT-260] Elaborate on faulty actor changes in the assessment

### DIFF
--- a/src/pages/assessments/AssessmentEdit.tsx
+++ b/src/pages/assessments/AssessmentEdit.tsx
@@ -305,6 +305,7 @@ const AssessmentEdit = ({ createMode = true }: AssessmentEditProps) => {
         name: organisation?.name || templateData?.organisation.name || "",
         id: organisation?.id || templateData?.organisation.id || "",
       },
+      principles: templateData?.principles || prev_assessment?.principles || [],
     }));
     setWizardTabActive(
       (actor?.id && organisation?.id) ||


### PR DESCRIPTION
Fix the bug related to faulty actor change during assessment creation. Now assessment principles on last tab of the wizard are updated according to the actor change.