### PR TITLE
CAT-328 Assessment creation: fix issue with valid actor duplicates

### DIFF
--- a/src/pages/assessments/AssessmentEdit.tsx
+++ b/src/pages/assessments/AssessmentEdit.tsx
@@ -120,13 +120,19 @@ const AssessmentEdit = ({ createMode = true }: AssessmentEditProps) => {
   // TODO: Get all available pages in an infinite scroll not all sequentially.
   useEffect(() => {
     if (data?.content) {
-      setValidations((validations) => [...validations, ...data.content]);
+      // if we are on the first page replace previous content
+      if (page === 1) {
+        setValidations(data.content);
+      } else {
+        setValidations((validations) => [...validations, ...data.content]);
+      }
+
       if (data?.number_of_page < data?.total_pages) {
         setPage((page) => page + 1);
         refetchGetValidationList();
       }
     }
-  }, [data, refetchGetValidationList]);
+  }, [data, refetchGetValidationList, page, validations]);
 
   // After retrieving user's valitions we create a struct for the option boxes creation
   const [actorsOrgsMap, setActorsOrgsMap] = useState<


### PR DESCRIPTION
# Fix duplicates in validated actors list.

The validated actors list is compiled by fetching first the approved validation requests from the api. When fetch the first page of the approved validation request replace local ui data with the result. When fetching further pages add them to the local data result. Fix also hook dependencies

