### PR TITLE
CAT-383 Reason for rejection of a validation

### DIFF
--- a/src/api/services/validations.ts
+++ b/src/api/services/validations.ts
@@ -151,6 +151,7 @@ export const useValidationRequest = ({
 export const useValidationStatusUpdate = ({
   validation_id,
   status,
+  rejection_reason,
   token,
 }: ValidationUpdateStatusParams) =>
   useMutation(
@@ -159,6 +160,7 @@ export const useValidationStatusUpdate = ({
         `/admin/validations/${validation_id}/update-status`,
         {
           status,
+          rejection_reason,
           token,
         },
       );

--- a/src/pages/validations/ValidationDetails.tsx
+++ b/src/pages/validations/ValidationDetails.tsx
@@ -7,7 +7,7 @@ import {
   ValidationStatus,
 } from "@/types";
 import { useRef, useState, useContext, useEffect } from "react";
-import { Modal } from "react-bootstrap";
+import { Form, Modal } from "react-bootstrap";
 import toast from "react-hot-toast";
 import {
   FaExclamationTriangle,
@@ -31,11 +31,13 @@ function ValidationDetails(props: ValidationProps) {
   const isAdmin = useRef<boolean>(false);
   const [reviewStatus, setReviewStatus] = useState<string>("");
   const { keycloak, registered } = useContext(AuthContext)!;
+  const [rejection, setRejection] = useState<string>("");
 
   const { mutateAsync: mutateValidationUpdateStatus } =
     useValidationStatusUpdate({
       validation_id: params.id!,
       status: reviewStatus,
+      rejection_reason: rejection,
       token: keycloak?.token || "",
       isRegistered: registered,
     });
@@ -79,10 +81,24 @@ function ValidationDetails(props: ValidationProps) {
         <Modal.Body className=" card-body border-danger text-center">
           Are you sure you want to reject validation with ID:{" "}
           <strong>{params.id}</strong> ?
+          <div className="text-start mt-2">
+            <Form.Control
+              id="input-share-user"
+              placeholder="Add a reason for rejecting this request (required)"
+              value={rejection}
+              as="textarea"
+              rows={3}
+              onChange={(e) => {
+                setRejection(e.target.value);
+              }}
+              aria-describedby="label-share-user"
+            />
+          </div>
         </Modal.Body>
         <Modal.Footer className="card-footer border-danger text-danger text-center">
           <button
             className="btn btn-danger mr-2"
+            disabled={rejection === ""}
             onClick={() => {
               setReviewStatus(ValidationStatus.REJECTED);
               const promise = mutateValidationUpdateStatus()
@@ -278,7 +294,10 @@ function ValidationDetails(props: ValidationProps) {
                         </span>
                       </small>
                     </h4>
-
+                    <div className="alert alert-danger">
+                      <strong>Rejection Reason:</strong>
+                      <p>{validation?.rejection_reason}</p>
+                    </div>
                     <div>
                       <strong>Rejected on:</strong> {validation?.validated_on}
                     </div>

--- a/src/types/validation.ts
+++ b/src/types/validation.ts
@@ -17,6 +17,7 @@ export type ValidationResponse = {
   created_on: string;
   validated_on: string;
   validated_by: string;
+  rejection_reason: string;
 };
 
 export type APIValidationResponse = ResponsePage<ValidationResponse[]>;
@@ -43,6 +44,7 @@ export type ValidationUpdateStatusParams = ApiAuthOptions &
 
 export interface ValidationStatusUpdate {
   validation_id: string;
+  rejection_reason?: string;
   status: string;
 }
 

--- a/style_script
+++ b/style_script
@@ -1,3 +1,0 @@
-#!/usr/bin/bash 
-npm run prettier:fix
-npm run stylelint:fix


### PR DESCRIPTION
- [x] Add an input box in validation rejection modal to specify a reason. The reason is always required when rejecting thus the reject button is only enabled when the user fills in a reason
- [x] Add the rejection reason in rejection details in a prominent red-alert style bootstrap div
- [x] Minor remove script_styles file (unnecessary) 