### PR TITLE
Cypress profile test

### DIFF
--- a/cypress/e2e/profile.cy.ts
+++ b/cypress/e2e/profile.cy.ts
@@ -1,0 +1,150 @@
+/// <reference types="cypress"/>
+describe("/profile", () => {
+  before(() => {
+    cy.setupValidation("identified");
+  });
+
+  beforeEach(() => {
+    cy.kcLogout();
+    cy.kcLogin("identified").as("identifiedTokens");
+    cy.visit("/profile");
+  });
+
+  it("checks an identified user profile information", () => {
+    // Check if profile information is correct.
+    cy.intercept("GET", "http://localhost:8080/v1/users/profile", {
+      fixture: "profile_empty.json",
+    });
+    cy.get("#user-id").should("contain", "identified_ui_voperson_id");
+    cy.get("#identified").should("contain", "Identified");
+  });
+
+  it("does not allow validations without updating details", () => {
+    cy.intercept("GET", "http://localhost:8080/v1/users/profile", {
+      fixture: "profile_empty.json",
+    });
+
+    cy.get("#validation-alert-warning").should(
+      "contain",
+      "You should update your personal details in order to be able to create validation requests",
+    );
+  });
+
+  it("does not show assessments/subjects without validation", () => {
+    cy.intercept("GET", "http://localhost:8080/v1/users/profile", {
+      fixture: "profile_updated.json",
+    });
+    cy.get("#assessments_section").should("have.class", "disabled");
+    cy.get("#subjects_section").should("have.class", "disabled");
+  });
+
+  it("links to validations", () => {
+    cy.get("#view_validations_button").should(
+      "have.attr",
+      "href",
+      "/validations",
+    );
+    cy.get("#create_validation_button").should(
+      "have.attr",
+      "href",
+      "/validations/request",
+    );
+  });
+
+  it("links to assessments", () => {
+    cy.get("#view_assessments_button").should(
+      "have.attr",
+      "href",
+      "/assessments",
+    );
+    cy.get("#create_assessment_button").should(
+      "have.attr",
+      "href",
+      "/assessments/create",
+    );
+  });
+
+  it("links to subjects", () => {
+    cy.get("#view_subjects_button").should("have.attr", "href", "/subjects");
+    cy.get("#create_subject_button").should(
+      "have.attr",
+      "href",
+      "/subjects?create",
+    );
+  });
+});
+
+describe("/profile/update", () => {
+  beforeEach(() => {
+    cy.kcLogout();
+    cy.kcLogin("identified").as("identifiedTokens");
+    cy.visit("/profile/update");
+  });
+
+  it("requires the required fields to be filled out", () => {
+    cy.get("#inputName").clear();
+    cy.get("#inputSurname").clear();
+    cy.get("#inputEmail").clear();
+    cy.get("#inputOrcidId").clear();
+    cy.get("#submit-button").click();
+    // Check if the input element has the class "is-invalid", indicating a red outline
+    cy.get("#inputName").should("have.class", "is-invalid");
+    cy.get("#inputSurname").should("have.class", "is-invalid");
+    cy.get("#inputEmail").should("have.class", "is-invalid");
+
+    cy.get(".invalid-feedback").each(($element) => {
+      cy.wrap($element).should("contain.text", "is required");
+    });
+  });
+
+  it("requires the name to be longer than 3 characters", () => {
+    cy.get("#inputName").clear().type("UI");
+
+    cy.get("#submit-button").click();
+    cy.get(".invalid-feedback").should("contain", "Minimum length is 3");
+  });
+
+  it("requires a valid email address", () => {
+    cy.get("#inputEmail").clear().type("test");
+    cy.get("#submit-button").click();
+    cy.get("#inputEmail").then(($input) => {
+      expect($input[0].validationMessage).to.contain("Please include an");
+    });
+
+    cy.get("#inputEmail").clear().type("test@");
+    cy.get("#submit-button").click();
+    cy.get("#inputEmail").then(($input) => {
+      expect($input[0].validationMessage).to.contain("Please enter a part");
+    });
+
+    cy.get("#inputEmail").clear().type("test@test");
+    cy.get("#submit-button").click();
+    cy.get("#inputEmail").should("have.class", "is-invalid");
+  });
+
+  it("Does not require an ORCID id", () => {
+    cy.get("#inputName").clear().type("Identified");
+    cy.get("#inputSurname").clear().type("Test");
+    cy.get("#inputEmail").clear().type("identified@example.com");
+    cy.get("#inputOrcidId").clear();
+    cy.get("#submit-button").click();
+
+    cy.url().should("match", /\/profile$/);
+  });
+
+  it("updates the personal details", () => {
+    cy.get("#inputName").clear().type("Identified");
+    cy.get("#inputSurname").clear().type("Test");
+    cy.get("#inputEmail").clear().type("identified@example.com");
+    cy.get("#inputOrcidId").clear().type("0000-0002-0255-5101");
+
+    cy.get("#submit-button").click();
+
+    cy.url().should("match", /\/profile$/);
+
+    cy.get("#name").should("contain", "Identified");
+    cy.get("#surname").should("contain", "Test");
+    cy.get("#email").should("contain", "identified@example.com");
+    cy.get("#orcid").should("contain", "0000-0002-0255-5101");
+  });
+});

