### PR TITLE
CAT-380 Add iframe

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,6 +27,7 @@ import About from "./pages/About";
 import { AssessmentEditMode } from "./types";
 import AdminUsers from "./pages/admin/AdminUsers";
 import AdminValidations from "./pages/admin/AdminValidations";
+import Explore from "./pages/Explore";
 
 const queryClient = new QueryClient();
 
@@ -69,6 +70,7 @@ function App() {
                 <Routes>
                   <Route path="/" element={<Home />} />
                   <Route path="/about" element={<About />} />
+                  <Route path="/explore" element={<Explore />} />
                   <Route
                     path="/assessments/create/:valID"
                     element={<ProtectedRoute />}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -104,6 +104,11 @@ function Header() {
                   ASSESSMENTS
                 </Link>
               </NavItem>
+              <NavItem>
+                <Link to="/explore" className="cat-nav-link">
+                  EXPLORE
+                </Link>
+              </NavItem>
             </Nav>
 
             {authenticated && userProfile?.user_type === "Admin" && (

--- a/src/config.json
+++ b/src/config.json
@@ -2,5 +2,8 @@
   "api": {
     "base_url": "http://localhost:8080",
     "version": "v1"
+  },
+  "embedded_views": {
+    "explore_view": "https://rdy.gr"
   }
 }

--- a/src/pages/Explore.tsx
+++ b/src/pages/Explore.tsx
@@ -1,0 +1,37 @@
+import { useEffect, useRef } from "react";
+import config from "@/config.json";
+
+function Explore() {
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+  // const [iframeHeight, setIframeHeight] = useState('0px');
+
+  useEffect(() => {
+    const handleResize = (event: MessageEvent) => {
+      if (event.origin === config.embedded_views.explore_view) {
+        // Replace with the actual domain of pageB
+        console.log("received size from child:", event.data);
+        if (iframeRef.current)
+          iframeRef.current.style.height = event.data + "px";
+      }
+    };
+
+    window.addEventListener("message", handleResize);
+
+    // Cleanup function to remove the event listener
+    return () => {
+      window.removeEventListener("message", handleResize);
+    };
+  }, []);
+
+  return (
+    <div>
+      <iframe
+        src={config.embedded_views.explore_view}
+        style={{ width: "100%", height: "800px" }}
+        ref={iframeRef}
+      ></iframe>
+    </div>
+  );
+}
+
+export default Explore;


### PR DESCRIPTION
Add a new 'Explore' view that hosts external results through an iframe (we can change 'Explore' name to whatever we want)

External view is configured through config.json