### PR TITLE
CAT-446 Support assessment sharing

### DIFF
--- a/src/pages/assessments/AssessmentEdit.tsx
+++ b/src/pages/assessments/AssessmentEdit.tsx
@@ -29,6 +29,7 @@ import {
   FaExclamationCircle,
   FaFileImport,
   FaHandPointRight,
+  FaShare,
   FaTimesCircle,
   FaUsers,
 } from "react-icons/fa";
@@ -45,10 +46,17 @@ import { DebugJSON } from "./components/DebugJSON";
 import { AssessmentSelectActor } from "./components/AssessmentSelectActor";
 
 import { toast } from "react-hot-toast";
+import { ShareModal } from "./components/ShareModal";
 
 type AssessmentEditProps = {
   mode: AssessmentEditMode;
 };
+
+interface ShareModalConfig {
+  show: boolean;
+  name: string;
+  id: string;
+}
 
 type Guide = {
   id: string;
@@ -87,6 +95,13 @@ const AssessmentEdit = ({
     title: "",
     text: "",
     show: false,
+  });
+
+  // Share Modal
+  const [shareModalConfig, setShareModalConfig] = useState<ShareModalConfig>({
+    show: false,
+    name: "",
+    id: "",
   });
 
   const handleGuideClose = () =>
@@ -399,6 +414,11 @@ const AssessmentEdit = ({
     } else if (mode === AssessmentEditMode.Edit && qAssessment.data) {
       const data = qAssessment.data.assessment_doc;
       setShared(qAssessment.data.shared_to_user);
+      setShareModalConfig({
+        id: qAssessment.data.assessment_doc.id,
+        name: qAssessment.data.assessment_doc.name,
+        show: false,
+      });
       setTemplateData(data);
     }
   }, [qTemplate.data, mode, qAssessment.data]);
