### PR TITLE
Cypress subject page test

### DIFF
--- a/cypress/e2e/subject.cy.ts
+++ b/cypress/e2e/subject.cy.ts
@@ -1,0 +1,104 @@
+describe("/subjects", () => {
+  before(() => {
+    cy.setupValidation("identified");
+  });
+  beforeEach(() => {
+    cy.kcLogout();
+    cy.kcLogin("identified");
+    cy.visit("/subjects");
+    cy.intercept(
+      "GET",
+      "http://localhost:8080/v1/subjects?size=10&page=1&sortby=asc",
+      {
+        fixture: "subjects/subjects",
+      },
+    ).as("getSubjects");
+  });
+  it("deletes a subject", () => {
+    cy.intercept("GET", "http://localhost:8080/v1/subjects/9", {
+      fixture: "subjects/subject",
+    }).as("getSubject");
+    cy.get("table")
+      .contains("td", "1")
+      .parent("tr")
+      .find("#delete-button-9")
+      .click();
+    cy.get(".modal-header")
+      .should("have.class", "bg-danger text-white")
+      .contains(".modal-title", "Delete subject");
+    cy.intercept("DELETE", "**/v1/subjects/**", {
+      fixture: "subjects/subject_deleted.json",
+      statusCode: 200,
+    });
+    cy.get(".btn-danger").click();
+    cy.contains("Subject succesfully deleted.").should("be.visible");
+  });
+  it("edits a subject", () => {
+    cy.intercept("GET", "http://localhost:8080/v1/subjects/9", {
+      fixture: "subjects/subject",
+    }).as("getSubject");
+    cy.get("table")
+      .contains("td", "1")
+      .parent("tr")
+      .find("#edit-button-9")
+      .click();
+    cy.get(".modal-header").contains("Edit subject");
+    cy.intercept("PATCH", "**/v1/subjects/**", {
+      fixture: "subjects/subject.json",
+      statusCode: 200,
+    });
+    cy.get(".btn-success").click();
+    cy.contains("Subject succesfully updated.").should("be.visible");
+  });
+});
+
+describe("/subjects?create", () => {
+  before(() => {
+    cy.setupValidation("identified");
+  });
+  beforeEach(() => {
+    cy.kcLogout();
+    cy.kcLogin("identified");
+    cy.visit("/subjects?create");
+  });
+
+  it("greets with create new subject", () => {
+    cy.get("#contained-modal-title-vcenter").contains("Create new subject");
+  });
+
+  it("closes the modal", () => {
+    cy.get(".modal-content").should("be.visible");
+    cy.get("#modal-cancel-button").click();
+    cy.get(".modal-content").should("not.exist");
+  });
+
+  it("creates a subject", () => {
+    cy.intercept("POST", "http://localhost:8080/v1/subjects", {
+      fixture: "subjects/subject",
+    }).as("postSubject");
+    cy.get("#input-info-subject-id").type("subject_test_id");
+    cy.get("#input-info-subject-name").type("subject_test_name");
+    cy.get("#input-info-subject-type").type("subject_test_type");
+    cy.get(".btn-success").click();
+    cy.wait("@postSubject");
+    cy.contains("Subject succesfully created.").should("be.visible");
+  });
+  it("requires a subject id", () => {
+    cy.get(".btn-success").click();
+    cy.get(".modal-content").should("be.visible");
+    cy.contains("Error during subject creation.").should("be.visible");
+  });
+  it("requires a subject name", () => {
+    cy.get("#input-info-subject-id").type("subject_test_id{enter}");
+    cy.get(".btn-success").click();
+    cy.get(".modal-content").should("be.visible");
+    cy.contains("Error during subject creation.").should("be.visible");
+  });
+  it("requires a subject type", () => {
+    cy.get("#input-info-subject-id").type("subject_test_id");
+    cy.get("#input-info-subject-name").type("subject_test_name{enter}");
+    cy.get(".btn-success").click();
+    cy.get(".modal-content").should("be.visible");
+    cy.contains("Error during subject creation.").should("be.visible");
+  });
+});

--- a/cypress/fixtures/subjects/subject.json
+++ b/cypress/fixtures/subjects/subject.json
@@ -1,0 +1,6 @@
+{
+  "name": "test",
+  "type": "1",
+  "id": 9,
+  "subject_id": "test"
+}

--- a/cypress/fixtures/subjects/subject_deleted.json
+++ b/cypress/fixtures/subjects/subject_deleted.json
@@ -1,0 +1,1 @@
+{ "code": 200, "message": "Subject has been successfully deleted." }

