### PR TITLE
Cypress keycloak login e2e test

### DIFF
--- a/cypress/e2e/login.cy.ts
+++ b/cypress/e2e/login.cy.ts
@@ -1,0 +1,30 @@
+describe("User Login Tests", () => {
+  beforeEach(() => {
+    cy.visit("/login");
+  });
+  it("greets with sign in", () => {
+    cy.origin("http://localhost:58080", () => {
+      cy.get("h1").should("contain", "Sign in to your account");
+    });
+  });
+  it("requires username", () => {
+    cy.origin("http://localhost:58080", () => {
+      cy.get("input#kc-login").click();
+      cy.get("#input-error").should("contain", "Invalid username or password.");
+    });
+  });
+  it("requires password", () => {
+    cy.origin("http://localhost:58080", () => {
+      cy.get("input#kc-login").click();
+      cy.get("#input-error").should("contain", "Invalid username or password.");
+    });
+  });
+  it("logs in", () => {
+    cy.origin("http://localhost:58080", () => {
+      cy.get("input#username").type("identified_ui");
+      cy.get("input#password").type("identified_ui");
+      cy.get("input#kc-login").click();
+    });
+    cy.url().should("include", "login");
+  });
+});


### PR DESCRIPTION
## Cypress keycloak login e2e test

### Description
This pull request adds a cypress spec for testing the keycloak login page. It checks required fields, and checks if the user is routed to the correct page after login.

### Changes made
- Added spec for login.
- 
 ### How to test
 #### With Cypress UI
- Setup and run both the fc4e-cat-ui and fc4e-cat-api locally.
- run `npx cypress open` in the fc4e-cat-ui project.
- Select E2E testing.
- Select a browser and click 'start testing'.
- This should open the chosen browser and allow you to run the test by clicking on 'assessment.cy.ts'.

#### On the CLI
- Setup and run both the fc4e-cat-ui and fc4e-cat-api locally.
- `npx cypress run` 