### PR TITLE
CAT-272 Update subject list in step2 of assessment creation

### DIFF
--- a/src/api/services/subjects.ts
+++ b/src/api/services/subjects.ts
@@ -1,5 +1,5 @@
 import { AxiosError } from "axios";
-import { ActorListResponse, ApiOptions, Subject } from "@/types";
+import { ApiOptions, Subject, SubjectListResponse } from "@/types";
 import { APIClient } from "@/api";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { handleBackendError } from "@/utils";
@@ -15,7 +15,7 @@ export const useGetSubjects = ({
   useQuery({
     queryKey: ["subjects"],
     queryFn: async () => {
-      const response = await APIClient(token).get<ActorListResponse>(
+      const response = await APIClient(token).get<SubjectListResponse>(
         `/subjects?size=${size}&page=${page}&sortby=${sortBy}`,
       );
       return response.data;

--- a/src/pages/assessments/components/AssessmentInfo.tsx
+++ b/src/pages/assessments/components/AssessmentInfo.tsx
@@ -210,7 +210,6 @@ export const AssessmentInfo = (props: AssessmentInfoProps) => {
         <Accordion.Body>
           <Row className="m-2">
             <AssessmentSelectSubject
-              actorId={props.actor?.id}
               subject={props.subject}
               onSubjectChange={props.onSubjectChange}
             />

--- a/src/types/assessment.ts
+++ b/src/types/assessment.ts
@@ -51,6 +51,7 @@ export interface AssessmentSubject {
   id: string;
   name: string;
   type: string;
+  db_id?: number;
 }
 
 export type AssessmentSubjectListResponse = ResponsePage<AssessmentSubject[]>;

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -28,6 +28,7 @@ export interface Actor {
 }
 
 export type ActorListResponse = ResponsePage<Actor[]>;
+export type SubjectListResponse = ResponsePage<Subject[]>;
 
 export type ApiServiceErr = {
   code: string;


### PR DESCRIPTION
Update the select subject component in step 2 of the create/edit assessment form. The component should load now the subjects provided by the GET `/api/subjects` backend call. Also when an existing subject is selected it should update the assessment json to include a db_id reference under subject object

- [x] Add SubjectListResponse Type and fix reference in api backend call
- [x] Update AssessmentSubject type with `db_id` field
- [x] Update SubjectSelect component in assessment editor to use the new get subjects api backend call to retrieve the list of user's subjects. 
- [x] Update handling of subject form field values to change when a user selects the subject from list
