### PR TITLE
CAT-427 Support multiple assessment types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1344,20 +1344,20 @@
       }
     },
     "node_modules/@tanstack/query-core": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-4.35.0.tgz",
-      "integrity": "sha512-4GMcKQuLZQi6RFBiBZNsLhl+hQGYScRZ5ZoVq8QAzfqz9M7vcGin/2YdSESwl7WaV+Qzsb5CZOAbMBes4lNTnA==",
+      "version": "4.36.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-4.36.1.tgz",
+      "integrity": "sha512-DJSilV5+ytBP1FbFcEJovv4rnnm/CokuVvrBEtW/Va9DvuJ3HksbXUJEpI0aV1KtuL4ZoO9AVE6PyNLzF7tLeA==",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@tanstack/react-query": {
-      "version": "4.35.0",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-4.35.0.tgz",
-      "integrity": "sha512-LLYDNnM9ewYHgjm2rzhk4KG/puN2rdoqCUD+N9+V7SwlsYwJk5ypX58rpkoZAhFyZ+KmFUJ7Iv2lIEOoUqydIg==",
+      "version": "4.36.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-4.36.1.tgz",
+      "integrity": "sha512-y7ySVHFyyQblPl3J3eQBWpXZkliroki3ARnBKsdJchlgt7yJLRDUcf4B8soufgiYt3pEQIkBWBx1N9/ZPIeUWw==",
       "dependencies": {
-        "@tanstack/query-core": "4.35.0",
+        "@tanstack/query-core": "4.36.1",
         "use-sync-external-store": "^1.2.0"
       },
       "funding": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,4 @@
 import { Container } from "react-bootstrap";
