### PR TITLE
CAT-310 Fix validation details requests for admin and non-admin views

### DIFF
--- a/src/api/services/validations.ts
+++ b/src/api/services/validations.ts
@@ -1,5 +1,4 @@
 import { APIClient } from "@/api";
-import decode from "jwt-decode";
 import { useQuery, useMutation } from "@tanstack/react-query";
 import { ApiOptions } from "@/types";
 import {
@@ -60,13 +59,13 @@ export const useGetValidationDetails = ({
   validation_id,
   token,
   isRegistered,
+  adminMode,
 }: ValidationDetailsRequestParams) =>
   useQuery({
     queryKey: ["validation_details", validation_id],
     queryFn: async () => {
-      const jwt = JSON.stringify(decode(token));
       let response = null;
-      if (jwt.includes("admin")) {
+      if (adminMode) {
         response = await APIClient(token).get<ValidationResponse>(
           `/admin/validations/${validation_id}`,
         );
@@ -75,6 +74,7 @@ export const useGetValidationDetails = ({
           `/validations/${validation_id}`,
         );
       }
+
       return response.data;
     },
     onError: (error: AxiosError) => {

--- a/src/pages/Validations.tsx
+++ b/src/pages/Validations.tsx
@@ -730,6 +730,7 @@ function ValidationDetails(props: ValidationProps) {
     validation_id: params.id!,
     token: keycloak?.token || "",
     isRegistered: registered,
+    adminMode: props.admin || false,
   });
 
   useEffect(() => {
@@ -865,16 +866,7 @@ function ValidationDetails(props: ValidationProps) {
               id: {validation?.id}
             </span>
           </h3>
-          {props.admin ? (
-            <h3 className="opacity-50">admin mode</h3>
-          ) : (
-            <Link
-              to="/validations/request"
-              className="btn btn-light border-black mx-3"
-            >
-              <FaPlus /> Create New
-            </Link>
-          )}
+          {props.admin ? <h3 className="opacity-50">admin mode</h3> : null}
         </div>
         <div className="row border-top py-3 mt-4">
           <header className="col-3 h4 text-muted">Requestor</header>

--- a/src/pages/assessments/AssessmentEdit.tsx
+++ b/src/pages/assessments/AssessmentEdit.tsx
@@ -81,6 +81,7 @@ const AssessmentEdit = ({ createMode = true }: AssessmentEditProps) => {
     validation_id: vldid!,
     token: keycloak?.token || "",
     isRegistered: registered,
+    adminMode: false,
   });
 
   const qTemplate = useGetTemplate(

--- a/src/types/validation.ts
+++ b/src/types/validation.ts
@@ -32,6 +32,7 @@ export interface ValidationRequest {
 
 export interface ValidationDetailsRequest {
   validation_id: string;
+  adminMode: boolean;
 }
 
 export type ValidationRequestParams = ApiAuthOptions & ValidationRequest;


### PR DESCRIPTION
- [x] Remove admin conditionals that used jwt token processing
- [x] Add an adminMode property for validation details backend hook to call `/v1/admin/validations/:id` when used in admin views and `/v1/validations/:id` when not.
- [x] Remove create new validation button from Validation details view