### PR TITLE
CAT-463 Support evidence urls with descriptions

### DIFF
--- a/src/pages/assessments/components/tests/EvidenceURLS.tsx
+++ b/src/pages/assessments/components/tests/EvidenceURLS.tsx
@@ -1,19 +1,19 @@
+import { EvidenceURL } from "@/types";
 import { useState } from "react";
-import { InputGroup, Form } from "react-bootstrap";
-import { FaExternalLinkAlt } from "react-icons/fa";
+import { InputGroup, Form, Row, Col } from "react-bootstrap";
 
 /**
  * Small component to add url list
  */
 
 interface EvidenceURLSProps {
-  urls: string[];
-  onListChange(newURLs: string[]): void;
+  urls: EvidenceURL[];
+  onListChange(newURLs: EvidenceURL[]): void;
 }
 
 export const EvidenceURLS = (props: EvidenceURLSProps) => {
-  const [urlList, setUrlList] = useState<string[]>(props.urls);
-  const [newURL, setNewURL] = useState("");
+  const [urlList, setUrlList] = useState<EvidenceURL[]>(props.urls);
+  const [newURL, setNewURL] = useState<EvidenceURL>({ url: "" });
   const [error, setError] = useState("");
   const urlRegex = /^(ftp|http|https):\/\/[^ "]+$/;
 
@@ -25,11 +25,11 @@ export const EvidenceURLS = (props: EvidenceURLSProps) => {
 
   const handleAddURL = () => {
     if (newURL) {
-      if (urlRegex.test(newURL)) {
+      if (urlRegex.test(newURL.url)) {
         const updatedURLs = [...urlList, newURL];
         setUrlList(updatedURLs);
         props.onListChange(updatedURLs);
-        setNewURL("");
+        setNewURL({ url: "" });
         setError("");
       } else {
         setError(
@@ -48,49 +48,93 @@ export const EvidenceURLS = (props: EvidenceURLSProps) => {
       {urlList.length > 0 && (
         <ul className="list-group mt-2">
           {urlList.map((item, index) => (
-            <li className="list-group-item py-1" key={index}>
-              <small>
-                <FaExternalLinkAlt />{" "}
-                <a
-                  className="ms-2"
-                  href={item}
-                  target="_blank"
-                  rel="noreferrer"
-                >
-                  {item}
-                </a>{" "}
-                <span
-                  className="btn btn-sm btn-light border ms-4"
-                  onClick={() => handleRemoveURL(index)}
-                >
-                  remove
-                </span>
-              </small>
+            <li className="list-group-item p-2" key={index}>
+              <Row>
+                <Col md="auto">
+                  <small>[{index}]</small>
+                </Col>
+                <Col>
+                  <div>
+                    <small>
+                      <a
+                        className="ms-2"
+                        href={item.url}
+                        target="_blank"
+                        rel="noreferrer"
+                      >
+                        {item.url}
+                      </a>{" "}
+                    </small>
+                  </div>
+                  <div>
+                    {item.description && (
+                      <small>
+                        <em className="ms-2">{item.description}</em>
+                      </small>
+                    )}
+                  </div>
+                </Col>
+                <Col md="auto">
+                  <small>
+                    <span
+                      className="btn btn-sm btn-light border ms-4"
+                      onClick={() => handleRemoveURL(index)}
+                    >
+                      remove
+                    </span>
+                  </small>
+                </Col>
+              </Row>
             </li>
           ))}
         </ul>
       )}
-      <InputGroup className="mt-2" size="sm">
-        <InputGroup.Text id="label-add-url">URL:</InputGroup.Text>
-        <Form.Control
-          id="input-add-url"
-          value={newURL}
-          onChange={(e) => {
-            setNewURL(e.target.value);
-            setError("");
-          }}
-          aria-describedby="label-add-url"
-          placeholder="Please enter and add a valid url to support your claim"
-          onKeyDown={(event) => {
-            if (event.key === "Enter") {
-              handleAddURL();
-            }
-          }}
-        />
-        <span className="btn btn-primary btn-sm" onClick={handleAddURL}>
-          Add
-        </span>
-      </InputGroup>
+      <Row className="m-1 p-2 bg-light border rounded-bottom">
+        <Col>
+          <InputGroup size="sm">
+            <InputGroup.Text id="label-add-url">URL:</InputGroup.Text>
+            <Form.Control
+              id="input-add-url"
+              value={newURL.url}
+              onChange={(e) => {
+                setNewURL({ ...newURL, url: e.target.value });
+                setError("");
+              }}
+              aria-describedby="label-add-url"
+              placeholder="Please enter and add a valid url to support your claim"
+              onKeyDown={(event) => {
+                if (event.key === "Enter") {
+                  handleAddURL();
+                }
+              }}
+            />
+          </InputGroup>
+          <InputGroup className="mt-2" size="sm">
+            <InputGroup.Text id="label-add-url">description:</InputGroup.Text>
+            <Form.Control
+              id="input-add-description"
+              value={newURL.description}
+              onChange={(e) => {
+                setNewURL({ ...newURL, description: e.target.value });
+                setError("");
+              }}
+              aria-describedby="label-add-url"
+              placeholder="Please enter a description of the evidence"
+              onKeyDown={(event) => {
+                if (event.key === "Enter") {
+                  handleAddURL();
+                }
+              }}
+            />
+          </InputGroup>
+        </Col>
+        <Col md="auto">
+          <span className="btn btn-primary btn-sm" onClick={handleAddURL}>
+            Add
+          </span>
+        </Col>
+      </Row>
+
       {error && <small className="text-danger">{error}</small>}
     </div>
   );

--- a/src/pages/assessments/components/tests/TestBinaryForm.tsx
+++ b/src/pages/assessments/components/tests/TestBinaryForm.tsx
@@ -5,7 +5,7 @@
 // import { useState } from "react"
 import { Button, Col, Form, Row } from "react-bootstrap";
 import { EvidenceURLS } from "./EvidenceURLS";
-import { AssessmentTest, TestBinary } from "@/types";
+import { AssessmentTest, EvidenceURL, TestBinary } from "@/types";
 import { FaRegQuestionCircle } from "react-icons/fa";
 
 interface AssessmentTestProps {
@@ -33,7 +33,7 @@ export const TestBinaryForm = (props: AssessmentTestProps) => {
     props.onTestChange(props.principleId, props.criterionId, newTest);
   };
 
-  function onURLChange(newURLS: string[]) {
+  function onURLChange(newURLS: EvidenceURL[]) {
     const newTest = { ...props.test, evidence_url: newURLS };
     props.onTestChange(props.principleId, props.criterionId, newTest);
   }

--- a/src/pages/assessments/components/tests/TestValueForm.tsx
+++ b/src/pages/assessments/components/tests/TestValueForm.tsx
@@ -13,7 +13,7 @@ import {
   Tooltip,
 } from "react-bootstrap";
 import { EvidenceURLS } from "./EvidenceURLS";
-import { AssessmentTest, TestValue } from "@/types";
+import { AssessmentTest, EvidenceURL, TestValue } from "@/types";
 import { FaLock, FaRegQuestionCircle } from "react-icons/fa";
 import { useState } from "react";
 
@@ -100,7 +100,7 @@ export const TestValueForm = (props: AssessmentTestProps) => {
     props.onTestChange(props.principleId, props.criterionId, newTest);
   };
 
-  function onURLChange(newURLS: string[]) {
+  function onURLChange(newURLS: EvidenceURL[]) {
     const newTest = { ...props.test, evidence_url: newURLS };
     props.onTestChange(props.principleId, props.criterionId, newTest);
   }

--- a/src/types/assessment.ts
+++ b/src/types/assessment.ts
@@ -132,7 +132,7 @@ export interface TestBinary {
   text: string;
   result: number | null;
   value: boolean | null;
-  evidence_url?: string[];
+  evidence_url?: EvidenceURL[];
 }
 
 export interface TestValue {
@@ -149,7 +149,12 @@ export interface TestValue {
   threshold_name?: string;
   threshold_locked?: boolean;
   benchmark: Benchmark;
-  evidence_url?: string[];
+  evidence_url?: EvidenceURL[];
+}
+
+export interface EvidenceURL {
+  url: string;
+  description?: string;
 }
 
 export interface Guidance {


### PR DESCRIPTION
- Update Schema in typescript types to support evidence urls with descriptions
- Change EvidenceURL component to accommodate descriptions (both input and display)
- Update onChange methods to look for descriptions in evidence urls and update Assesment Json accordingly