-
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
@@ -106,7 +105,7 @@ function App() {
                     />
                   </Route>
                   <Route
-                    path="/assessments/:asmtID"
+                    path="/assessments/:asmtId"
                     element={<ProtectedRoute />}
                   >
                     {/* Use AssessmentEdit component with mode = edit */}

--- a/src/api/services/assessments.ts
+++ b/src/api/services/assessments.ts
@@ -15,11 +15,7 @@ import { handleBackendError } from "@/utils";
 export function useCreateAssessment(token: string) {
   const navigate = useNavigate();
   return useMutation({
-    mutationFn: (postData: {
-      validation_id: number;
-      template_id: number;
-      assessment_doc: Assessment;
-    }) => {
+    mutationFn: (postData: { assessment_doc: Assessment }) => {
       return APIClient(token).post("/assessments", postData);
     },
     // for the time being redirect to assessment list

--- a/src/api/services/templates.ts
+++ b/src/api/services/templates.ts
@@ -12,7 +12,7 @@ export const useGetTemplate = (
   isRegistered: boolean,
 ) =>
   useQuery({
-    queryKey: ["template", actorId],
+    queryKey: ["template", templateTypeId],
     queryFn: async () => {
       const response = await APIClient(token).get<TemplateResponse>(
         `/templates/by-type/${templateTypeId}/by-actor/${actorId}`,

--- a/src/api/services/users.ts
+++ b/src/api/services/users.ts
@@ -1,7 +1,12 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { AxiosError } from "axios";
 import { APIClient } from "@/api";
-import { ApiOptions, ApiUsers, UserAccess } from "@/types";
+import {
+  ApiOptions,
+  ApiUsers,
+  AsmtEligibilityResponse,
+  UserAccess,
+} from "@/types";
 import { UserResponse, UserListResponse } from "@/types";
 import { handleBackendError } from "@/utils";
 
@@ -11,6 +16,22 @@ export const useGetProfile = ({ token, isRegistered }: ApiOptions) =>
     queryFn: async () => {
       const response =
         await APIClient(token).get<UserResponse>(`/users/profile`);
+      return response.data;
+    },
+    onError: (error: AxiosError) => {
+      return handleBackendError(error);
+    },
+    retry: false,
+    enabled: isRegistered,
+  });
+
+export const useGetAsmtEligibility = ({ token, isRegistered }: ApiOptions) =>
+  useQuery({
+    queryKey: ["assessment-eligibility"],
+    queryFn: async () => {
+      const response = await APIClient(token).get<AsmtEligibilityResponse>(
+        `/users/assessment-eligibility`,
+      );
       return response.data;
     },
     onError: (error: AxiosError) => {

--- a/src/pages/assessments/components/AssessmentSelectActor.tsx
+++ b/src/pages/assessments/components/AssessmentSelectActor.tsx
@@ -4,27 +4,39 @@
  */
 
 import { Form } from "react-bootstrap";
-import { ActorOrganisationMapping } from "@/types";
+import { ActorOrgAsmtType } from "@/types";
 
 interface AssessmentSelectActorProps {
-  actorsOrgsMap: ActorOrganisationMapping[];
-  asmtID?: string;
-  validationID: string;
+  actorMap: ActorOrgAsmtType[];
+  asmtId?: string;
   templateDataActorId?: number;
-  templateDataOrgName?: string;
+  templateDataOrgId?: string;
+  templateDataAsmtTypeId?: number;
   actorId?: number;
-  orgName?: string;
+  orgId?: string;
+  asmtTypeId?: number;
+  importAsmtTypeId?: number;
+  importActorId?: number;
   onSelectActor: (
-    valId: string,
-    actorName: string,
     actorId: number,
-    orgName: string,
+    actorName: string,
     orgId: string,
+    orgName: string,
+    asmtTypeId: number,
+    asmtTypeName: string,
   ) => void;
 }
 
 export const AssessmentSelectActor = (props: AssessmentSelectActorProps) => {
   let checked = false;
+  let filteredActors = props.actorMap;
+  if (props.importAsmtTypeId && props.importActorId) {
+    filteredActors = props.actorMap.filter(
+      (item) =>
+        item.assessment_type_id === props.importAsmtTypeId &&
+        item.actor_id === props.importActorId,
+    );
+  }
   return (
     <>
       <span className="mb-3">
@@ -37,54 +49,57 @@ export const AssessmentSelectActor = (props: AssessmentSelectActorProps) => {
           style={{ maxHeight: "30vh" }}
           className="overflow-auto px-4 py-2 border"
         >
-          {props.actorsOrgsMap &&
-            props.actorsOrgsMap.map((t, i) => {
-              if (props.actorId && props.orgName) {
+          {filteredActors &&
+            filteredActors.map((t, i) => {
+              if (props.actorId && props.orgId) {
                 checked =
                   props.actorId === t.actor_id &&
-                  props.orgName === t.organisation_name;
+                  props.orgId === t.organisation_id &&
+                  props.asmtTypeId === t.assessment_type_id;
               } else {
                 checked =
                   props.templateDataActorId === t.actor_id &&
-                  props.templateDataOrgName === t.organisation_name;
+                  props.templateDataOrgId === t.organisation_id &&
+                  props.templateDataAsmtTypeId === t.assessment_type_id;
               }
-              if ((props.validationID || props.asmtID) && checked) {
+
+              if (props.asmtId && checked) {
                 return (
                   <Form.Check
                     key={`type-${i}`}
-                    value={t.validation_id}
                     disabled={!checked}
                     type="radio"
                     aria-label={`radio-${i}`}
-                    label={`${t.actor_name} at ${t.organisation_name}`}
+                    label={`${t.actor_name} at ${t.organisation_name} - ${t.assessment_type_name}`}
                     onChange={() => {
                       props.onSelectActor(
-                        t.validation_id.toString(),
-                        t.actor_name,
                         t.actor_id,
-                        t.organisation_name,
+                        t.actor_name,
                         t.organisation_id,
+                        t.organisation_name,
+                        t.assessment_type_id,
+                        t.assessment_type_name,
                       );
                     }}
                     checked={checked}
                   />
                 );
-              } else if (!props.validationID && !props.asmtID) {
+              } else if (!props.asmtId) {
                 return (
                   <Form.Check
                     key={`type-${i}`}
-                    value={t.validation_id}
                     type="radio"
                     id={`radio-${i}`}
                     aria-label={`radio-${i}`}
-                    label={`${t.actor_name} at ${t.organisation_name}`}
+                    label={`${t.actor_name} at ${t.organisation_name} - ${t.assessment_type_name}`}
                     onChange={() => {
                       props.onSelectActor(
-                        t.validation_id.toString(),
-                        t.actor_name,
                         t.actor_id,
-                        t.organisation_name,
+                        t.actor_name,
                         t.organisation_id,
+                        t.organisation_name,
+                        t.assessment_type_id,
+                        t.assessment_type_name,
                       );
                     }}
                     checked={checked}

--- a/src/pages/assessments/components/tests/TestValueForm.tsx
+++ b/src/pages/assessments/components/tests/TestValueForm.tsx
@@ -89,12 +89,6 @@ export const TestValueForm = (props: AssessmentTestProps) => {
     if (newTest.value) {
       if (comparisonMode === "equal_greater_than") {
         result = newTest.value >= comparisonValue ? 1 : 0;
-        console.log(
-          comparisonMode,
-          newTest.value,
-          comparisonValue,
-          newTest.threshold,
-        );
       } else if (comparisonMode === "equal_less_than") {
         result = newTest.value <= comparisonValue ? 1 : 0;
       } else {
@@ -110,8 +104,6 @@ export const TestValueForm = (props: AssessmentTestProps) => {
     const newTest = { ...props.test, evidence_url: newURLS };
     props.onTestChange(props.principleId, props.criterionId, newTest);
   }
-
-  console.log(props.test);
 
   return (
     <div>

--- a/src/types/assessment.ts
+++ b/src/types/assessment.ts
@@ -165,12 +165,13 @@ export interface ResultStats {
   optional: number;
 }
 
-export type ActorOrganisationMapping = {
-  actor_name: string;
+export type ActorOrgAsmtType = {
   actor_id: number;
+  actor_name: string;
   organisation_id: string;
   organisation_name: string;
-  validation_id: number;
+  assessment_type_id: number;
+  assessment_type_name: string;
 };
 
 export interface AssessmentListItem {
@@ -182,6 +183,8 @@ export interface AssessmentListItem {
   template_id: number;
   published: boolean;
 }
+
+export type AsmtEligibilityResponse = ResponsePage<ActorOrgAsmtType[]>;
 
 export type AssessmentListResponse = ResponsePage<AssessmentListItem[]>;
 


### PR DESCRIPTION
Based on cat-api changes introduced here: 
https://github.com/FC4E-CAT/fc4e-cat-api/pull/224
~⚠️ WARNING: to be merged after the above PR ☝️~ *merged*

Support for different assessment types when creating/editing/importing assessments

- [x] Use new backend call to retrieve user's list of assessment eligibility (triplets of assessment_type, organisation, actor)
- [x] Update assessment edit/view to render a new list of actor-orgs-assessment type triplets
- [x] Update SelectActor methods when a user selects a triplet of (actor,org,assesment type)
- [x] Update import procedure based on assessment type
- [x] Minor cleanups and code reorganisation