### PR TITLE
CAT-329 Simplify navigation menu

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -12,7 +12,7 @@ import logo from "@/logo.svg";
 import { useGetProfile } from "@/api";
 import { trimProfileID } from "@/utils";
 import { AuthContext } from "@/auth";
-import { FaUser, FaCog, FaShieldAlt } from "react-icons/fa";
+import { FaUser, FaShieldAlt } from "react-icons/fa";
 import { UserProfile } from "@/types";
 
 function Header() {
@@ -84,42 +84,26 @@ function Header() {
           {/* Collapsible part that holds navigation links */}
           <Navbar.Collapse id="basic-navbar-nav">
             <Nav className="me-auto">
-              <NavItem>
-                <Link to="/" className="cat-nav-link">
-                  HOME
-                </Link>
-              </NavItem>
-              <NavItem>
-                <Link to="/" className="cat-nav-link cat-text-faded">
-                  SEARCH
-                </Link>
-              </NavItem>
-              <NavItem>
-                <Link to="/assess" className="cat-nav-link">
-                  ASSESS
-                </Link>
-              </NavItem>
-              <NavItem>
-                <Link to="#" className="cat-nav-link cat-text-faded">
-                  RESOURCES
-                </Link>
-              </NavItem>
-
               {authenticated && userProfile?.id && (
                 <>
                   <NavItem>
                     <Link to="/profile" className="cat-nav-link">
-                      <FaUser />
+                      <FaUser /> PROFILE
                     </Link>
                   </NavItem>
-
                   <NavItem>
-                    <Link to="/" className="cat-nav-link cat-text-faded">
-                      <FaCog />
+                    <Link to="/validations" className="cat-nav-link">
+                      VALIDATIONS
                     </Link>
                   </NavItem>
                 </>
               )}
+
+              <NavItem>
+                <Link to="/assess" className="cat-nav-link">
+                  ASSESSMENTS
+                </Link>
+              </NavItem>
             </Nav>
 
             {authenticated && userProfile?.user_type === "Admin" && (
@@ -128,7 +112,7 @@ function Header() {
                   id="admin_nav"
                   title={
                     <span className="text-dark">
-                      <FaShieldAlt /> ADMIN
+                      <FaShieldAlt /> ADMIN MODE
                     </span>
                   }
                   className="cat-nav-item"

--- a/src/pages/assessments/Assessments.tsx
+++ b/src/pages/assessments/Assessments.tsx
@@ -8,6 +8,8 @@ import ownersImg from "@/assets/thumb_user.png";
 import { useGetActors } from "@/api";
 import { Col, Row } from "react-bootstrap";
 import { ActorCard } from "./components/ActorCard";
+import { AuthContext } from "@/auth";
+import { useContext } from "react";
 
 interface CardProps {
   id: number;
@@ -25,6 +27,8 @@ function Assessments() {
     page: 1,
     sortBy: "asc",
   });
+
+  const { authenticated } = useContext(AuthContext)!;
 
   const cardProps: CardProps[] = [];
 
@@ -65,17 +69,22 @@ function Assessments() {
               <FaCheckCircle className="me-1" /> assessments
             </h3>
           </div>
-          <div className="d-flex justify-content-end my-2">
-            <Link
-              to={`/assessments/create`}
-              className="btn btn-light border-black mx-3"
-            >
-              <FaPlus /> Create New
-            </Link>
-            <Link to="/assessments" className="btn btn-light border-black mx-3">
-              <FaList /> View Your Assessments
-            </Link>
-          </div>
+          {authenticated && (
+            <div className="d-flex justify-content-end my-2">
+              <Link
+                to={`/assessments/create`}
+                className="btn btn-light border-black mx-3"
+              >
+                <FaPlus /> Create New
+              </Link>
+              <Link
+                to="/assessments"
+                className="btn btn-light border-black mx-3"
+              >
+                <FaList /> View Your Assessments
+              </Link>
+            </div>
+          )}
         </div>
       </>
       <>


### PR DESCRIPTION
# 🎯 Goal
Simplify the navigation menu by removing unused placeholder items

# 🏗️ Implementation
- [x] Rearrange menu to display the following prominent items:
  - `PROFILE`, `VALIDATIONS`, `ASSESSMENTS` when user is logged in
  - `ASSESSMENTS` when user is logged out
 - [x] Fix main `ASSESSMENTS` view to display `Create new` or `View your Assessment` buttons **only** when user is logged in
 - [x] When user logs as admin, an `ADMIN MODE` menu is displayed at the right side of the bar to signify a special place for administrative operations