### PR TITLE
Cypress spec /assess and /assessment page

### DIFF
--- a/cypress/e2e/assess.cy.ts
+++ b/cypress/e2e/assess.cy.ts
@@ -25,7 +25,7 @@ describe("/assess", () => {
       "href",
       "/assessments",
     );
-    cy.get("#create_assessment_button").should(
+    cy.get("#assessment_form_button").should(
       "have.attr",
       "href",
       "/assessments/create",

--- a/cypress/e2e/assess.cy.ts
+++ b/cypress/e2e/assess.cy.ts
@@ -1,0 +1,34 @@
+/// <reference types="cypress"/>
+describe("/assess", () => {
+  beforeEach(() => {
+    cy.kcLogout();
+    cy.kcLogin("identified").as("identifiedTokens");
+    cy.visit("/assess");
+  });
+
+  it("should have actor cards that are flippable", () => {
+    cy.get('[id^="actorCard_"]').eq(0).as("actorCard");
+    cy.get("@actorCard").find('[id^="frontButton_"]').click();
+    cy.get("@actorCard").find('[id^="frontButton_"]').should("not.exist");
+    cy.get("@actorCard").find('[id^="backButton_"]').click();
+    cy.get("@actorCard").find('[id^="assessmentButton_"]').should("exist");
+  });
+
+  it("should link to the public assessments page", () => {
+    cy.get('[id^="actorCard_"]').eq(0).as("actorCard");
+    cy.get("@actorCard").find('[id^="assessmentButton_"]').click();
+    cy.url().should("include", "public-assessments");
+  });
+  it("should have working links", () => {
+    cy.get("#view_assessments_button").should(
+      "have.attr",
+      "href",
+      "/assessments",
+    );
+    cy.get("#create_assessment_button").should(
+      "have.attr",
+      "href",
+      "/assessments/create",
+    );
+  });
+});

--- a/cypress/e2e/assessment.cy.ts
+++ b/cypress/e2e/assessment.cy.ts
@@ -91,16 +91,12 @@ describe("/assessments/create", () => {
     cy.get("form:visible").within(() => {
       cy.get("#test-check-yes").click();
     });
-    cy.get("#left-tabs-tabpane-C5 .badge:visible")
-      .contains("PASS")
-      .should("exist");
+    cy.get("#left-tabs-tabpane-C5").contains("PASS").should("exist");
     cy.get("#left-tabs-tab-C6").click();
     cy.get("form:visible").within(() => {
       cy.get("#test-check-yes").click();
     });
-    cy.get("#left-tabs-tabpane-C6 .badge:visible")
-      .contains("PASS")
-      .should("exist");
+    cy.get("#left-tabs-tabpane-C6").contains("PASS").should("exist");
     cy.get("#left-tabs-tab-C7").click();
 
     cy.get("form:visible")
@@ -117,85 +113,65 @@ describe("/assessments/create", () => {
         cy.get("#input-value-control").type("70");
         cy.get("#input-value-community").type("70");
       });
-    cy.get("#left-tabs-tabpane-C7 .badge:visible")
-      .contains("PASS")
-      .should("exist");
+    cy.get("#left-tabs-tabpane-C7").contains("PASS").should("exist");
 
     cy.get("#left-tabs-tab-C11").click();
     cy.get("form:visible").within(() => {
       cy.get("#test-check-yes").click();
     });
-    cy.get("#left-tabs-tabpane-C11 .badge:visible")
-      .contains("PASS")
-      .should("exist");
+    cy.get("#left-tabs-tabpane-C11").contains("PASS").should("exist");
 
     cy.get("#left-tabs-tab-C14").click();
     cy.get("form:visible").within(() => {
       cy.get("#input-value-control").type("70");
       cy.get("#input-value-community").type("70");
     });
-    cy.get("#left-tabs-tabpane-C14 .badge:visible")
-      .contains("PASS")
-      .should("exist");
+    cy.get("#left-tabs-tabpane-C14").contains("PASS").should("exist");
 
     cy.get("#left-tabs-tab-C34").click();
     cy.get("form:visible").within(() => {
       cy.get("#input-value-control").type("70");
       cy.get("#input-value-community").type("70");
     });
-    cy.get("#left-tabs-tabpane-C34 .badge:visible")
-      .contains("PASS")
-      .should("exist");
+    cy.get("#left-tabs-tabpane-C34").contains("PASS").should("exist");
 
     cy.get("#left-tabs-tab-C16").click();
     cy.get("form:visible").within(() => {
       cy.get("#input-value-control").type("70");
       cy.get("#input-value-community").type("70");
     });
-    cy.get("#left-tabs-tabpane-C16 .badge:visible")
-      .contains("PASS")
-      .should("exist");
+    cy.get("#left-tabs-tabpane-C16").contains("PASS").should("exist");
 
     cy.get("#left-tabs-tab-C19").click();
     cy.get("form:visible").within(() => {
       cy.get("#test-check-yes").click();
     });
-    cy.get("#left-tabs-tabpane-C19 .badge:visible")
-      .contains("PASS")
-      .should("exist");
+    cy.get("#left-tabs-tabpane-C19").contains("PASS").should("exist");
 
     cy.get("#left-tabs-tab-C22").click();
     cy.get("form:visible").within(() => {
       cy.get("#test-check-yes").click();
     });
-    cy.get("#left-tabs-tabpane-C22 .badge:visible")
-      .contains("PASS")
-      .should("exist");
+    cy.get("#left-tabs-tabpane-C22").contains("PASS").should("exist");
 
     cy.get("#left-tabs-tab-C29").click();
     cy.get("form:visible").within(() => {
       cy.get("#test-check-yes").click();
     });
-    cy.get("#left-tabs-tabpane-C29 .badge:visible")
-      .contains("PASS")
-      .should("exist");
+    cy.get("#left-tabs-tabpane-C29").contains("PASS").should("exist");
 
     cy.get("#left-tabs-tab-C28").click();
     cy.get("form:visible").within(() => {
       cy.get("#test-check-yes").click();
     });
-    cy.get("#left-tabs-tabpane-C28 .badge:visible")
-      .contains("PASS")
-      .should("exist");
+    cy.get("#left-tabs-tabpane-C28").contains("PASS").should("exist");
 
     cy.get("#left-tabs-tab-C35").click();
     cy.get("form:visible").within(() => {
       cy.get("#input-value-control").type("70");
       cy.get("#input-value-community").type("70");
     });
-    cy.get("#left-tabs-tabpane-C35 .badge:visible")
-      .contains("PASS")
-      .should("exist");
+    cy.get("#left-tabs-tabpane-C35").contains("PASS").should("exist");
 
     cy.get("#create_assessment_button").click();
     cy.url().should("contain", "/assessments");
@@ -250,7 +226,7 @@ describe("/assessments", () => {
     cy.get("form:visible").within(() => {
       cy.get("#test-check-no").click();
     });
-    cy.get("#left-tabs-tabpane-C5 .badge:visible").contains("FAIL");
+    cy.get("#left-tabs-tabpane-C5").contains("FAIL");
     cy.contains("Close").click();
     // select via Ranking header to prevent breaking tests when columns change.
     cy.contains("thead th", "Ranking").then((rankingHeader) => {
@@ -273,7 +249,7 @@ describe("/assessments", () => {
     cy.get("form:visible").within(() => {
       cy.get("#test-check-no").click();
     });
-    cy.get("#left-tabs-tabpane-C5 .badge:visible").contains("FAIL");
+    cy.get("#left-tabs-tabpane-C5").contains("FAIL");
     cy.get("#submit_assessment_button").click();
     // select via Ranking header to prevent breaking tests when columns change.
     cy.contains("thead th", "Ranking").then((rankingHeader) => {

--- a/cypress/e2e/assessment.cy.ts
+++ b/cypress/e2e/assessment.cy.ts
@@ -255,11 +255,6 @@ describe("/assessments", () => {
     // select via Ranking header to prevent breaking tests when columns change.
     cy.contains("thead th", "Ranking").then((rankingHeader) => {
       const rankingColumnIndex = rankingHeader.index();
-      const badgeColumnIndex = rankingColumnIndex - 1;
-
-      cy.get(`tbody > :nth-child(1) > :nth-child(${badgeColumnIndex + 1})`)
-        .find(".badge")
-        .should("contain", "PASS");
 
       cy.get(
         `tbody > :nth-child(1) > :nth-child(${rankingColumnIndex + 1})`,

--- a/cypress/e2e/assessment.cy.ts
+++ b/cypress/e2e/assessment.cy.ts
@@ -28,7 +28,7 @@ describe("/assessments/create", () => {
 
   it("Can go to step 2 and go back", () => {
     cy.get("#radio-0").click();
-    cy.get(".btn-success").should("not.have.attr", "disabled");
+    cy.get("#create_assessment_button").should("not.have.attr", "disabled");
     cy.get("#next-button").click();
     cy.get("#assessment-wizard-tab-step-2").should(
       "have.attr",
@@ -44,7 +44,7 @@ describe("/assessments/create", () => {
   });
   it("makes the submitter fields readonly", () => {
     cy.get("#radio-0").click();
-    cy.get(".btn-success").should("not.have.attr", "disabled");
+    cy.get("#create_assessment_button").should("not.have.attr", "disabled");
     cy.get("#next-button").click();
     cy.get('#accordion_general button[aria-expanded="true"]').should("exist");
     cy.get("#accordion_submitter").click();
@@ -80,7 +80,7 @@ describe("/assessments/create", () => {
     const subjectName = "identified_test_subject_name";
     const subjectType = "identified_test_subject_type";
     cy.get("#radio-0").click();
-    cy.get(".btn-success").should("not.have.attr", "disabled");
+    cy.get("#create_assessment_button").should("not.have.attr", "disabled");
     cy.get("#assessment-wizard-tab-step-2").click();
     cy.get("#input-info-name").type("identified_test_assessment");
     cy.get("#accordion_subject").click();
@@ -197,8 +197,107 @@ describe("/assessments/create", () => {
       .contains("PASS")
       .should("exist");
 
-    cy.get(".btn-success").click();
+    cy.get("#create_assessment_button").click();
     cy.url().should("contain", "/assessments");
     cy.contains("Assessment succesfully created.").should("be.visible");
+  });
+});
+
+describe("/assessments", () => {
+  beforeEach(() => {
+    cy.kcLogout();
+    cy.kcLogin("identified").as("identifiedTokens");
+    cy.visit("/assessments");
+  });
+
+  it("should be able to filter on subject type and name", () => {
+    cy.contains("Filter").click();
+
+    // Test subject type filtering
+    cy.get("#floatingSelectSubjectType").select("identified_test_subject_type");
+    cy.get("#floatingSelectSubjectType")
+      .find(":selected")
+      .should("have.text", "identified_test_subject_type");
+    cy.get("#apply_filter_button").click();
+    cy.get("table").find("tbody").find("tr").should("exist");
+
+    cy.get("#clear_filter_button").click();
+    cy.get("#floatingSelectSubjectType")
+      .find(":selected")
+      .should("have.text", "Select Subject Type");
+
+    // Test subject name filtering
+    cy.get("#floatingSelectSubjectName").select("identified_test_subject_name");
+    cy.get("#floatingSelectSubjectName")
+      .find(":selected")
+      .should("have.text", "identified_test_subject_name");
+    cy.get("#apply_filter_button").click();
+    cy.get("table").find("tbody").find("tr").should("exist");
+    cy.get("#clear_filter_button").click();
+    cy.get("#floatingSelectSubjectName")
+      .find(":selected")
+      .should("have.text", "Select Subject Name");
+  });
+
+  it("makes no changes to assessment when editing and not saving", () => {
+    cy.get("table")
+      .contains("td", "1")
+      .parent("tr")
+      .find('[id^="edit-button-"]')
+      .click();
+    cy.get("#actorRadio").contains("PID Manager at Oxford Fertility");
+    cy.get("#assessment-wizard-tab-step-3").click();
+    cy.get("form:visible").within(() => {
+      cy.get("#test-check-no").click();
+    });
+    cy.get("#left-tabs-tabpane-C5 .badge:visible").contains("FAIL");
+    cy.contains("Close").click();
+    // select via Ranking header to prevent breaking tests when columns change.
+    cy.contains("thead th", "Ranking").then((rankingHeader) => {
+      const rankingColumnIndex = rankingHeader.index();
+      const badgeColumnIndex = rankingColumnIndex - 1;
+
+      cy.get(`tbody > :nth-child(1) > :nth-child(${badgeColumnIndex + 1})`)
+        .find(".badge")
+        .should("contain", "PASS");
+
+      cy.get(
+        `tbody > :nth-child(1) > :nth-child(${rankingColumnIndex + 1})`,
+      ).should("contain", "7");
+    });
+  });
+
+  it("edits an assessment", () => {
+    cy.get("table")
+      .contains("td", "1")
+      .parent("tr")
+      .find('[id^="edit-button-"]')
+      .click();
+    cy.get("#actorRadio").contains("PID Manager at Oxford Fertility");
+    cy.get("#assessment-wizard-tab-step-3").click();
+    cy.get("form:visible").within(() => {
+      cy.get("#test-check-no").click();
+    });
+    cy.get("#left-tabs-tabpane-C5 .badge:visible").contains("FAIL");
+    cy.get("#submit_assessment_button").click();
+    // select via Ranking header to prevent breaking tests when columns change.
+    cy.contains("thead th", "Ranking").then((rankingHeader) => {
+      const rankingColumnIndex = rankingHeader.index();
+      cy.get(
+        `tbody > :nth-child(1) > :nth-child(${rankingColumnIndex + 1})`,
+      ).should("contain", "6");
+    });
+    cy.contains("Assessment succesfully updated.").should("be.visible");
+  });
+
+  it("deletes an assessment", () => {
+    cy.get("table")
+      .contains("td", "1")
+      .parent("tr")
+      .find('[id^="delete-button-"]')
+      .click();
+    cy.get("#contained-modal-title-vcenter").contains("Delete Assessment");
+    cy.get(".btn-danger").click();
+    cy.contains("Assessment succesfully deleted.").should("be.visible");
   });
 });

--- a/src/pages/assessments/AssessmentEdit.tsx
+++ b/src/pages/assessments/AssessmentEdit.tsx
@@ -570,6 +570,7 @@ const AssessmentEdit = ({ createMode = true }: AssessmentEditProps) => {
             <div>
               {createMode ? (
                 <Button
+                  id="create_assessment_button"
                   disabled={!wizardTabActive}
                   className="ms-5 btn btn-success px-5"
                   onClick={() => {
@@ -581,6 +582,7 @@ const AssessmentEdit = ({ createMode = true }: AssessmentEditProps) => {
               ) : (
                 <>
                   <Button
+                    id="save_assessment_button"
                     disabled={!wizardTabActive}
                     className="ms-2 btn btn-success px-5"
                     onClick={() => {
@@ -591,6 +593,7 @@ const AssessmentEdit = ({ createMode = true }: AssessmentEditProps) => {
                   </Button>
 
                   <Button
+                    id="submit_assessment_button"
                     disabled={
                       !(
                         assessment &&

--- a/src/pages/assessments/Assessments.tsx
+++ b/src/pages/assessments/Assessments.tsx
@@ -72,14 +72,14 @@ function Assessments() {
           {authenticated && (
             <div className="d-flex justify-content-end my-2">
               <Link
-                  id="assessment_form_button"
+                id="assessment_form_button"
                 to={`/assessments/create`}
                 className="btn btn-light border-black mx-3"
               >
                 <FaPlus /> Create New
               </Link>
               <Link
-                  id="view_assessments_button"
+                id="view_assessments_button"
                 to="/assessments"
                 className="btn btn-light border-black mx-3"
               >

--- a/src/pages/assessments/Assessments.tsx
+++ b/src/pages/assessments/Assessments.tsx
@@ -72,12 +72,14 @@ function Assessments() {
           {authenticated && (
             <div className="d-flex justify-content-end my-2">
               <Link
+                  id="assessment_form_button"
                 to={`/assessments/create`}
                 className="btn btn-light border-black mx-3"
               >
                 <FaPlus /> Create New
               </Link>
               <Link
+                  id="view_assessments_button"
                 to="/assessments"
                 className="btn btn-light border-black mx-3"
               >

--- a/src/pages/assessments/AssessmentsList.tsx
+++ b/src/pages/assessments/AssessmentsList.tsx
@@ -359,12 +359,14 @@ function AssessmentsList({ listPublic = false }: AssessmentListProps) {
                 <>
                   <div className="edit-buttons btn-group shadow">
                     <Link
+                      id={`edit-button-${item.id}`}
                       className="btn btn-secondary cat-action-view-link btn-sm "
                       to={`/assessments/${item.id}`}
                     >
                       <FaEdit />
                     </Link>
                     <Button
+                      id={`download-button-${item.id}`}
                       className="btn btn-secondary cat-action-reject-link btn-sm "
                       onClick={() => {
                         setAsmtNumID(item["id"]);
@@ -373,6 +375,7 @@ function AssessmentsList({ listPublic = false }: AssessmentListProps) {
                       <FaDownload />
                     </Button>
                     <Button
+                      id={`delete-button-${item.id}`}
                       className="btn btn-secondary cat-action-reject-link btn-sm "
                       onClick={() => {
                         handleDeleteOpenModal(item);
@@ -557,6 +560,7 @@ function AssessmentsList({ listPublic = false }: AssessmentListProps) {
                 <Col className="d-flex justify-content-end filter-div">
                   <InputGroup className="mb-3">
                     <Button
+                      id="apply_filter_button"
                       className="btn btn-success btn centerButton"
                       type="submit"
                     >
@@ -565,6 +569,7 @@ function AssessmentsList({ listPublic = false }: AssessmentListProps) {
                   </InputGroup>
                   <InputGroup className="mb-3">
                     <Button
+                      id="clear_filter_button"
                       className="btn btn-primary btn centerButton"
                       type="submit"
                       onClick={() => {

--- a/src/pages/assessments/components/ActorCard.tsx
+++ b/src/pages/assessments/components/ActorCard.tsx
@@ -17,6 +17,9 @@ export function ActorCard({
   description: string;
   disabled?: boolean;
 }) {
+  // Sanitize the title to remove characters not suitable for HTML IDs
+  const sanitizedTitle = title.replace(/[^\w\s]/gi, "").replace(/\s+/g, "_");
+
   // if card is flipped it displays the help text and not the front content
   const [flipped, setFlipped] = useState<boolean>(false);
   const handleFlip = () => {
@@ -25,6 +28,7 @@ export function ActorCard({
 
   return (
     <Card
+      id={`actorCard_${sanitizedTitle}`}
       className="p-2 border-grey shadow-sm mb-2"
       style={{ height: "350px" }}
     >
@@ -43,6 +47,7 @@ export function ActorCard({
               <Card.Title className="d-flex justify-content-between">
                 {title}
                 <span
+                  id={`frontButton_${sanitizedTitle}`}
                   role="button"
                   onClick={handleFlip}
                   className="text-end mb-1"
@@ -55,7 +60,7 @@ export function ActorCard({
             <Card.Footer className="bg-transparent border-0">
               <Link to={link} className="text-decoration-none">
                 <span className="me-2">{linkText}</span>
-                <span role="button">
+                <span role="button" id={`assessmentButton_${sanitizedTitle}`}>
                   <FaExternalLinkAlt />
                 </span>
               </Link>
@@ -68,6 +73,7 @@ export function ActorCard({
               <Card.Title className="d-flex justify-content-between">
                 {title}
                 <span
+                  id={`backButton_${sanitizedTitle}`}
                   role="button"
                   onClick={handleFlip}
                   className="text-end mb-1"


### PR DESCRIPTION
## Cypress spec /assess and /assessment page
### Description
This PR adds the assess spec and updates the assessment spec. The assess spec, assess.cy.ts, tests the /assess page. It check all interaction on the page like the links and the actor cards. The assessment spec has been extended with tests for the editing and deleting of an assessment. It also now tests the filter functionality for the assessment table.

I've also added dynamic ids for the actor cards and for the action buttons in the assessment table. Please have a look if you agree with the way these dynamic ids are generated.

### Changes made
- Added a spec for testing the /assess page.
- Updated assessment spec to include tests for /assessment page functionality.
- Added ids for selecting elements to use in the specs.
- Added dynamic ids for the actor cards and assessment table actions.


 ### How to test
 #### With Cypress UI
- Setup and run both the fc4e-cat-ui and fc4e-cat-api locally.
- run `npx cypress open` in the fc4e-cat-ui project.
- Select E2E testing.
- Select a browser and click 'start testing'.
- This should open the chosen browser and allow you to run the test by clicking on 'assessment.cy.ts'.

#### On the CLI
- Setup and run both the fc4e-cat-ui and fc4e-cat-api locally.
- `npx cypress run` 