### PR TITLE
CAT-365 Redirect when non-admin users try to access admin paths

### DIFF
--- a/src/auth/ProtectedRoute.tsx
+++ b/src/auth/ProtectedRoute.tsx
@@ -1,11 +1,16 @@
 import { useContext, useEffect } from "react";
-import { Outlet } from "react-router-dom";
+import { Outlet, useLocation, useNavigate } from "react-router-dom";
 import { AuthContext } from "@/auth";
 import Keycloak from "keycloak-js";
 import KeycloakConfig from "@/keycloak.json";
 import { useUserRegister, useGetProfile } from "@/api";
 
 export function ProtectedRoute() {
+  // check if the current path leads to an admin-view
+  const adminRoute = useLocation().pathname.startsWith("/admin");
+  // load navigate hook to use it to programmaticaly navigate to profile page if needed
+  const navigate = useNavigate();
+
   const {
     authenticated,
     setAuthenticated,
@@ -73,6 +78,13 @@ export function ProtectedRoute() {
       setRegistered(true);
     }
   }, [isSuccessRegister, setRegistered, profileData]);
+
+  // check if a non-admin user tries to access an admin view
+  useEffect(() => {
+    if (authenticated && adminRoute && profileData?.user_type !== "admin") {
+      navigate("/profile");
+    }
+  }, [authenticated, adminRoute, profileData, navigate]);
 
   if (authenticated && isSuccess) {
     return <Outlet />;


### PR DESCRIPTION
When an non-admin user tries to access a path that leads to an admin-view, redirect to the profile page