### PR TITLE
CAT-343 redesign admin users view

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -12,6 +12,10 @@
   border-bottom: solid 2px #919191;
 }
 
+.cat-cursor-pointer {
+  cursor: pointer;
+}
+
 .cat-list-bullet-image {
   list-style: url("/fclogo.png");
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,7 +11,7 @@ import {
   Profile,
   RequestValidation,
   ValidationList,
-  Users,
+  // Users,
   ProfileUpdate,
   ValidationDetails,
 } from "@/pages";
@@ -25,6 +25,7 @@ import { Toaster } from "react-hot-toast";
 import Subjects from "./pages/Subjects";
 import About from "./pages/About";
 import { AssessmentEditMode } from "./types";
+import AdminUsers from "./pages/admin/AdminUsers";
 
 const queryClient = new QueryClient();
 
@@ -128,7 +129,7 @@ function App() {
                     <Route index element={<ProfileUpdate />} />
                   </Route>
                   <Route path="/admin/users" element={<ProtectedRoute />}>
-                    <Route index element={<Users />} />
+                    <Route index element={<AdminUsers />} />
                   </Route>
                   <Route
                     path="/validations/request"

--- a/src/api/services/users.ts
+++ b/src/api/services/users.ts
@@ -1,7 +1,7 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { AxiosError } from "axios";
 import { APIClient } from "@/api";
-import { ApiOptions, UserAccess } from "@/types";
+import { ApiOptions, ApiUsers, UserAccess } from "@/types";
 import { UserResponse, UserListResponse } from "@/types";
 import { handleBackendError } from "@/utils";
 
@@ -31,8 +31,36 @@ export const useGetAdminUsers = ({
     queryKey: ["users", { size, page, sortBy }],
     queryFn: async () => {
       const response = await APIClient(token).get<UserListResponse>(
-        `/admin/users?size=${size}&page=${page}&sortby=${sortBy}`,
+        `/admin/users?size=${size}&page=${page}&sort=${sortBy}`,
       );
+      return response.data;
+    },
+    onError: (error: AxiosError) => {
+      return handleBackendError(error);
+    },
+    enabled: !!token && isRegistered,
+  });
+
+export const useAdminGetUsers = ({
+  size,
+  page,
+  sortBy,
+  sortOrder,
+  token,
+  isRegistered,
+  search,
+  type,
+  status,
+}: ApiUsers) =>
+  useQuery({
+    queryKey: ["users"],
+    queryFn: async () => {
+      let url = `/admin/users?size=${size}&page=${page}&sort=${sortBy}&order=${sortOrder}`;
+      search ? (url = `${url}&search=${search}`) : null;
+      type ? (url = `${url}&type=${type}`) : null;
+      status ? (url = `${url}&status=${status}`) : null;
+
+      const response = await APIClient(token).get<UserListResponse>(url);
       return response.data;
     },
     onError: (error: AxiosError) => {
@@ -67,7 +95,7 @@ export const useUserRegister = () =>
     },
   );
 
-export function useBanUser(token: string) {
+export function useDeleteUser(token: string) {
   const queryClient = useQueryClient();
   return useMutation(
     async (data: UserAccess) => {
@@ -89,7 +117,7 @@ export function useBanUser(token: string) {
   );
 }
 
-export function useUnbanUser(token: string) {
+export function useRestoreUser(token: string) {
   const queryClient = useQueryClient();
   return useMutation(
     async (data: UserAccess) => {

--- a/src/pages/Users.tsx
+++ b/src/pages/Users.tsx
@@ -1,6 +1,6 @@
 import { useContext, useEffect, useMemo, useRef, useState } from "react";
 import { ColumnDef } from "@tanstack/react-table";
-import { useGetAdminUsers, useUnbanUser, useBanUser } from "@/api";
+import { useGetAdminUsers, useRestoreUser, useDeleteUser } from "@/api";
 import { CustomTable } from "@/components";
 import { FaLock, FaLockOpen, FaUnlock, FaUsers } from "react-icons/fa";
 import { AlertInfo, UserProfile } from "@/types";
@@ -143,8 +143,8 @@ function Users() {
   const { keycloak } = useContext(AuthContext)!;
 
   // hooks for handling subjects in through the backend
-  const mutationBanUser = useBanUser(keycloak?.token || "");
-  const mutationUnbanUser = useUnbanUser(keycloak?.token || "");
+  const mutationBanUser = useDeleteUser(keycloak?.token || "");
+  const mutationUnbanUser = useRestoreUser(keycloak?.token || "");
 
   const handleUnban = (id: string, reason: string) => {
     const promise = mutationUnbanUser

--- a/src/pages/admin/AdminUsers.tsx
+++ b/src/pages/admin/AdminUsers.tsx
@@ -1,0 +1,604 @@
+import { useAdminGetUsers, useDeleteUser, useRestoreUser } from "@/api";
+import { AuthContext } from "@/auth";
+import { AlertInfo, UserProfile } from "@/types";
+import { useContext, useEffect, useRef, useState } from "react";
+import {
+  Alert,
+  Button,
+  Col,
+  Form,
+  Modal,
+  OverlayTrigger,
+  Row,
+  Table,
+  Tooltip,
+} from "react-bootstrap";
+import {
+  FaArrowDown,
+  FaArrowLeft,
+  FaArrowRight,
+  FaArrowUp,
+  FaArrowsAltV,
+  FaBars,
+  FaCheckCircle,
+  FaExclamationTriangle,
+  FaPencilAlt,
+  FaShieldAlt,
+  FaTrashAlt,
+  FaTrashRestoreAlt,
+  FaUser,
+  FaUserCircle,
+} from "react-icons/fa";
+import toast from "react-hot-toast";
+
+type UserState = {
+  sortOrder: string;
+  sortBy: string;
+  type: string;
+  page: number;
+  size: number;
+  search: string;
+  status: string;
+};
+
+// Modes under which UserModal operates
+enum UserModalMode {
+  Delete,
+  Restore,
+}
+
+// Basic configuration for subject modal
+type UserModalBasicConfig = {
+  mode: UserModalMode;
+  id: string;
+  show: boolean;
+};
+
+// Props for subject modal
+type UserModalProps = UserModalBasicConfig & {
+  onHide: () => void;
+  handleRestore: (id: string, reason: string) => void;
+  handleDelete: (id: string, reason: string) => void;
+};
+
+// Creates a modal with a small form to create/edit a subject
+export function UserModal(props: UserModalProps) {
+  const [reason, setReason] = useState<string>("");
+  const [error, setError] = useState<boolean>(false);
+
+  useEffect(() => {
+    if (props.show) {
+      setReason("");
+      setError(false);
+    }
+  }, [props.show]);
+
+  return (
+    <Modal
+      {...props}
+      size="lg"
+      aria-labelledby="contained-modal-title-vcenter"
+      centered
+    >
+      <Modal.Header
+        className={
+          props.mode == UserModalMode.Delete
+            ? "bg-danger text-white"
+            : "bg-success text-white"
+        }
+        closeButton
+      >
+        <Modal.Title id="contained-modal-title-vcenter">
+          {props.mode == UserModalMode.Delete && (
+            <span>
+              <FaTrashAlt className="me-2" /> Delete user
+            </span>
+          )}
+          {props.mode == UserModalMode.Restore && (
+            <span>
+              <FaTrashRestoreAlt className="me-2" /> Restore user
+            </span>
+          )}
+        </Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        <Form>
+          <p>
+            Are you sure you want to delete user with id:{" "}
+            <strong>{props.id}</strong> ?
+          </p>
+          <Form.Group className="mb-3" controlId="input-delete-user-reason">
+            <Form.Label>
+              <strong>Reason (*)</strong>
+            </Form.Label>
+            <Form.Control
+              className={error ? "is-invalid" : ""}
+              as="textarea"
+              rows={2}
+              value={reason}
+              onChange={(e) => setReason(e.target.value)}
+            />
+            {error && <p className="text-danger">You must specify a reason</p>}
+          </Form.Group>
+        </Form>
+      </Modal.Body>
+      <Modal.Footer className="d-flex justify-content-between">
+        <Button className="btn-secondary" onClick={() => props.onHide()}>
+          Cancel
+        </Button>
+        {props.mode == UserModalMode.Delete && (
+          <Button
+            className="btn-danger"
+            onClick={() => {
+              if (reason === "") {
+                setError(true);
+              } else {
+                props.handleDelete(props.id, reason);
+              }
+            }}
+          >
+            Delete
+          </Button>
+        )}
+        {props.mode == UserModalMode.Restore && (
+          <Button
+            className="btn-success"
+            onClick={() => {
+              {
+                if (reason === "") {
+                  setError(true);
+                } else {
+                  props.handleRestore(props.id, reason);
+                }
+              }
+            }}
+          >
+            Restore
+          </Button>
+        )}
+      </Modal.Footer>
+    </Modal>
+  );
+}
+
+const idToColor = (id: string) => {
+  // generate hash from id
+  const hash = Array.from(id).reduce(
+    (acc, char) => acc + char.charCodeAt(0),
+    0,
+  );
+
+  // define color palette
+  const palette = [
+    "#ea7286",
+    "#eab281",
+    "#e3e19f",
+    "#a9c484",
+    "#5d937b",
+    "#58525a",
+    "#a07ca7",
+    "#f4a4bf",
+    "#f5d1b6",
+    "#eeede3",
+    "#d6cec2",
+    "#a2a6a9",
+    "#777f8f",
+    "#a3b2d2",
+    "#bfded8",
+    "#bf796d",
+  ];
+
+  // select the color
+  return palette[hash % palette.length];
+};
+
+// trim the field if it is too big
+const trimField = (value: string, length: number) => {
+  if (value.length > length) {
+    return value.slice(0, length) + "...";
+  }
+  return value;
+};
+
+// create an up/down arrow to designate sorting in a column
+const SortMarker = (field: string, sortField: string, sortOrder: string) => {
+  if (field === sortField) {
+    if (sortOrder === "DESC") return <FaArrowUp />;
+    else if (sortOrder === "ASC") return <FaArrowDown />;
+  }
+  return <FaArrowsAltV className="text-secondary opacity-50" />;
+};
+
+// create a user status badge for deleted and active
+const UserStatusBadge = (banned: boolean) => {
+  if (banned)
+    return (
+      <small className="badge bg-light text-danger border-danger">
+        Deleted
+      </small>
+    );
+  return <span className="badge bg-light text-success border">Active</span>;
+};
+
+// create a user type badge for identified, admin and verified
+const UserTypeBadge = (userType: string) => {
+  const userTypeLower = userType.toLowerCase();
+  if (userTypeLower === "identified") {
+    return <span className="badge bg-secondary">Identified</span>;
+  } else if (userTypeLower === "admin") {
+    return (
+      <span className="badge bg-primary">
+        <FaShieldAlt /> Admin
+      </span>
+    );
+  } else if (userTypeLower === "validated") {
+    return (
+      <span className="badge bg-success">
+        <FaCheckCircle /> Validated
+      </span>
+    );
+  } else {
+    return null;
+  }
+};
+
+// create the tooltips
+const tooltipDelete = <Tooltip id="tip-delete">Delete User</Tooltip>;
+const tooltipRestore = <Tooltip id="tip-restore">Restore User</Tooltip>;
+const tooltipEdit = <Tooltip id="tip-restore">Edit User Details</Tooltip>;
+const tooltipView = <Tooltip id="tip-restore">View User Details</Tooltip>;
+
+// the main component that lists the admin users in a table
+export default function AdminUsers() {
+  // toast alert reference used in notification messaging
+  const toastAlert = useRef<AlertInfo>({
+    message: "",
+  });
+
+  const { keycloak, registered } = useContext(AuthContext)!;
+
+  const [userModalConfig, setUserModalConfig] = useState<UserModalBasicConfig>({
+    mode: UserModalMode.Delete,
+    show: false,
+    id: "",
+  });
+
+  // hooks for handling subjects in through the backend
+  const mutationBanUser = useDeleteUser(keycloak?.token || "");
+  const mutationUnbanUser = useRestoreUser(keycloak?.token || "");
+
+  const handleRestore = (id: string, reason: string) => {
+    const promise = mutationUnbanUser
+      .mutateAsync({ user_id: id, reason: reason })
+      .catch((err) => {
+        toastAlert.current = {
+          message: "Error during user restore.",
+        };
+        throw err;
+      })
+      .then(() => {
+        toastAlert.current = {
+          message: "User succesfully restored",
+        };
+        // close the modal
+        setUserModalConfig((prevConfig) => ({ ...prevConfig, show: false }));
+      });
+    toast.promise(promise, {
+      loading: "Restoring User...",
+      success: () => `${toastAlert.current.message}`,
+      error: () => `${toastAlert.current.message}`,
+    });
+  };
+
+  const handleDelete = (id: string, reason: string) => {
+    const promise = mutationBanUser
+      .mutateAsync({ user_id: id, reason: reason })
+      .catch((err) => {
+        toastAlert.current = {
+          message: "Error during user ban.",
+        };
+        throw err;
+      })
+      .then(() => {
+        toastAlert.current = {
+          message: "Subject succesfully banned.",
+        };
+        // close the modal
+        setUserModalConfig((prevConfig) => ({ ...prevConfig, show: false }));
+      });
+    toast.promise(promise, {
+      loading: "Banning...",
+      success: () => `${toastAlert.current.message}`,
+      error: () => `${toastAlert.current.message}`,
+    });
+  };
+
+  const [opts, setOpts] = useState<UserState>({
+    sortBy: "name",
+    sortOrder: "ASC",
+    type: "",
+    page: 1,
+    size: 20,
+    search: "",
+    status: "",
+  });
+
+  // handler for changing page size
+  const handleChangePageSize = (evt: { target: { value: string } }) => {
+    setOpts({ ...opts, page: 1, size: parseInt(evt.target.value) });
+  };
+
+  // handler for clicking to sort
+  const handleSortClick = (field: string) => {
+    if (field === opts.sortBy) {
+      if (opts.sortOrder === "ASC") {
+        setOpts({ ...opts, sortOrder: "DESC" });
+      } else {
+        setOpts({ ...opts, sortOrder: "ASC" });
+      }
+    } else {
+      setOpts({ ...opts, sortOrder: "ASC", sortBy: field });
+    }
+  };
+
+  // data get admin users
+  const { isLoading, data, refetch } = useAdminGetUsers({
+    size: opts.size,
+    page: opts.page,
+    sortBy: opts.sortBy,
+    sortOrder: opts.sortOrder,
+    token: keycloak?.token || "",
+    isRegistered: registered,
+    search: opts.search,
+    type: opts.type,
+    status: opts.status,
+  });
+
+  // refetch users when parameters change
+  useEffect(() => {
+    refetch();
+  }, [opts, refetch]);
+
+  // get the user data to create the table
+  const users: UserProfile[] = data ? data?.content : [];
+
+  return (
+    <div className="mb-4">
+      <UserModal
+        {...userModalConfig}
+        onHide={() => setUserModalConfig({ ...userModalConfig, show: false })}
+        handleDelete={handleDelete}
+        handleRestore={handleRestore}
+      />
+      <h4>
+        <FaUser /> <strong className="align-middle">Users</strong>
+      </h4>
+      <Form className="mt-2 mb-2">
+        <Row>
+          <Col>
+            <Form.Select
+              onChange={(e) => {
+                setOpts({ ...opts, type: e.target.value });
+              }}
+              value={opts.type}
+            >
+              <option value="">Select type...</option>
+              <option>Identified</option>
+              <option>Validated</option>
+              <option>Admin</option>
+            </Form.Select>
+          </Col>
+          <Col>
+            <Form.Select
+              onChange={(e) => {
+                setOpts({ ...opts, status: e.target.value });
+              }}
+              value={opts.status}
+            >
+              <option value="">Select status...</option>
+              <option value="active">Active</option>
+              <option value="deleted">Deleted</option>
+            </Form.Select>
+          </Col>
+          <Col xs={6}>
+            <div className="d-flex justify-content-center">
+              <Form.Control
+                placeholder="Search ..."
+                onChange={(e) => {
+                  setOpts({ ...opts, search: e.target.value });
+                }}
+                value={opts.search}
+              />
+              <Button
+                onClick={() => {
+                  setOpts({ ...opts, search: "", type: "", status: "" });
+                }}
+                className="ms-4"
+              >
+                Clear
+              </Button>
+            </div>
+          </Col>
+        </Row>
+      </Form>
+
+      <code className="text-black">
+        <Table hover>
+          <thead>
+            <tr className="table-light">
+              <th>
+                <span
+                  onClick={() => handleSortClick("name")}
+                  className="cat-cursor-pointer"
+                >
+                  Name {SortMarker("name", opts.sortBy, opts.sortOrder)}
+                </span>
+              </th>
+              <th>
+                <span
+                  onClick={() => handleSortClick("email")}
+                  className="cat-cursor-pointer"
+                >
+                  Email {SortMarker("email", opts.sortBy, opts.sortOrder)}
+                </span>
+              </th>
+              <th>
+                <span>Registered</span>
+              </th>
+              <th>
+                <span>User Type</span>
+              </th>
+              <th>
+                <span>Status</span>
+              </th>
+              <th></th>
+            </tr>
+          </thead>
+          {users.length > 0 ? (
+            <tbody>
+              {users.map((item) => {
+                return (
+                  <tr key={item.id}>
+                    <td className="align-middle">
+                      <div className="d-flex  justify-content-start">
+                        <div>
+                          <FaUserCircle
+                            size={"3rem"}
+                            style={{ color: idToColor(item.id) }}
+                          />
+                        </div>
+                        <div className="ms-2 d-flex flex-column justify-content-between">
+                          <div>{item.name || <br />}</div>
+                          <div>
+                            <span
+                              style={{ fontSize: "0.64rem" }}
+                              className="text-muted"
+                            >
+                              id: {trimField(item.id, 20)}
+                            </span>
+                          </div>
+                        </div>
+                      </div>
+                    </td>
+                    <td className="align-middle">{item.email}</td>
+                    <td className="align-middle">
+                      {item.registered_on.split("T")[0]}
+                    </td>
+                    <td className="align-middle">
+                      {UserTypeBadge(item.user_type)}
+                    </td>
+                    <td className="align-middle">
+                      {UserStatusBadge(item.banned)}
+                    </td>
+                    <td>
+                      <OverlayTrigger placement="top" overlay={tooltipView}>
+                        <Button className="btn-light">
+                          <FaBars />
+                        </Button>
+                      </OverlayTrigger>
+                      <OverlayTrigger placement="top" overlay={tooltipEdit}>
+                        <Button className="btn-light">
+                          <FaPencilAlt />
+                        </Button>
+                      </OverlayTrigger>
+                      {item.banned ? (
+                        <OverlayTrigger
+                          placement="top"
+                          overlay={tooltipRestore}
+                        >
+                          <Button
+                            className="btn-light"
+                            onClick={() => {
+                              setUserModalConfig({
+                                id: item.id,
+                                mode: UserModalMode.Restore,
+                                show: true,
+                              });
+                            }}
+                          >
+                            <FaTrashRestoreAlt />
+                          </Button>
+                        </OverlayTrigger>
+                      ) : (
+                        <OverlayTrigger placement="top" overlay={tooltipDelete}>
+                          <Button
+                            className="btn-light"
+                            onClick={() => {
+                              setUserModalConfig({
+                                id: item.id,
+                                mode: UserModalMode.Delete,
+                                show: true,
+                              });
+                            }}
+                          >
+                            <FaTrashAlt />
+                          </Button>
+                        </OverlayTrigger>
+                      )}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          ) : null}
+        </Table>
+        {!isLoading && users.length === 0 && (
+          <Alert variant="warning" className="text-center mx-auto">
+            <h3>
+              <FaExclamationTriangle />
+            </h3>
+            <h5>No data found...</h5>
+          </Alert>
+        )}
+        <div className="d-flex justify-content-end">
+          <div>
+            <span className="mx-1">rows per page: </span>
+            <select
+              name="per-page"
+              value={opts.size.toString() || "20"}
+              id="per-page"
+              onChange={handleChangePageSize}
+            >
+              <option value="5">5</option>
+              <option value="10">10</option>
+              <option value="15">15</option>
+              <option value="20">20</option>
+            </select>
+          </div>
+
+          {data && data.number_of_page && data.total_pages && (
+            <div className="ms-4">
+              <span>
+                {(data.number_of_page - 1) * opts.size + 1} -{" "}
+                {(data.number_of_page - 1) * opts.size + data.size_of_page} of{" "}
+                {data.total_elements}
+              </span>
+              <span
+                onClick={() => {
+                  setOpts({ ...opts, page: opts.page - 1 });
+                }}
+                className={`ms-4 btn py-0 btn-light btn-small ${
+                  opts.page === 1 ? "disabled text-muted" : null
+                }`}
+              >
+                <FaArrowLeft />
+              </span>
+              <span
+                onClick={() => {
+                  setOpts({ ...opts, page: opts.page + 1 });
+                }}
+                className={`btn py-0 btn-light btn-small" ${
+                  data?.total_pages > data?.number_of_page
+                    ? null
+                    : "disabled text-muted"
+                }`}
+              >
+                <FaArrowRight />
+              </span>
+            </div>
+          )}
+        </div>
+      </code>
+    </div>
+  );
+}

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -44,6 +44,7 @@ export interface ApiPaginationOptions {
   size?: number;
   page?: number;
   sortBy?: string;
+  sortOrder?: string;
 }
 
 export interface ApiPublicAssessmentOptions {
@@ -103,4 +104,10 @@ export type Subject = {
 export type UserAccess = {
   user_id: string;
   reason?: string;
+};
+
+export type ApiUsers = ApiOptions & {
+  type: string;
+  search: string;
+  status: string;
 };


### PR DESCRIPTION
Redesign Admin: Users view

- [x] Add new backend call to get and filter users when admin
- [x] Create a simpler table with sorting capability in specific columns
- [x] Add inline filter/search form on top of table heading
- [x] Add pagination 
- [x] Add user id trimming
- [x] Add date formatting in register column
- [x] Add delete button with tooltip
- [x] Add user icon coloring based on id parsing 