### PR TITLE
CAT-471 Emphasize shared assessments in assessments list

### DIFF
--- a/src/api/services/assessments.ts
+++ b/src/api/services/assessments.ts
@@ -85,7 +85,7 @@ export function useGetAssessments({
     }
   });
   return useQuery({
-    queryKey: ["assessments", { size, page, sortBy, ...filters }],
+    queryKey: ["assessments"],
     queryFn: async () => {
       const response = await APIClient(token).get<AssessmentListResponse>(url);
       return response.data;
@@ -161,6 +161,7 @@ export function useShareAssessment(token: string, id: string) {
     // for the time being redirect to assessment list
     onSuccess: () => {
       queryClient.invalidateQueries(["assessment-shares", id]);
+      queryClient.invalidateQueries(["assessments"]);
     },
   });
 }

--- a/src/pages/assessments/AssessmentsList.tsx
+++ b/src/pages/assessments/AssessmentsList.tsx
@@ -410,7 +410,7 @@ function AssessmentsList({ listPublic = false }: AssessmentListProps) {
                     </Button>
                     <Button
                       id={`share-button-${item.id}`}
-                      className="btn btn-secondary cat-action-reject-link btn-sm "
+                      className={`btn cat-action-reject-link btn-sm ${item.shared ? "btn-success border" : "btn-secondary"}`}
                       onClick={() => {
                         handleShareOpenModal(item);
                       }}

--- a/src/types/assessment.ts
+++ b/src/types/assessment.ts
@@ -216,6 +216,7 @@ export interface AssessmentListItem {
   template_id: number;
   published: boolean;
   shared_to_user: boolean;
+  shared: boolean;
 }
 
 export type AsmtEligibilityResponse = ResponsePage<ActorOrgAsmtType[]>;


### PR DESCRIPTION
- Update assessment type schema to retrieve `shared: boolean` attribute
- Make share buttons green in assessment list when an assessment has `shared: true`
- Simplify react query assessment list caching keys to refresh assessment list when something becomes shared