### PR TITLE
CAT-491 Fix assessment name in delete assessment modal

### DIFF
--- a/src/pages/assessments/AssessmentsList.tsx
+++ b/src/pages/assessments/AssessmentsList.tsx
@@ -208,7 +208,7 @@ function AssessmentsList({ listPublic = false }: AssessmentListProps) {
         ...deleteModalConfig,
         show: true,
         itemId: item.id,
-        itemName: "test",
+        itemName: item.name,
       });
     };
 


### PR DESCRIPTION
Fix delete assessment modal to display the correct assessment name instead of placeholder "Test" value