### PR TITLE
CAT-469 Fix admin view users link and admin route checks

### DIFF
--- a/src/auth/ProtectedRoute.tsx
+++ b/src/auth/ProtectedRoute.tsx
@@ -81,16 +81,12 @@ export function ProtectedRoute() {
 
   // check if a non-admin user tries to access an admin view
   useEffect(() => {
-    if (
-      authenticated &&
-      adminRoute &&
-      profileData?.user_type.toLowerCase() !== "admin"
-    ) {
-      navigate("/profile");
+    if (authenticated && adminRoute && profileData) {
+      if (profileData.user_type.toLowerCase() !== "admin") navigate("/profile");
     }
   }, [authenticated, adminRoute, profileData, navigate]);
 
-  if (authenticated && isSuccess) {
+  if (authenticated && isSuccess && profileData) {
     return <Outlet />;
   } else {
     return <></>;

--- a/src/pages/admin/AdminUsers.tsx
+++ b/src/pages/admin/AdminUsers.tsx
@@ -27,6 +27,7 @@ import {
 } from "react-icons/fa";
 import toast from "react-hot-toast";
 import { idToColor, trimField } from "@/utils/admin";
+import { Link } from "react-router-dom";
 
 type UserState = {
   sortOrder: string;
@@ -466,16 +467,12 @@ export default function AdminUsers() {
                     </td>
                     <td>
                       <OverlayTrigger placement="top" overlay={tooltipView}>
-                        <Button
-                          variant="light"
-                          size="sm"
-                          onClick={() =>
-                            (window.location.href = `/admin/users/view/${item.id}`)
-                          }
+                        <Link
+                          className="btn btn-sm btn-light"
+                          to={`/admin/users/view/${item.id}`}
                         >
-                          {/* <Button className="btn-light btn-sm m-1"> */}
                           <FaBars />
-                        </Button>
+                        </Link>
                       </OverlayTrigger>
                       {item.banned ? (
                         <OverlayTrigger


### PR DESCRIPTION
- Fix view user details button to be an actual react-router link element 
- When checking if user is eligible to follow an admin route, check only if you have at hand the user profile data to check for admin value