### PR TITLE
CAT-399 Support max mode in criteria and equal_less_than mode in benc…

### DIFF
--- a/src/pages/assessments/components/CriteriaTabs.tsx
+++ b/src/pages/assessments/components/CriteriaTabs.tsx
@@ -57,13 +57,6 @@ export function CriteriaTabs(props: CriteriaTabsProps) {
   }, [props]);
 
   props.principles.forEach((principle) => {
-    // comment to not push principle lable to navigation list
-    // navs.push(
-    //   <span className="mt-2 text-muted" key={principle.id}>
-    //     {principle.id} - {principle.name}:
-    //   </span>,
-    // );
-
     principle.criteria.forEach((criterion) => {
       navs.push(
         <Nav.Item key={criterion.id} className="cat-crit-tab">
@@ -118,8 +111,8 @@ export function CriteriaTabs(props: CriteriaTabsProps) {
       criterion.metric.tests.forEach((test) => {
         if (test.type === "binary") {
           testList.push(
-            <div className="border mt-4">
-              <div className="cat-test-div" key={test.id}>
+            <div className="border mt-4" key={test.id}>
+              <div className="cat-test-div">
                 <TestBinaryForm
                   test={test}
                   onTestChange={props.onTestChange}
@@ -132,8 +125,8 @@ export function CriteriaTabs(props: CriteriaTabsProps) {
           );
         } else if (test.type === "value") {
           testList.push(
-            <div className="border mt-4">
-              <div className="cat-test-div" key={test.id}>
+            <div className="border mt-4" key={test.id}>
+              <div className="cat-test-div">
                 <TestValueForm
                   test={test}
                   onTestChange={props.onTestChange}

--- a/src/pages/assessments/components/tests/TestValueForm.tsx
+++ b/src/pages/assessments/components/tests/TestValueForm.tsx
@@ -7,6 +7,7 @@ import { Button, Col, Form, InputGroup, Row } from "react-bootstrap";
 import { EvidenceURLS } from "./EvidenceURLS";
 import { AssessmentTest, TestValue } from "@/types";
 import { FaRegQuestionCircle } from "react-icons/fa";
+import { useState } from "react";
 
 interface AssessmentTestProps {
   test: TestValue;
@@ -26,36 +27,71 @@ enum TestValueEventType {
 }
 
 export const TestValueForm = (props: AssessmentTestProps) => {
+  const [localValue, setLocalValue] = useState<string>(
+    props.test.value?.toString() || "",
+  );
+  const [localThreshold, setLocalThreshold] = useState<string>(
+    props.test.threshold?.toString() || "",
+  );
+
   const handleValueChange = (
     eventType: TestValueEventType,
     event: React.ChangeEvent<HTMLInputElement>,
   ) => {
     const newTest = { ...props.test };
     // keep only number digits as input
-    const numberOnlyVal = event.target.value.replace(/[^0-9]/g, "");
+    const numberOnlyVal = event.target.value.replace(/[^0-9.]/g, "");
+
     if (eventType === TestValueEventType.Value) {
-      newTest.value = parseInt(numberOnlyVal);
+      setLocalValue(numberOnlyVal);
+      newTest.value = parseFloat(numberOnlyVal);
     } else {
-      newTest.threshold = parseInt(numberOnlyVal);
+      setLocalThreshold(numberOnlyVal);
+      newTest.threshold = parseFloat(numberOnlyVal);
     }
 
     // evaluate result - benchmark till now supports only equal_greater_than
     // this will change in the future
-    const comparisonMode = "equal_greater_than";
+    let comparisonMode = "";
     let comparisonValue = 0;
-    if (comparisonMode in newTest.benchmark) {
-      if (typeof newTest.benchmark[comparisonMode] === "number") {
-        comparisonValue = newTest.benchmark[comparisonMode];
-      } else if (
-        props.test.benchmark[comparisonMode] === "threshold" &&
-        props.test.threshold
-      ) {
-        comparisonValue = props.test.threshold;
+
+    // find comparisonMode
+    const modes = ["equal_greater_than", "equal_less_than", "equal"];
+
+    for (const mode of modes) {
+      if (mode in newTest.benchmark) {
+        comparisonMode = mode;
+        break;
       }
     }
+
+    if (comparisonMode in newTest.benchmark) {
+      if (typeof newTest.benchmark[comparisonMode] === "number") {
+        comparisonValue = newTest.benchmark[comparisonMode] as number;
+      } else if (
+        newTest.benchmark[comparisonMode] === "threshold" &&
+        newTest.threshold
+      ) {
+        comparisonValue = newTest.threshold;
+      }
+    }
+
     let result: 0 | 1 | null = null;
+
     if (newTest.value) {
-      result = newTest.value >= comparisonValue ? 1 : 0;
+      if (comparisonMode === "equal_greater_than") {
+        result = newTest.value >= comparisonValue ? 1 : 0;
+        console.log(
+          comparisonMode,
+          newTest.value,
+          comparisonValue,
+          newTest.threshold,
+        );
+      } else if (comparisonMode === "equal_less_than") {
+        result = newTest.value <= comparisonValue ? 1 : 0;
+      } else {
+        result = newTest.value === comparisonValue ? 1 : 0;
+      }
     }
     newTest.result = result;
 
@@ -103,40 +139,36 @@ export const TestValueForm = (props: AssessmentTestProps) => {
           <div>
             <h5>{props.test.text}</h5>
             <Row>
-              <Col xs={2}>
-                <InputGroup className="mt-1">
-                  <InputGroup.Text id="label-first-value">
-                    {props.test.value_name}:
-                  </InputGroup.Text>
-                  <Form.Control
-                    value={props.test.value || ""}
-                    type="text"
-                    id="input-value-control"
-                    onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                      handleValueChange(TestValueEventType.Value, e)
-                    }
-                  />
-                </InputGroup>
-              </Col>
+              <InputGroup className="mt-1">
+                <InputGroup.Text id="label-first-value">
+                  {props.test.value_name}:
+                </InputGroup.Text>
+                <Form.Control
+                  value={localValue || ""}
+                  type="text"
+                  id="input-value-control"
+                  onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                    handleValueChange(TestValueEventType.Value, e)
+                  }
+                />
+              </InputGroup>
             </Row>
             {props.test.threshold !== undefined && (
               <>
                 <Row className="mt-1">
-                  <Col xs={2}>
-                    <InputGroup className="mt-2">
-                      <InputGroup.Text id="label-second-value">
-                        {props.test.threshold_name || "Threshold"}:{" "}
-                      </InputGroup.Text>
-                      <Form.Control
-                        value={props.test.threshold || ""}
-                        type="text"
-                        id="input-value-community"
-                        onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                          handleValueChange(TestValueEventType.Threshold, e)
-                        }
-                      />
-                    </InputGroup>
-                  </Col>
+                  <InputGroup className="mt-2">
+                    <InputGroup.Text id="label-second-value">
+                      {props.test.threshold_name || "Threshold"}:{" "}
+                    </InputGroup.Text>
+                    <Form.Control
+                      value={localThreshold || ""}
+                      type="text"
+                      id="input-value-community"
+                      onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                        handleValueChange(TestValueEventType.Threshold, e)
+                      }
+                    />
+                  </InputGroup>
                 </Row>
               </>
             )}

--- a/src/types/assessment.ts
+++ b/src/types/assessment.ts
@@ -118,13 +118,8 @@ export enum MetricAlgorithm {
   Single = "single",
 }
 
-/** Each metric includes a benchmark. For now, we only deal with equal than greater kind  */
-export interface BenchmarkEqualGreaterThan {
-  equal_greater_than: number | string;
-}
-
-/** Each benchmark will gonna have different types - right now only one type is supported  */
-export type Benchmark = BenchmarkEqualGreaterThan;
+/** Each benchmark will gonna have different types  */
+export type Benchmark = Record<string, string | number>;
 
 /** Each metric has a list of tests. Test can be of different kinds */
 export interface TestBinary {

--- a/src/utils/assessment.ts
+++ b/src/utils/assessment.ts
@@ -26,6 +26,12 @@ export function evalMetric(metric: Metric): {
       if (sum === null || item.result === null) return null;
       return sum + item.result;
     }, 0);
+  } else if (metric.algorithm === "max") {
+    value = metric.tests.reduce((max: number | null, item: AssessmentTest) => {
+      // if any of the test values are null (not filled-in) designate the whole metric value/result as null
+      if (max === null || item.result === null) return null;
+      return Math.max(item.result, max);
+    }, -Infinity);
   }
   // if all the tests are filled-in and a value has been produced calculate also the rating
   if (value !== null) {


### PR DESCRIPTION
…hmarks

Should be merged along with the api PR: https://github.com/FC4E-CAT/fc4e-cat-api/pull/213

- [x] Change type of benchmark into a string map in order to accommodate more easily new modes such as "equal", "equal_less_than" etc. The value remains a string or number. 
- [x] Change `TestValue` component functionality to take into consideration benchmarks with "equal" or "equal_less_than" modes
- [x] Change  `TestValue` component internal state to be able to support float numbers for entry values 
- [x] Fix react key placement in rendering list of criterion tests 
- [x] Update criterion calculation method to support "max" mode in metrics