### PR TITLE
ARGO-283 Refactor handling of table headers

### DIFF
--- a/src/components/CustomTable.tsx
+++ b/src/components/CustomTable.tsx
@@ -359,18 +359,10 @@ function CustomTable<T>({
                             </div>
                           ) : (
                             <>
-                              <span>
-                                {header.column.id
-                                  .split("_")
-                                  .join(" ")
-                                  .toLowerCase()
-                                  .replace(
-                                    /\b[a-z](?=[a-z])/g,
-                                    function (letter) {
-                                      return letter.toUpperCase();
-                                    },
-                                  )}
-                              </span>
+                              {flexRender(
+                                header.column.columnDef.header,
+                                header.getContext(),
+                              )}
                             </>
                           )}
                         </>

--- a/src/pages/assessments/AssessmentsList.tsx
+++ b/src/pages/assessments/AssessmentsList.tsx
@@ -281,25 +281,25 @@ function AssessmentsList({ listPublic = false }: AssessmentListProps) {
       : [
           {
             accessorKey: "name",
-            header: () => <span>ID</span>,
+            header: () => <span>Id</span>,
             cell: (info) => info.getValue(),
             enableColumnFilter: false,
           },
           {
             accessorKey: "type",
-            header: () => <span>type</span>,
+            header: () => <span>Type</span>,
             cell: (info) => info.getValue(),
             enableColumnFilter: false,
           },
           {
             accessorKey: "compliance",
-            header: () => <span>compliance</span>,
+            header: () => <span>Compliance</span>,
             cell: (info) => <ComplianceBadge compliance={info.getValue()} />,
             enableColumnFilter: false,
           },
           {
             accessorKey: "ranking",
-            header: () => <span>ranking</span>,
+            header: () => <span>Ranking</span>,
             cell: (info) => {
               return info.getValue() === null ? (
                 <ComplianceBadge compliance={null} />
@@ -311,7 +311,7 @@ function AssessmentsList({ listPublic = false }: AssessmentListProps) {
           },
           {
             accessorKey: "published",
-            header: () => <span>access</span>,
+            header: () => <span>Access</span>,
             cell: (info) => {
               return info.getValue() === true ? "Public" : "Private";
             },
@@ -319,19 +319,19 @@ function AssessmentsList({ listPublic = false }: AssessmentListProps) {
           },
           {
             accessorKey: "subject_type",
-            header: () => <span>subject type</span>,
+            header: () => <span>Subject Type</span>,
             cell: (info) => info.getValue(),
             enableColumnFilter: false,
           },
           {
             accessorKey: "subject_name",
-            header: () => <span>subject name</span>,
+            header: () => <span>Subject Name</span>,
             cell: (info) => info.getValue(),
             enableColumnFilter: false,
           },
           {
             accessorKey: "organisation",
-            header: () => <span>organisation</span>,
+            header: () => <span>Organisation</span>,
             cell: (info) => info.getValue(),
             enableColumnFilter: false,
           },


### PR DESCRIPTION
Each table definition has an already declared `header` property that includes the column label in a `span` element. 
- Use these definitions when rendering the table headers. 
- Fix some of these definitions in Assessment List table in order to have capitalized first letters. 
- This automatically fixes the column labels in the Subjects table