--- a/cypress/fixtures/profile_empty.json
+++ b/cypress/fixtures/profile_empty.json
@@ -1,0 +1,7 @@
+{
+  "id": "identified_ui_voperson_id",
+  "registered_on": "2024-01-03T15:39:23.000+01:00",
+  "user_type": "Identified",
+  "roles": ["identified"],
+  "banned": false
+}

--- a/cypress/fixtures/profile_updated.json
+++ b/cypress/fixtures/profile_updated.json
@@ -1,0 +1,12 @@
+{
+  "id": "identified_ui_voperson_id",
+  "registered_on": "2024-01-03T15:39:23.000+01:00",
+  "user_type": "Identified",
+  "name": "Identified",
+  "surname": "Test",
+  "email": "identified@example.com",
+  "orcid_id": "0000-0002-0255-5101",
+  "updated_on": "2024-01-03T17:07:50.478+01:00",
+  "roles": ["identified"],
+  "banned": false
+}

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -113,12 +113,14 @@ function Profile() {
                 </div>
                 <div className="mt-4">
                   <Link
+                    id="view_validations_button"
                     to="/validations"
                     className="btn btn-light border-black"
                   >
                     View List
                   </Link>
                   <Link
+                    id="create_validation_button"
                     to="/validations/request"
                     className="btn btn-light border-black mx-3"
                   >
@@ -130,20 +132,22 @@ function Profile() {
           </section>
         </div>
         <div className="row border-top py-3 mt-4 mb-4">
-          <header className="col-3 h4 text-muted">Assesments</header>
-          <section className="col-9 disabled">
+          <header className="col-3 h4 text-muted">Assessments</header>
+          <section id="assessments_section" className="col-9 disabled">
             {(userProfile?.user_type === "Validated" ||
               userProfile?.user_type === "Admin") && (
               <>
                 <div>View your current assessments or create a new one.</div>
                 <div className="mt-4">
                   <Link
+                    id="view_assessments_button"
                     to="/assessments"
                     className="btn btn-light border-black"
                   >
                     View List
                   </Link>
                   <Link
+                    id="create_assessment_button"
                     to="/assessments/create"
                     className="btn btn-light border-black mx-3"
                   >
@@ -156,16 +160,21 @@ function Profile() {
         </div>
         <div className="row border-top py-3 mt-4 mb-4">
           <header className="col-3 h4 text-muted">Subjects</header>
-          <section className="col-9 disabled">
+          <section id="subjects_section" className="col-9 disabled">
             {(userProfile?.user_type === "Validated" ||
               userProfile?.user_type === "Admin") && (
               <>
                 <div>View and manage your current Assessment Subjects</div>
                 <div className="mt-4">
-                  <Link to="/subjects" className="btn btn-light border-black">
+                  <Link
+                    id="view_subjects_button"
+                    to="/subjects"
+                    className="btn btn-light border-black"
+                  >
                     View List
                   </Link>
                   <Link
+                    id="create_subject_button"
                     to="/subjects?create"
                     className="btn btn-light border-black mx-3"
                   >


### PR DESCRIPTION
## Cypress profile test

### Description
This PR adds a spec that tests both the /profile and the /profile/update pages. It checks that the links are working or hidden depending on the state of the users profile info. It also tests the profile update form.

### Changes made
- Added tests for the /profile page
- Added tests for the /profile/update page
- Added ids for selecting certain fields in the profile page.
- Added ids for checking if a field was hidden.

 ### How to test
 #### With Cypress UI
- Setup and run both the fc4e-cat-ui and fc4e-cat-api locally.
- run `npx cypress open` in the fc4e-cat-ui project.
- Select E2E testing.
- Select a browser and click 'start testing'.
- This should open the chosen browser and allow you to run the test by clicking on 'assessment.cy.ts'.

#### On the CLI
- Setup and run both the fc4e-cat-ui and fc4e-cat-api locally.
- `npx cypress run` 