### PR TITLE
CAT-390 make Public Assessment download button work without login

### DIFF
--- a/src/api/services/assessments.ts
+++ b/src/api/services/assessments.ts
@@ -122,27 +122,38 @@ export function useGetPublicAssessments({
   });
 }
 
+// works for public and private assessments
 export function useGetAssessment({
   id,
+  isPublic,
   token,
   isRegistered,
 }: {
   id: string;
+  isPublic: boolean;
   token?: string;
   isRegistered?: boolean;
 }) {
   return useQuery({
     queryKey: ["assessment", id],
     queryFn: async () => {
-      const response = await APIClient(token).get<AssessmentDetailsResponse>(
-        `/assessments/${id}`,
-      );
+      let url: string;
+      if (isPublic) {
+        url = `/assessments/public/${id}`;
+      } else {
+        url = `/assessments/${id}`;
+      }
+      const response =
+        await APIClient(token).get<AssessmentDetailsResponse>(url);
       return response.data;
     },
     onError: (error: AxiosError) => {
       return handleBackendError(error);
     },
-    enabled: (!!token && isRegistered && id !== "") || id !== "",
+    enabled:
+      (isPublic && id !== "") ||
+      (!!token && isRegistered && id !== "") ||
+      id !== "",
   });
 }
 

--- a/src/pages/assessments/AssessmentEdit.tsx
+++ b/src/pages/assessments/AssessmentEdit.tsx
@@ -153,6 +153,7 @@ const AssessmentEdit = ({
     id: asmtNumID,
     token: keycloak?.token || "",
     isRegistered: registered,
+    isPublic: false,
   });
 
   const [page, setPage] = useState<number>(1);

--- a/src/pages/assessments/AssessmentsList.tsx
+++ b/src/pages/assessments/AssessmentsList.tsx
@@ -131,6 +131,7 @@ function AssessmentsList({ listPublic = false }: AssessmentListProps) {
     id: asmtNumID,
     token: keycloak?.token || "",
     isRegistered: registered || false,
+    isPublic: listPublic,
   });
 
   useEffect(() => {


### PR DESCRIPTION
Make useGetAssessment hook work in private and public mode. When in public mode the useGetAssessment hook uses a different api endpoint (`/assessments/public/{id}`) to get a specific assessment that is available publicly. 

Use the hook accordingly to the AssessmentList component by examining the prop (isPublic). IsPublic is true when we are displaying a public assessment view list. 

In the case of AssessmentEdit component the mode is always private so we set isPublic to always false