@@ -536,6 +556,14 @@ const AssessmentEdit = ({
 
   return (
     <>
+      <ShareModal
+        show={shareModalConfig.show}
+        name={shareModalConfig.name}
+        id={shareModalConfig.id}
+        onHide={() => {
+          setShareModalConfig({ ...shareModalConfig, show: false });
+        }}
+      />
       <Offcanvas
         show={guide.show}
         onHide={handleGuideClose}
@@ -551,7 +579,7 @@ const AssessmentEdit = ({
         </Offcanvas.Body>
       </Offcanvas>
       <div className="cat-view-heading-block row border-bottom">
-        <div className="col col-lg-6">
+        <div className="col">
           <h2 className="cat-view-heading text-muted">
             {`${mode} assessment`}
             <p className="lead cat-view-lead">
@@ -559,7 +587,7 @@ const AssessmentEdit = ({
               {assessment && assessment.id && (
                 <>
                   <p className="text-info">
-                    <small> with id ${assessment.id}</small>
+                    <small> with id {assessment.id}</small>
                   </p>
                 </>
               )}
@@ -567,9 +595,18 @@ const AssessmentEdit = ({
           </h2>
         </div>
         <div className="col-md-auto">
-          {shared && (
+          {shared ? (
             <button className="btn btn-secondary">
               shared with me <FaUsers className="ms-1" />
+            </button>
+          ) : (
+            <button
+              className="btn btn-success"
+              onClick={() => {
+                setShareModalConfig({ ...shareModalConfig, show: true });
+              }}
+            >
+              <FaShare /> Share
             </button>
           )}
         </div>

--- a/src/pages/assessments/AssessmentsList.tsx
+++ b/src/pages/assessments/AssessmentsList.tsx
@@ -17,6 +17,7 @@ import {
   FaDownload,
   FaFileImport,
   FaUsers,
+  FaShare,
 } from "react-icons/fa";
 import {
   Collapse,
@@ -45,6 +46,7 @@ import { Link } from "react-router-dom";
 import { DeleteModal } from "@/components/DeleteModal";
 
 import { toast } from "react-hot-toast";
+import { ShareModal } from "./components/ShareModal";
 
 /**
  * ComplianceBadge gets a compliance value (null, false, true) and renders
@@ -81,6 +83,12 @@ interface DeleteModalConfig {
   itemName: string;
 }
 
+interface ShareModalConfig {
+  show: boolean;
+  name: string;
+  id: string;
+}
+
 function AssessmentsList({ listPublic = false }: AssessmentListProps) {
   const { keycloak, registered } = useContext(AuthContext)!;
   // get the extra url parameters when in public list mode from url
@@ -93,7 +101,7 @@ function AssessmentsList({ listPublic = false }: AssessmentListProps) {
     message: "",
   });
 
-  // Modal
+  // Delete Modal
   const [deleteModalConfig, setDeleteModalConfig] = useState<DeleteModalConfig>(
     {
       show: false,
@@ -103,6 +111,13 @@ function AssessmentsList({ listPublic = false }: AssessmentListProps) {
       itemName: "",
     },
   );
+
+  // Share Modal
+  const [shareModalConfig, setShareModalConfig] = useState<ShareModalConfig>({
+    show: false,
+    name: "",
+    id: "",
+  });
 
   const actorId = actorIdParam ? parseInt(actorIdParam, 10) : -1;
   const assessmentTypeId = assessmentTypeIdParam
@@ -194,6 +209,14 @@ function AssessmentsList({ listPublic = false }: AssessmentListProps) {
         show: true,
         itemId: item.id,
         itemName: "test",
+      });
+    };
+
+    const handleShareOpenModal = (item: AssessmentListItem) => {
+      setShareModalConfig({
+        show: true,
+        name: item.name,
+        id: item.id,
       });
     };
 
@@ -386,6 +409,15 @@ function AssessmentsList({ listPublic = false }: AssessmentListProps) {
                       <FaDownload />
                     </Button>
                     <Button
+                      id={`share-button-${item.id}`}
+                      className="btn btn-secondary cat-action-reject-link btn-sm "
+                      onClick={() => {
+                        handleShareOpenModal(item);
+                      }}
+                    >
+                      <FaShare />
+                    </Button>
+                    <Button
                       id={`delete-button-${item.id}`}
                       className="btn btn-secondary cat-action-reject-link btn-sm "
                       onClick={() => {
@@ -442,6 +474,14 @@ function AssessmentsList({ listPublic = false }: AssessmentListProps) {
 
   return (
     <div>
+      <ShareModal
+        show={shareModalConfig.show}
+        name={shareModalConfig.name}
+        id={shareModalConfig.id}
+        onHide={() => {
+          setShareModalConfig({ id: "", name: "", show: false });
+        }}
+      />
       <DeleteModal
         show={deleteModalConfig.show}
         title={deleteModalConfig.title}

--- a/src/pages/assessments/components/ShareModal.tsx
+++ b/src/pages/assessments/components/ShareModal.tsx
@@ -1,0 +1,126 @@
+import { useGetAssessmentShares, useShareAssessment } from "@/api";
+import { AuthContext } from "@/auth";
+import { AlertInfo } from "@/types";
+import { useContext, useRef, useState } from "react";
+import { Modal, Button, ListGroup, Form, InputGroup } from "react-bootstrap";
+import toast from "react-hot-toast";
+import { FaShare, FaUserAlt } from "react-icons/fa";
+
+interface ShareModalProps {
+  name: string;
+  id: string;
+  show: boolean;
+  onHide: () => void;
+}
+/**
+ * Modal component for adding shares (share assessment to other users)
+ */
+export function ShareModal(props: ShareModalProps) {
+  const alert = useRef<AlertInfo>({
+    message: "",
+  });
+
+  const { keycloak, registered } = useContext(AuthContext)!;
+
+  const qShares = useGetAssessmentShares({
+    id: props.id,
+    token: keycloak?.token || "",
+    isRegistered: registered || false,
+  });
+  const mutateShare = useShareAssessment(keycloak?.token || "", props.id);
+  const [email, setEmail] = useState("");
+
+  function handleShare() {
+    const promise = mutateShare
+      .mutateAsync({
+        shared_with_user: email,
+      })
+      .catch((err) => {
+        alert.current = {
+          message: "Error: " + err.response.data.message,
+        };
+        throw err;
+      })
+      .then(() => {
+        setEmail("");
+        alert.current = {
+          message: "Succesfully shared with: " + email,
+        };
+      });
+    toast.promise(promise, {
+      loading: "Sharing...",
+      success: () => `${alert.current.message}`,
+      error: () => `${alert.current.message}`,
+    });
+  }
+
+  return (
+    <Modal
+      {...props}
+      size="lg"
+      aria-labelledby="contained-modal-title-vcenter"
+      centered
+    >
+      <Modal.Header className="bg-success text-white" closeButton>
+        <Modal.Title id="contained-modal-title-vcenter">
+          <FaShare className="me-2" /> Share assessment
+        </Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        <ListGroup>
+          <ListGroup.Item>
+            <strong>Name: </strong>
+            {props.name}
+          </ListGroup.Item>
+          <ListGroup.Item>
+            <strong>ID: </strong>
+            {props.id}
+          </ListGroup.Item>
+        </ListGroup>
+
+        <div className="mt-2 bg-light p-3 rounded border">
+          <InputGroup>
+            <InputGroup.Text id="label-share-user">Share with:</InputGroup.Text>
+            <Form.Control
+              id="input-share-user"
+              placeholder="Enter user's email to share the assessment with"
+              value={email}
+              onChange={(e) => {
+                setEmail(e.target.value);
+              }}
+              aria-describedby="label-share-user"
+            />
+            <Button
+              disabled={email.length == 0}
+              onClick={() => {
+                handleShare();
+              }}
+            >
+              Confirm
+            </Button>
+          </InputGroup>
+          {qShares.data && (
+            <div className="mt-2">
+              <small>
+                Already Shared with:
+                <ListGroup>
+                  {qShares.data.shared_users.map((item) => (
+                    <ListGroup.Item key={item.id}>
+                      <FaUserAlt className="me-2" /> {item.name} {item.surname}{" "}
+                      ({item.email})
+                    </ListGroup.Item>
+                  ))}
+                </ListGroup>
+              </small>
+            </div>
+          )}
+        </div>
+      </Modal.Body>
+      <Modal.Footer className="d-flex justify-content-between">
+        <Button className="btn-secondary" onClick={props.onHide}>
+          Close
+        </Button>
+      </Modal.Footer>
+    </Modal>
+  );
+}

--- a/src/types/assessment.ts
+++ b/src/types/assessment.ts
@@ -253,3 +253,14 @@ export interface AssessmentTypeResponse {
   total_pages: number;
   content: AssessmentType[];
 }
+
+export interface SharedUsers {
+  shared_users: SharedUser[];
+}
+
+export interface SharedUser {
+  id: string;
+  name: string;
+  surname: string;
+  email: string;
+}


### PR DESCRIPTION


### Goal
Support sharing of assessments between users

### Implementation
- [x] Create a new modal component that allows sharing: `SharingModal`
- [x] Add new api backend service hooks `useAssessmentShare` and `useGetAssessmentShares`
- [x] Use sharing modal in AssessmentList
- [x] Use sharing modal when editing an Assessment