--- a/cypress/fixtures/subjects/subject_edit.json
+++ b/cypress/fixtures/subjects/subject_edit.json
@@ -1,0 +1,6 @@
+{
+  "name": "test",
+  "type": "identified_test_subject_type",
+  "id": 1,
+  "subject_id": "identified_test_subject_id"
+}

--- a/cypress/fixtures/subjects/subjects.json
+++ b/cypress/fixtures/subjects/subjects.json
@@ -1,0 +1,57 @@
+{
+  "size_of_page": 4,
+  "number_of_page": 1,
+  "total_elements": 4,
+  "total_pages": 1,
+  "content": [
+    {
+      "name": "test",
+      "type": "1",
+      "id": 9,
+      "subject_id": "test"
+    },
+    {
+      "name": "test",
+      "type": "test",
+      "id": 8,
+      "subject_id": "test"
+    },
+    {
+      "name": "subject_test_name",
+      "type": "subject_test_type",
+      "id": 7,
+      "subject_id": "subject_test_id"
+    },
+    {
+      "name": "identified_test_subject_name",
+      "type": "identified_test_subject_type",
+      "id": 1,
+      "subject_id": "identified_test_subject_id"
+    },
+    {
+      "name": "test",
+      "type": "2",
+      "id": 9,
+      "subject_id": "test"
+    },
+    {
+      "name": "test",
+      "type": "3",
+      "id": 8,
+      "subject_id": "test"
+    },
+    {
+      "name": "test",
+      "type": "4",
+      "id": 7,
+      "subject_id": "test"
+    },
+    {
+      "name": "test",
+      "type": "5",
+      "id": 1,
+      "subject_id": "test"
+    }
+  ],
+  "links": []
+}

--- a/src/pages/Subjects.tsx
+++ b/src/pages/Subjects.tsx
@@ -323,7 +323,7 @@ function Subjects() {
             <>
               <div className="edit-buttons btn-group shadow">
                 <Button
-                  id={`edit-button-${info.getValue().id}`}
+                  id={`edit-button-${item.id}`}
                   className="btn btn-secondary cat-action-reject-link btn-sm "
                   onClick={() => {
                     if (item.id) {
@@ -338,7 +338,7 @@ function Subjects() {
                   <FaEdit />
                 </Button>
                 <Button
-                  id={`delete-button-${info.getValue().id}`}
+                  id={`delete-button-${item.id}`}
                   className="btn btn-secondary cat-action-reject-link btn-sm "
                   onClick={() => {
                     if (item.id) {

--- a/src/pages/Subjects.tsx
+++ b/src/pages/Subjects.tsx
@@ -213,7 +213,11 @@ export function SubjectModal(props: SubjectModalProps) {
       <Modal.Footer className="d-flex justify-content-between">
         {props.mode == SubjectModalMode.Create && (
           <>
-            <Button className="btn-secondary" onClick={() => props.onHide()}>
+            <Button
+              id="modal-cancel-button"
+              className="btn-secondary"
+              onClick={() => props.onHide()}
+            >
               Cancel
             </Button>
             <Button
@@ -319,6 +323,7 @@ function Subjects() {
             <>
               <div className="edit-buttons btn-group shadow">
                 <Button
+                  id={`edit-button-${info.getValue().id}`}
                   className="btn btn-secondary cat-action-reject-link btn-sm "
                   onClick={() => {
                     if (item.id) {
@@ -333,6 +338,7 @@ function Subjects() {
                   <FaEdit />
                 </Button>
                 <Button
+                  id={`delete-button-${info.getValue().id}`}
                   className="btn btn-secondary cat-action-reject-link btn-sm "
                   onClick={() => {
                     if (item.id) {


### PR DESCRIPTION
## Cypress subject page test

### Description
This PR adds a spec for testing the /subjects and the /subjects?create pages. It tests the subjects?create form and the editing and deleting of subjects.

### Changes made
- Added tests for the /subjects page
- Added tests for the /subjects?create page
- Added id for button that closes modal.
- Added dynamic ids for the subject edit and delete button in the subjects table.

 ### How to test
 #### With Cypress UI
- Setup and run both the fc4e-cat-ui and fc4e-cat-api locally.
- run `npx cypress open` in the fc4e-cat-ui project.
- Select E2E testing.
- Select a browser and click 'start testing'.
- This should open the chosen browser and allow you to run the test by clicking on 'assessment.cy.ts'.

#### On the CLI
- Setup and run both the fc4e-cat-ui and fc4e-cat-api locally.
- `npx cypress run` 