### PR TITLE
CAT-302 Improve error notifications in assessment create form

### DIFF
--- a/src/api/services/assessments.ts
+++ b/src/api/services/assessments.ts
@@ -188,8 +188,7 @@ export function useGetObjects({
   } else {
     url = url.concat(`/objects?size=${size}&page=${page}`);
   }
-  console.log(url);
-  console.log(actorId);
+
   return useQuery({
     queryKey: ["objects", { size, page, assessmentTypeId, actorId }],
     queryFn: async () => {

--- a/src/pages/assessments/components/AssessmentInfo.tsx
+++ b/src/pages/assessments/components/AssessmentInfo.tsx
@@ -12,7 +12,15 @@ import {
 } from "react-bootstrap";
 import { AssessmentSubject, UserProfile, AssessmentActor } from "@/types";
 import { AssessmentSelectSubject } from "./AssessmentSelectSubject";
-import { FaCog, FaInfo, FaLock, FaUserAlt, FaInfoCircle } from "react-icons/fa";
+import {
+  FaCog,
+  FaInfo,
+  FaLock,
+  FaUserAlt,
+  FaInfoCircle,
+  FaExclamationCircle,
+} from "react-icons/fa";
+import { useState, useEffect } from "react";
 
 interface AssessmentInfoProps {
   id?: string;
@@ -24,25 +32,53 @@ interface AssessmentInfoProps {
   subject: AssessmentSubject;
   published: boolean;
   profile?: UserProfile;
+  reqFields: string[];
   onNameChange(name: string): void;
   onSubjectChange(subject: AssessmentSubject): void;
   onPublishedChange(published: boolean): void;
 }
 
 export const AssessmentInfo = (props: AssessmentInfoProps) => {
+  const [accKeys, setAccKeys] = useState<string[]>([]);
+
+  const toggleAccKey = (name: string) => {
+    if (accKeys.includes(name)) {
+      setAccKeys(accKeys.filter((item) => item !== name));
+    } else {
+      setAccKeys([...accKeys, name]);
+    }
+  };
+
+  // call use effect to react to required field changes
+  useEffect(() => {
+    setAccKeys((keys) => {
+      const subjectErrors = ["subject_name", "subject_id", "subject_type"].some(
+        (item) => props.reqFields.includes(item),
+      );
+      const newKeys: string[] = [];
+      if (subjectErrors && !keys.includes("acc-3")) newKeys.push("acc-3");
+      if (props.reqFields.includes("name") && !keys.includes("acc-1"))
+        newKeys.push("acc-1");
+      return [...keys, ...newKeys];
+    });
+  }, [props.reqFields]);
+
   return (
-    <Accordion defaultActiveKey="acc-1">
+    <Accordion defaultActiveKey={["acc-1"]} activeKey={accKeys} alwaysOpen>
       <Accordion.Item eventKey="acc-1" id="accordion_general">
-        <Accordion.Header>
+        <Accordion.Header onClick={() => toggleAccKey("acc-1")}>
           <span>
             <FaInfo color="blue" className="me-2" />
             General Info
+            {props.reqFields.includes("name") && (
+              <FaExclamationCircle className="ms-2 text-danger rounded-circle bg-white" />
+            )}
           </span>
         </Accordion.Header>
         <Accordion.Body>
           <Row>
             <Col>
-              <InputGroup className="mb-3">
+              <InputGroup className="mb-1">
                 <OverlayTrigger
                   key="top"
                   placement="top"
@@ -65,14 +101,22 @@ export const AssessmentInfo = (props: AssessmentInfoProps) => {
                     props.onNameChange(e.target.value);
                   }}
                   aria-describedby="label-info-name"
+                  className={
+                    props.reqFields.includes("name") ? "is-invalid" : ""
+                  }
                 />
               </InputGroup>
+              {props.reqFields.includes("name") && (
+                <p className="text-danger text-end">
+                  A unique name for the assessment is required
+                </p>
+              )}
             </Col>
           </Row>
 
           <Row>
             <Col>
-              <InputGroup className="mb-3">
+              <InputGroup className="mt-2">
                 <OverlayTrigger
                   key="top"
                   placement="top"
@@ -99,7 +143,7 @@ export const AssessmentInfo = (props: AssessmentInfoProps) => {
         </Accordion.Body>
       </Accordion.Item>
       <Accordion.Item eventKey="acc-2" id="accordion_submitter">
-        <Accordion.Header>
+        <Accordion.Header onClick={() => toggleAccKey("acc-2")}>
           <span>
             <FaUserAlt color="green" className="me-2" />
             Submitter
@@ -201,10 +245,15 @@ export const AssessmentInfo = (props: AssessmentInfoProps) => {
         </Accordion.Body>
       </Accordion.Item>
       <Accordion.Item eventKey="acc-3" id="accordion_subject">
-        <Accordion.Header>
+        <Accordion.Header onClick={() => toggleAccKey("acc-3")}>
           <span>
             <FaCog color="orange" className="me-2" />
             Subject of assessment <em>(Object, Entity or Service)</em>
+            {["subject_name", "subject_id", "subject_type"].some((item) =>
+              props.reqFields.includes(item),
+            ) && (
+              <FaExclamationCircle className="ms-2 text-danger rounded-circle bg-white" />
+            )}
           </span>
         </Accordion.Header>
         <Accordion.Body>
@@ -212,12 +261,13 @@ export const AssessmentInfo = (props: AssessmentInfoProps) => {
             <AssessmentSelectSubject
               subject={props.subject}
               onSubjectChange={props.onSubjectChange}
+              reqFields={props.reqFields}
             />
           </Row>
         </Accordion.Body>
       </Accordion.Item>
       <Accordion.Item eventKey="acc-4" id="accordion_license">
-        <Accordion.Header>
+        <Accordion.Header onClick={() => toggleAccKey("acc-4")}>
           <span>
             <FaLock color="crimson" className="me-2" />
             Rights, Licencing or Re-use

--- a/src/pages/assessments/components/AssessmentSelectSubject.tsx
+++ b/src/pages/assessments/components/AssessmentSelectSubject.tsx
@@ -18,6 +18,7 @@ import { useGetSubjects } from "@/api/services/subjects";
 type AssessmentSelectSubjectProps = {
   subject: AssessmentSubject;
   onSubjectChange(subject: AssessmentSubject): void;
+  reqFields: string[];
 };
 
 export const AssessmentSelectSubject = (
@@ -110,7 +111,7 @@ export const AssessmentSelectSubject = (
       </Row>
       <Row>
         <Row>
-          <InputGroup className="mb-3">
+          <InputGroup className="mb-1">
             <OverlayTrigger
               key="top"
               placement="top"
@@ -137,11 +138,17 @@ export const AssessmentSelectSubject = (
                 );
               }}
               aria-describedby="label-info-subject-id"
+              className={
+                props.reqFields.includes("subject_id") ? "is-invalid" : ""
+              }
             />
           </InputGroup>
+          {props.reqFields.includes("subject_id") && (
+            <p className="text-danger text-end">Subject id required</p>
+          )}
         </Row>
         <Row>
-          <InputGroup className="mb-3">
+          <InputGroup className="mb-1 mt-2">
             <OverlayTrigger
               key="top"
               placement="top"
@@ -166,11 +173,17 @@ export const AssessmentSelectSubject = (
                 );
               }}
               aria-describedby="label-info-subject-name"
+              className={
+                props.reqFields.includes("subject_name") ? "is-invalid" : ""
+              }
             />
           </InputGroup>
+          {props.reqFields.includes("subject_name") && (
+            <p className="text-danger text-end">The subject name is required</p>
+          )}
         </Row>
         <Row>
-          <InputGroup className="mb-3">
+          <InputGroup className="mb-1 mt-2">
             <OverlayTrigger
               key="top"
               placement="top"
@@ -197,8 +210,14 @@ export const AssessmentSelectSubject = (
                 );
               }}
               aria-describedby="label-info-subject-type"
+              className={
+                props.reqFields.includes("subject_type") ? "is-invalid" : ""
+              }
             />
           </InputGroup>
+          {props.reqFields.includes("subject_type") && (
+            <p className="text-danger text-end">The subject type is required</p>
+          )}
         </Row>
       </Row>
     </>

--- a/src/pages/assessments/components/CriterionProgress.tsx
+++ b/src/pages/assessments/components/CriterionProgress.tsx
@@ -5,8 +5,6 @@ export function CriterionProgress({ metric }: { metric: Metric }) {
   let filled = 0;
   const testMarkers = [];
 
-  console.log(tests);
-
   for (const item of tests) {
     if (item.result !== null) {
       if (item.result === 0) {

--- a/src/pages/validations/RequestValidation.tsx
+++ b/src/pages/validations/RequestValidation.tsx
@@ -203,8 +203,6 @@ function RequestValidation() {
     </>
   );
 
-  console.log(watchOrgSource);
-
   return (
     <div className="mt-4">
       <h3 className="cat-view-heading">


### PR DESCRIPTION
Solves #140

- [x] Add method to inspect which of the required fields are empty
- [x] Add extra state and methods to control interactivity of the Assessment Edit Info Accordeon component
- [x] Add error styling and interactive messages in required fields
- [x] When user clicks Create / Save check if any of the required fields are empty. If yes display the error messages on the form and open expand the corresponding accordeon items