### PR TITLE
CAT-323 Fix approve/reject admin validation paths

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -133,7 +133,9 @@ function App() {
                   >
                     <Route
                       index
-                      element={<ValidationDetails toReject={true} />}
+                      element={
+                        <ValidationDetails admin={true} toReject={true} />
+                      }
                     />
                   </Route>
                   <Route
@@ -142,7 +144,9 @@ function App() {
                   >
                     <Route
                       index
-                      element={<ValidationDetails toApprove={true} />}
+                      element={
+                        <ValidationDetails admin={true} toApprove={true} />
+                      }
                     />
                   </Route>
                   <Route path="/login" element={<ProtectedRoute />}>

--- a/src/pages/validations/ValidationDetails.tsx
+++ b/src/pages/validations/ValidationDetails.tsx
@@ -7,6 +7,7 @@ import {
   ValidationStatus,
 } from "@/types";
 import { useRef, useState, useContext, useEffect } from "react";
+import { Modal } from "react-bootstrap";
 import toast from "react-hot-toast";
 import {
   FaExclamationTriangle,
@@ -57,117 +58,114 @@ function ValidationDetails(props: ValidationProps) {
 
   if (props.toReject) {
     rejectCard = (
-      <div className="container">
-        <div className="card border-danger mb-2">
-          <div className="card-header border-danger text-danger text-center">
-            <h5>
-              <FaExclamationTriangle className="mx-3" />
-              <strong>Validation Request Rejection</strong>
-            </h5>
-          </div>
-          <div className=" card-body border-danger text-center">
-            Are you sure you want to reject validation with ID:{" "}
-            <strong>{params.id}</strong> ?
-          </div>
-          <div className="card-footer border-danger text-danger text-center">
-            <button
-              className="btn btn-danger mr-2"
-              onClick={() => {
-                setReviewStatus(ValidationStatus.REJECTED);
-                const promise = mutateValidationUpdateStatus()
-                  .catch((err) => {
-                    alert.current = {
-                      message: "Error during validation rejection.",
-                    };
-                    throw err;
-                  })
-                  .then(() => {
-                    alert.current = {
-                      message: "Validation successfully rejected.",
-                    };
-                  })
-                  .finally(() => navigate("/admin/validations"));
-                toast.promise(promise, {
-                  loading: "Rejecting",
-                  success: () => `${alert.current.message}`,
-                  error: () => `${alert.current.message}`,
-                });
-              }}
-            >
-              Reject
-            </button>
-            <button
-              onClick={() => {
-                navigate(`/admin/validations/${params.id}`);
-              }}
-              className="btn btn-dark mx-4"
-            >
-              Cancel
-            </button>
-          </div>
-        </div>
-      </div>
+      <Modal show={true} className="border-danger mb-2">
+        <Modal.Header className="card-header border-danger text-danger text-center">
+          <h5>
+            <FaExclamationTriangle className="mx-3" />
+            <strong>Validation Request Rejection</strong>
+          </h5>
+        </Modal.Header>
+        <Modal.Body className=" card-body border-danger text-center">
+          Are you sure you want to reject validation with ID:{" "}
+          <strong>{params.id}</strong> ?
+        </Modal.Body>
+        <Modal.Footer className="card-footer border-danger text-danger text-center">
+          <button
+            className="btn btn-danger mr-2"
+            onClick={() => {
+              setReviewStatus(ValidationStatus.REJECTED);
+              const promise = mutateValidationUpdateStatus()
+                .catch((err) => {
+                  alert.current = {
+                    message: "Error during validation rejection.",
+                  };
+                  throw err;
+                })
+                .then(() => {
+                  alert.current = {
+                    message: "Validation successfully rejected.",
+                  };
+                })
+                .finally(() => navigate("/admin/validations"));
+              toast.promise(promise, {
+                loading: "Rejecting",
+                success: () => `${alert.current.message}`,
+                error: () => `${alert.current.message}`,
+              });
+            }}
+          >
+            Reject
+          </button>
+          <button
+            onClick={() => {
+              navigate(`/admin/validations/${params.id}`);
+            }}
+            className="btn btn-dark mx-4"
+          >
+            Cancel
+          </button>
+        </Modal.Footer>
+      </Modal>
     );
   }
 
   if (props.toApprove) {
     approveCard = (
-      <div className="container">
-        <div className="card border-success mb-2">
-          <div className="card-header border-success text-success text-center">
-            <h5>
-              <FaExclamationTriangle className="mx-3" />
-              <strong>Validation Request Approval</strong>
-            </h5>
-          </div>
-          <div className=" card-body border-info text-center">
-            Are you sure you want to approve validation with ID:{" "}
-            <strong>{params.id}</strong> ?
-          </div>
-          <div className="card-footer border-success text-success text-center">
-            <button
-              className="btn btn-success mr-2"
-              onClick={() => {
-                setReviewStatus(ValidationStatus.APPROVED);
-                const promise = mutateValidationUpdateStatus()
-                  .catch((err) => {
-                    alert.current = {
-                      message: "Error during validation approval.",
-                    };
-                    throw err;
-                  })
-                  .then(() => {
-                    alert.current = {
-                      message: "Validation successfully approved.",
-                    };
-                  })
-                  .finally(() => navigate("/admin/validations"));
-                toast.promise(promise, {
-                  loading: "Approving",
-                  success: () => `${alert.current.message}`,
-                  error: () => `${alert.current.message}`,
-                });
-              }}
-            >
-              Approve
-            </button>
-            <button
-              onClick={() => {
-                navigate(`/admin/validations/${params.id}`);
-              }}
-              className="btn btn-dark mx-4"
-            >
-              Cancel
-            </button>
-          </div>
-        </div>
-      </div>
+      <Modal show={true}>
+        <Modal.Header className="border-success text-success text-center">
+          <h5>
+            <FaExclamationTriangle className="mx-3" />
+            <strong>Validation Request Approval</strong>
+          </h5>
+        </Modal.Header>
+        <Modal.Body className="border-info text-center">
+          Are you sure you want to approve validation with ID:{" "}
+          <strong>{params.id}</strong> ?
+        </Modal.Body>
+        <Modal.Footer className="border-success text-success text-center">
+          <button
+            className="btn btn-success mr-2"
+            onClick={() => {
+              setReviewStatus(ValidationStatus.APPROVED);
+              const promise = mutateValidationUpdateStatus()
+                .catch((err) => {
+                  alert.current = {
+                    message: "Error during validation approval.",
+                  };
+                  throw err;
+                })
+                .then(() => {
+                  alert.current = {
+                    message: "Validation successfully approved.",
+                  };
+                })
+                .finally(() => navigate("/admin/validations"));
+              toast.promise(promise, {
+                loading: "Approving",
+                success: () => `${alert.current.message}`,
+                error: () => `${alert.current.message}`,
+              });
+            }}
+          >
+            Approve
+          </button>
+          <button
+            onClick={() => {
+              navigate(`/admin/validations/${params.id}`);
+            }}
+            className="btn btn-dark mx-4"
+          >
+            Cancel
+          </button>
+        </Modal.Footer>
+      </Modal>
     );
   }
 
   if (keycloak?.token) {
     return (
       <div className="mt-4">
+        <span id="alert-spot" />
         {rejectCard}
         {approveCard}
         <div
@@ -301,13 +299,13 @@ function ValidationDetails(props: ValidationProps) {
               <section className="col-9">
                 <Link
                   className="btn btn-light border-black text-success"
-                  to={`/validations/${params.id}/approve#alert-spot`}
+                  to={`/admin/validations/${params.id}/approve#alert-spot`}
                 >
                   <FaCheck /> Approve
                 </Link>
                 <Link
                   className="btn btn-light mx-4 text-danger border-black"
-                  to={`/validations/${params.id}/reject#alert-spot`}
+                  to={`/admin/validations/${params.id}/reject#alert-spot`}
                 >
                   <FaTimes /> Reject
                 </Link>
@@ -321,8 +319,6 @@ function ValidationDetails(props: ValidationProps) {
         >
           Back
         </Link>
-
-        <span id="alert-spot" />
       </div>
     );
   } else {


### PR DESCRIPTION
CAT-326 Fix admin validation details view information backend path 
CAT-327 Turn approve/reject dialogs into modals

# Implementation:
- [x] When approving/rejecting validations in admin mode use the correct admin paths: such as `/admin/validations/{id}/approve` etc instead of the plain `/validations/{id}`
- [x] When viewing validation details in admin mode call the `/admin/validations/{id}` path instead of the plain `/validations/{id}`
- [x] When clicking to approve or reject a validation a dialog appears on top of the page out of view. Modify the dialog as a proper modal to be more user friendly