### PR TITLE
CAT-447 Add shared with me label to assessments

### DIFF
--- a/src/pages/assessments/AssessmentEdit.tsx
+++ b/src/pages/assessments/AssessmentEdit.tsx
@@ -21,6 +21,7 @@ import {
   Form,
   Alert,
   Offcanvas,
+  Badge,
 } from "react-bootstrap";
 import { AssessmentInfo, CriteriaTabs } from "@/pages/assessments/components";
 import {
@@ -30,6 +31,7 @@ import {
   FaFileImport,
   FaHandPointRight,
   FaTimesCircle,
+  FaUsers,
 } from "react-icons/fa";
 import { evalAssessment, evalMetric } from "@/utils";
 
@@ -137,6 +139,7 @@ const AssessmentEdit = ({
     isPublic: false,
   });
 
+  const [shared, setShared] = useState<boolean>(false);
   const [importError, setImportError] = useState<string>("");
   const [page] = useState<number>(1);
   const [actorMap, setActorMap] = useState<ActorOrgAsmtType[]>([]);
@@ -396,6 +399,7 @@ const AssessmentEdit = ({
       // if not on create mode load assessment itself
     } else if (mode === AssessmentEditMode.Edit && qAssessment.data) {
       const data = qAssessment.data.assessment_doc;
+      setShared(qAssessment.data.shared_to_user);
       setTemplateData(data);
     }
   }, [qTemplate.data, mode, qAssessment.data]);
@@ -550,7 +554,16 @@ const AssessmentEdit = ({
       <h3 className="cat-view-heading">
         <FaCheckCircle className="me-2" /> {`${mode} assessment`}
         {assessment && assessment.id && (
-          <span className="badge bg-secondary ms-2">id: {assessment?.id}</span>
+          <>
+            <span className="badge bg-secondary ms-2">
+              id: {assessment?.id}
+              {shared && (
+                <Badge pill bg="light" text="secondary" className="border ms-4">
+                  shared with me <FaUsers className="ms-1" />
+                </Badge>
+              )}
+            </span>
+          </>
         )}
       </h3>
       <Tab.Container

--- a/src/pages/assessments/AssessmentsList.tsx
+++ b/src/pages/assessments/AssessmentsList.tsx
@@ -17,6 +17,7 @@ import {
   FaTimes,
   FaDownload,
   FaFileImport,
+  FaUsers,
 } from "react-icons/fa";
 import {
   Collapse,
@@ -29,6 +30,7 @@ import {
   FloatingLabel,
   OverlayTrigger,
   Tooltip,
+  Badge,
 } from "react-bootstrap";
 import { AssessmentListItem, AssessmentFiltersType, AlertInfo } from "@/types";
 import {
@@ -281,7 +283,18 @@ function AssessmentsList({ listPublic = false }: AssessmentListProps) {
           {
             accessorKey: "name",
             header: () => <span>Name</span>,
-            cell: (info) => info.getValue(),
+            cell: (info) => {
+              return (
+                <>
+                  <div>{info.getValue() + ""}</div>
+                  {info.row.original.shared_to_user && (
+                    <Badge pill bg="light" text="secondary" className="border">
+                      shared with me <FaUsers className="ms-1" />
+                    </Badge>
+                  )}
+                </>
+              );
+            },
             enableColumnFilter: false,
           },
           {

--- a/src/types/assessment.ts
+++ b/src/types/assessment.ts
@@ -35,6 +35,7 @@ export interface Assessment {
   result: AssessmentResult;
   principles: Principle[];
   published: boolean;
+  shared_with_user: boolean;
 }
 
 /** Reference with numerical id */
@@ -202,12 +203,14 @@ export interface AssessmentAdminDetailsResponse {
 
 export interface AssessmentListItem {
   id: string;
+  name: string;
   user_id: string;
   validation_id: number;
   created_on: number;
   updated_on: string;
   template_id: number;
   published: boolean;
+  shared_to_user: boolean;
 }
 
 export type AsmtEligibilityResponse = ResponsePage<ActorOrgAsmtType[]>;
@@ -216,6 +219,7 @@ export type AssessmentListResponse = ResponsePage<AssessmentListItem[]>;
 
 export interface AssessmentDetailsResponse {
   id: number;
+  shared_to_user: boolean;
   assessment_doc: Assessment;
 }
 


### PR DESCRIPTION
Add a label `shared with me` when an assessment appears on my list as a share from another user. The label is displayed both in the assessments view and in the edit assessment tab