### PR TITLE
CAT-380 Update iframe view name to Pid Selection. Make view visible (…

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,7 +27,7 @@ import About from "./pages/About";
 import { AssessmentEditMode } from "./types";
 import AdminUsers from "./pages/admin/AdminUsers";
 import AdminValidations from "./pages/admin/AdminValidations";
-import Explore from "./pages/Explore";
+import PidSelection from "./pages/PidSelection";
 
 const queryClient = new QueryClient();
 
@@ -70,7 +70,7 @@ function App() {
                 <Routes>
                   <Route path="/" element={<Home />} />
                   <Route path="/about" element={<About />} />
-                  <Route path="/explore" element={<Explore />} />
+                  <Route path="/pid-selection" element={<PidSelection />} />
                   <Route
                     path="/assessments/create/:valID"
                     element={<ProtectedRoute />}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -105,8 +105,8 @@ function Header() {
                 </Link>
               </NavItem>
               <NavItem>
-                <Link to="/explore" className="cat-nav-link">
-                  EXPLORE
+                <Link to="/pid-selection" className="cat-nav-link">
+                  PID SELECTION
                 </Link>
               </NavItem>
             </Nav>

--- a/src/config.json
+++ b/src/config.json
@@ -4,6 +4,6 @@
     "version": "v1"
   },
   "embedded_views": {
-    "explore_view": "https://rdy.gr"
+    "pid_selection_view": ""
   }
 }

--- a/src/pages/PidSelection.tsx
+++ b/src/pages/PidSelection.tsx
@@ -1,13 +1,13 @@
 import { useEffect, useRef } from "react";
 import config from "@/config.json";
 
-function Explore() {
+function PidSelection() {
   const iframeRef = useRef<HTMLIFrameElement>(null);
   // const [iframeHeight, setIframeHeight] = useState('0px');
 
   useEffect(() => {
     const handleResize = (event: MessageEvent) => {
-      if (event.origin === config.embedded_views.explore_view) {
+      if (event.origin === config?.embedded_views?.pid_selection_view) {
         // Replace with the actual domain of pageB
         console.log("received size from child:", event.data);
         if (iframeRef.current)
@@ -26,7 +26,7 @@ function Explore() {
   return (
     <div>
       <iframe
-        src={config.embedded_views.explore_view}
+        src={config?.embedded_views?.pid_selection_view}
         style={{ width: "100%", height: "800px" }}
         ref={iframeRef}
       ></iframe>
@@ -34,4 +34,4 @@ function Explore() {
   );
 }
 
-export default Explore;
+export default PidSelection;


### PR DESCRIPTION
…empty content) when config params are missing

Update Header nav item and view name to `PID SELECTION` (component name also and route)
Make View work if config options are missing. Displays empty content instead of crashing

