### PR TITLE
Support crud of principles

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,6 +30,8 @@ import AssessmentsTable from "./pages/admin/AssessmentsTable";
 import ViewUsers from "./pages/admin/ViewUsers";
 import Motivations from "./pages/motivations/Motivations";
 import MotivationDetails from "./pages/motivations/MotivationDetails";
+import Principles from "./pages/principles/Principles";
+import PrincipleDetails from "./pages/principles/PrincipleDetails";
 
 const queryClient = new QueryClient();
 
@@ -196,6 +198,12 @@ function App() {
                   </Route>
                   <Route path="/motivations/:id" element={<ProtectedRoute />}>
                     <Route index element={<MotivationDetails />} />
+                  </Route>
+                  <Route path="/principles" element={<ProtectedRoute />}>
+                    <Route index element={<Principles />} />
+                  </Route>
+                  <Route path="/principles/:id" element={<ProtectedRoute />}>
+                    <Route index element={<PrincipleDetails />} />
                   </Route>
                   <Route path="/login" element={<ProtectedRoute />}>
                     <Route index element={<Profile />} />

--- a/src/api/services/principles.ts
+++ b/src/api/services/principles.ts
@@ -1,0 +1,127 @@
+import { AxiosError } from "axios";
+import { APIClient } from "@/api";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { handleBackendError } from "@/utils";
+import {
+  ApiOptions,
+  Principle,
+  PrincipleInput,
+  PrincipleResponse,
+} from "@/types";
+
+export const useGetPrinciples = ({
+  size,
+  page,
+  token,
+  isRegistered,
+}: ApiOptions) =>
+  useQuery({
+    queryKey: ["principles", { size, page }],
+    queryFn: async () => {
+      const response = await APIClient(token).get<PrincipleResponse>(
+        `/registry/principles?size=${size}&page=${page}`,
+      );
+      return response.data;
+    },
+    onError: (error: AxiosError) => {
+      return handleBackendError(error);
+    },
+    enabled: !!token && isRegistered,
+  });
+
+export const useGetPrinciple = ({
+  id,
+  token,
+  isRegistered,
+}: {
+  id: string;
+  token: string;
+  isRegistered: boolean;
+}) =>
+  useQuery({
+    queryKey: ["principle", id],
+    queryFn: async () => {
+      let response = null;
+
+      response = await APIClient(token).get<Principle>(
+        `/registry/principles/${id}`,
+      );
+      return response.data;
+    },
+    onError: (error: AxiosError) => {
+      return handleBackendError(error);
+    },
+    enabled: !!token && isRegistered && id !== "" && id !== undefined,
+  });
+
+export const useCreatePrinciple = (
+  token: string,
+  { pri, label, description }: PrincipleInput,
+) => {
+  const queryClient = useQueryClient();
+  return useMutation(
+    async () => {
+      const response = await APIClient(token).post<PrincipleResponse>(
+        `/registry/principles`,
+        {
+          pri,
+          label,
+          description,
+        },
+      );
+      return response.data;
+    },
+
+    {
+      onError: (error: AxiosError) => {
+        return handleBackendError(error);
+      },
+      onSuccess: () => {
+        queryClient.invalidateQueries(["principles"]);
+      },
+    },
+  );
+};
+
+export const useUpdatePrinciple = (
+  token: string,
+  id: string,
+  { pri, label, description }: PrincipleInput,
+) => {
+  const queryClient = useQueryClient();
+  return useMutation(
+    async () => {
+      const response = await APIClient(token).patch<PrincipleResponse>(
+        `/registry/principles/${id}`,
+        {
+          pri,
+          label,
+          description,
+        },
+      );
+      return response.data;
+    },
+
+    {
+      onError: (error: AxiosError) => {
+        return handleBackendError(error);
+      },
+      onSuccess: () => {
+        queryClient.invalidateQueries(["principle", id]);
+      },
+    },
+  );
+};
+
+export function useDeletePrinciple(token: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (principleId: string) => {
+      return APIClient(token).delete(`/registry/principles/${principleId}`);
+    },
+    // on success refresh principles query (so that the deleted principle dissapears from list)
+    onSuccess: () => {
+      queryClient.invalidateQueries(["principles"]);
+    },
+  });
+}

--- a/src/components/DeleteModal.tsx
+++ b/src/components/DeleteModal.tsx
@@ -1,5 +1,5 @@
 import { Modal, Button, ListGroup, ListGroupItem } from "react-bootstrap";
-import { FaTimes } from "react-icons/fa";
+import { FaTrash } from "react-icons/fa";
 
 interface DeleteModalProps {
   title: string;
@@ -27,7 +27,7 @@ export function DeleteModal(props: DeleteModalProps) {
     >
       <Modal.Header className="bg-danger text-white" closeButton>
         <Modal.Title id="contained-modal-title-vcenter">
-          <FaTimes className="me-2" /> {props.title}
+          <FaTrash className="me-2" /> {props.title}
         </Modal.Title>
       </Modal.Header>
       <Modal.Body>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -95,6 +95,9 @@ function Header() {
                         <Dropdown.Item as={Link} to="/motivations">
                           <FaShieldAlt /> Motivations
                         </Dropdown.Item>
+                        <Dropdown.Item as={Link} to="/principles">
+                          <FaShieldAlt /> Principles
+                        </Dropdown.Item>
                         <Dropdown.Item as={Link} to="/admin/users">
                           <FaShieldAlt /> Users
                         </Dropdown.Item>

--- a/src/pages/assessments/components/CriteriaTabs.tsx
+++ b/src/pages/assessments/components/CriteriaTabs.tsx
@@ -23,10 +23,10 @@ import {
   FaHeartPulse,
 } from "react-icons/fa6";
 import {
+  AssessmentPrinciple,
   AssessmentTest,
   CriterionImperative,
   // MetricAlgorithm,
-  Principle,
 } from "@/types";
 import {
   TestBinaryForm,
@@ -37,7 +37,7 @@ import { useEffect, useState } from "react";
 import { CriterionProgress } from "./CriterionProgress";
 
 type CriteriaTabsProps = {
-  principles: Principle[];
+  principles: AssessmentPrinciple[];
   resetActiveTab: boolean;
   handleGuide(id: string, title: string, text: string): void;
   handleGuideClose(): void;

--- a/src/pages/motivations/MotivationDetails.tsx
+++ b/src/pages/motivations/MotivationDetails.tsx
@@ -89,16 +89,6 @@ export default function MotivationDetails() {
             )}
           </h2>
         </Col>
-        <Col md="auto">
-          <Button
-            variant="secondary"
-            onClick={() => {
-              navigate(-1);
-            }}
-          >
-            Back
-          </Button>
-        </Col>
       </div>
       <Row className="mt-4 border-bottom pb-4">
         <Col md="auto">
@@ -109,7 +99,7 @@ export default function MotivationDetails() {
             onClick={() => {
               setShowUpdate(true);
             }}
-            className="btn-light border"
+            className="btn-light border-black"
           >
             Update Details
           </Button>
@@ -189,6 +179,16 @@ export default function MotivationDetails() {
           )}
         </div>
       </Row>
+      <div className="mt-4">
+        <Button
+          variant="secondary"
+          onClick={() => {
+            navigate(-1);
+          }}
+        >
+          Back
+        </Button>
+      </div>
     </div>
   );
 }

--- a/src/pages/principles/PrincipleDetails.tsx
+++ b/src/pages/principles/PrincipleDetails.tsx
@@ -1,0 +1,181 @@
+import { AuthContext } from "@/auth";
+import { useState, useContext, useEffect, useRef } from "react";
+import { Button, Col, Row } from "react-bootstrap";
+
+import { FaFile, FaTrash } from "react-icons/fa";
+
+import { useParams, useNavigate } from "react-router-dom";
+import { PrincipleModal } from "./components/PrincipleModal";
+import { AlertInfo, Principle } from "@/types";
+import { useDeletePrinciple, useGetPrinciple } from "@/api/services/principles";
+import { DeleteModal } from "@/components/DeleteModal";
+import toast from "react-hot-toast";
+
+interface DeleteModalConfig {
+  show: boolean;
+  title: string;
+  message: string;
+  itemId: string;
+  itemName: string;
+}
+
+export default function PrincipleDetails() {
+  const navigate = useNavigate();
+  const params = useParams();
+
+  const { keycloak, registered } = useContext(AuthContext)!;
+
+  // Delete Modal
+  const [deleteModalConfig, setDeleteModalConfig] = useState<DeleteModalConfig>(
+    {
+      show: false,
+      title: "Delete Principle",
+      message: "Are you sure you want to delete the following principle?",
+      itemId: "",
+      itemName: "",
+    },
+  );
+
+  const [principle, setPrinciple] = useState<Principle>();
+  const [showUpdate, setShowUpdate] = useState(false);
+  const { data: principleData } = useGetPrinciple({
+    id: params.id!,
+    token: keycloak?.token || "",
+    isRegistered: registered,
+  });
+
+  const mutationDelete = useDeletePrinciple(keycloak?.token || "");
+
+  const alert = useRef<AlertInfo>({
+    message: "",
+  });
+
+  const handleDeleteConfirmed = () => {
+    if (deleteModalConfig.itemId) {
+      const promise = mutationDelete
+        .mutateAsync(deleteModalConfig.itemId)
+        .catch((err) => {
+          alert.current = {
+            message: "Error during principle deletion!",
+          };
+          throw err;
+        })
+        .then(() => {
+          alert.current = {
+            message: "Principle succesfully deleted.",
+          };
+          setDeleteModalConfig({
+            ...deleteModalConfig,
+            show: false,
+            itemId: "",
+            itemName: "",
+          });
+          navigate(-1);
+        });
+      toast.promise(promise, {
+        loading: "Deleting...",
+        success: () => `${alert.current.message}`,
+        error: () => `${alert.current.message}`,
+      });
+    }
+  };
+
+  useEffect(() => {
+    setPrinciple(principleData);
+  }, [principleData]);
+
+  return (
+    <div className="pb-4">
+      <DeleteModal
+        show={deleteModalConfig.show}
+        title={deleteModalConfig.title}
+        message={deleteModalConfig.message}
+        itemId={deleteModalConfig.itemId}
+        itemName={deleteModalConfig.itemName}
+        onHide={() => {
+          setDeleteModalConfig({ ...deleteModalConfig, show: false });
+        }}
+        onDelete={handleDeleteConfirmed}
+      />
+      <PrincipleModal
+        principle={principle || null}
+        show={showUpdate}
+        onHide={() => {
+          setShowUpdate(false);
+        }}
+      />
+      <div className="cat-view-heading-block row border-bottom">
+        <Col>
+          <h2 className="text-muted cat-view-heading ">
+            Principle Details
+            {principle && (
+              <p className="lead cat-view-lead">
+                Principle id:{" "}
+                <strong className="badge bg-secondary">{principle.id}</strong>
+              </p>
+            )}
+          </h2>
+        </Col>
+        <Col md="auto">
+          {principleData && (
+            <Button
+              variant="danger"
+              onClick={() => {
+                setDeleteModalConfig({
+                  ...deleteModalConfig,
+                  show: true,
+                  itemId: principleData.id,
+                  itemName: `${principleData.label} - ${principleData.pri}`,
+                });
+              }}
+            >
+              <FaTrash className="me-2" />
+              Delete Principle
+            </Button>
+          )}
+        </Col>
+      </div>
+      <Row className="mt-4 border-bottom pb-4">
+        <Col md="auto">
+          <div className="p-3 text-center">
+            <FaFile size={"4rem"} className="text-secondary" />
+          </div>
+          <Button
+            onClick={() => {
+              setShowUpdate(true);
+            }}
+            className="btn-light border-black"
+          >
+            Update Details
+          </Button>
+        </Col>
+        <Col>
+          <div>
+            <strong>Pri:</strong> {principle?.pri}
+          </div>
+          <div>
+            <strong>Label:</strong> {principle?.label}
+          </div>
+          <div>
+            <div>
+              <strong>Description:</strong>
+            </div>
+            <div>
+              <small>{principle?.description}</small>
+            </div>
+          </div>
+        </Col>
+      </Row>
+      <div className="mt-4">
+        <Button
+          variant="secondary"
+          onClick={() => {
+            navigate("/principles");
+          }}
+        >
+          Back
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/principles/Principles.tsx
+++ b/src/pages/principles/Principles.tsx
@@ -1,0 +1,281 @@
+import { AuthContext } from "@/auth";
+import { useContext, useEffect, useRef, useState } from "react";
+import { Alert, Button, OverlayTrigger, Table, Tooltip } from "react-bootstrap";
+import {
+  FaArrowLeft,
+  FaArrowRight,
+  FaBars,
+  FaExclamationTriangle,
+  FaPlus,
+  FaTrash,
+} from "react-icons/fa";
+
+import {
+  useDeletePrinciple,
+  useGetPrinciples,
+} from "@/api/services/principles";
+import { AlertInfo, Principle } from "@/types";
+import { Link } from "react-router-dom";
+import { PrincipleModal } from "./components/PrincipleModal";
+import toast from "react-hot-toast";
+import { DeleteModal } from "@/components/DeleteModal";
+
+type Pagination = {
+  page: number;
+  size: number;
+};
+
+interface DeleteModalConfig {
+  show: boolean;
+  title: string;
+  message: string;
+  itemId: string;
+  itemName: string;
+}
+
+const tooltipView = <Tooltip id="tip-restore">View Principle Details</Tooltip>;
+const tooltipDelete = <Tooltip id="tip-restore">Delete Principle</Tooltip>;
+
+// the main component that lists the motivations in a table
+export default function Principles() {
+  const { keycloak, registered } = useContext(AuthContext)!;
+
+  const alert = useRef<AlertInfo>({
+    message: "",
+  });
+
+  // Delete Modal
+  const [deleteModalConfig, setDeleteModalConfig] = useState<DeleteModalConfig>(
+    {
+      show: false,
+      title: "Delete Principle",
+      message: "Are you sure you want to delete the following principle?",
+      itemId: "",
+      itemName: "",
+    },
+  );
+
+  const mutationDelete = useDeletePrinciple(keycloak?.token || "");
+
+  const handleDeleteConfirmed = () => {
+    if (deleteModalConfig.itemId) {
+      const promise = mutationDelete
+        .mutateAsync(deleteModalConfig.itemId)
+        .catch((err) => {
+          alert.current = {
+            message: "Error during principle deletion!",
+          };
+          throw err;
+        })
+        .then(() => {
+          alert.current = {
+            message: "Principle succesfully deleted.",
+          };
+          setDeleteModalConfig({
+            ...deleteModalConfig,
+            show: false,
+            itemId: "",
+            itemName: "",
+          });
+        });
+      toast.promise(promise, {
+        loading: "Deleting...",
+        success: () => `${alert.current.message}`,
+        error: () => `${alert.current.message}`,
+      });
+    }
+  };
+
+  const [opts, setOpts] = useState<Pagination>({
+    page: 1,
+    size: 10,
+  });
+
+  const [showCreate, setShowCreate] = useState(false);
+
+  // handler for changing page size
+  const handleChangePageSize = (evt: { target: { value: string } }) => {
+    setOpts({ ...opts, page: 1, size: parseInt(evt.target.value) });
+  };
+
+  // data get list of motivations
+  const { isLoading, data, refetch } = useGetPrinciples({
+    size: opts.size,
+    page: opts.page,
+    token: keycloak?.token || "",
+    isRegistered: registered,
+  });
+
+  // refetch users when parameters change
+  useEffect(() => {
+    refetch();
+  }, [opts, refetch]);
+
+  // get the principle data to create the table
+  const principles: Principle[] = data ? data?.content : [];
+
+  return (
+    <div>
+      <DeleteModal
+        show={deleteModalConfig.show}
+        title={deleteModalConfig.title}
+        message={deleteModalConfig.message}
+        itemId={deleteModalConfig.itemId}
+        itemName={deleteModalConfig.itemName}
+        onHide={() => {
+          setDeleteModalConfig({ ...deleteModalConfig, show: false });
+        }}
+        onDelete={handleDeleteConfirmed}
+      />
+      <PrincipleModal
+        principle={null}
+        show={showCreate}
+        onHide={() => {
+          setShowCreate(false);
+        }}
+      />
+      <div className="cat-view-heading-block row border-bottom">
+        <div className="col">
+          <h2 className="text-muted cat-view-heading ">
+            Principles
+            <p className="lead cat-view-lead">Manage principles.</p>
+          </h2>
+        </div>
+        <div className="col-md-auto cat-heading-right">
+          <Button
+            variant="warning"
+            onClick={() => {
+              setShowCreate(true);
+            }}
+          >
+            <FaPlus /> Create New
+          </Button>
+        </div>
+      </div>
+      <div>
+        <Table hover>
+          <thead>
+            <tr className="table-light">
+              <th>
+                <span>MTV</span>
+              </th>
+              <th>
+                <span>Label</span>
+              </th>
+              <th>
+                <span>Description</span>
+              </th>
+              <th>
+                <span>Modified</span>
+              </th>
+              <th></th>
+            </tr>
+          </thead>
+          {principles.length > 0 ? (
+            <tbody>
+              {principles.map((item) => {
+                return (
+                  <tr key={item.id}>
+                    <td className="align-middle">{item.pri}</td>
+                    <td className="align-middle">{item.label}</td>
+
+                    <td className="align-middle">{item.description}</td>
+                    <td className="align-middle">
+                      <small>{item.last_touch.split(".")[0]}</small>
+                    </td>
+                    <td>
+                      <div className="d-flex flex-nowrap">
+                        <OverlayTrigger placement="top" overlay={tooltipView}>
+                          <Link
+                            className="btn btn-light btn-sm m-1"
+                            to={`/principles/${item.id}`}
+                          >
+                            <FaBars />
+                          </Link>
+                        </OverlayTrigger>
+                        <OverlayTrigger placement="top" overlay={tooltipDelete}>
+                          <Button
+                            className="btn btn-light btn-sm m-1"
+                            onClick={() => {
+                              setDeleteModalConfig({
+                                ...deleteModalConfig,
+                                show: true,
+                                itemId: item.id,
+                                itemName: `${item.label} - ${item.pri}`,
+                              });
+                            }}
+                          >
+                            <FaTrash />
+                          </Button>
+                        </OverlayTrigger>
+                      </div>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          ) : null}
+        </Table>
+        {!isLoading && principles.length === 0 && (
+          <Alert variant="warning" className="text-center mx-auto">
+            <h3>
+              <FaExclamationTriangle />
+            </h3>
+            <h5>No data found...</h5>
+          </Alert>
+        )}
+        <div className="d-flex justify-content-end">
+          <div>
+            <span className="mx-1">rows per page: </span>
+            <select
+              name="per-page"
+              value={opts.size.toString() || "20"}
+              id="per-page"
+              onChange={handleChangePageSize}
+            >
+              <option value="5">5</option>
+              <option value="10">10</option>
+              <option value="15">15</option>
+              <option value="20">20</option>
+            </select>
+          </div>
+
+          {data && data.number_of_page && data.total_pages && (
+            <div className="ms-4">
+              <span>
+                {(data.number_of_page - 1) * opts.size + 1} -{" "}
+                {(data.number_of_page - 1) * opts.size + data.size_of_page} of{" "}
+                {data.total_elements}
+              </span>
+              <span
+                onClick={() => {
+                  setOpts({ ...opts, page: opts.page - 1 });
+                }}
+                className={`ms-4 btn py-0 btn-light btn-small ${
+                  opts.page === 1 ? "disabled text-muted" : null
+                }`}
+              >
+                <FaArrowLeft />
+              </span>
+              <span
+                onClick={() => {
+                  setOpts({ ...opts, page: opts.page + 1 });
+                }}
+                className={`btn py-0 btn-light btn-small" ${
+                  data?.total_pages > data?.number_of_page
+                    ? null
+                    : "disabled text-muted"
+                }`}
+              >
+                <FaArrowRight />
+              </span>
+            </div>
+          )}
+        </div>
+      </div>
+      <div className="row py-3 p-4">
+        <div className="col"></div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/principles/components/PrincipleModal.tsx
+++ b/src/pages/principles/components/PrincipleModal.tsx
@@ -1,0 +1,264 @@
+import {
+  useCreatePrinciple,
+  useUpdatePrinciple,
+} from "@/api/services/principles";
+import { AuthContext } from "@/auth";
+import { AlertInfo, Principle, PrincipleInput } from "@/types";
+import { useContext, useEffect, useRef, useState } from "react";
+import {
+  Modal,
+  Button,
+  Form,
+  InputGroup,
+  Row,
+  Col,
+  OverlayTrigger,
+  Tooltip,
+} from "react-bootstrap";
+import toast from "react-hot-toast";
+import { FaFile, FaInfoCircle } from "react-icons/fa";
+
+interface PrincipleModalProps {
+  principle: Principle | null;
+  show: boolean;
+  onHide: () => void;
+}
+/**
+ * Modal component for creating/editing a principle
+ */
+export function PrincipleModal(props: PrincipleModalProps) {
+  const alert = useRef<AlertInfo>({
+    message: "",
+  });
+
+  const { keycloak } = useContext(AuthContext)!;
+
+  const [principleInput, setPrincipleInput] = useState<PrincipleInput>({
+    pri: "",
+    label: "",
+    description: "",
+  });
+
+  const [showErrors, setShowErrors] = useState(false);
+
+  function handleValidate() {
+    setShowErrors(true);
+    return (
+      principleInput.pri !== "" &&
+      principleInput.label !== "" &&
+      principleInput.description !== ""
+    );
+  }
+
+  const mutateCreate = useCreatePrinciple(
+    keycloak?.token || "",
+    principleInput,
+  );
+
+  const mutateUpdate = useUpdatePrinciple(
+    keycloak?.token || "",
+    props.principle?.id || "",
+    principleInput,
+  );
+
+  useEffect(() => {
+    if (props.show) {
+      if (props.principle) {
+        setPrincipleInput({
+          pri: props.principle.pri,
+          label: props.principle.label,
+          description: props.principle.description,
+        });
+      } else {
+        setPrincipleInput({
+          pri: "",
+          label: "",
+          description: "",
+        });
+      }
+
+      setShowErrors(false);
+    }
+  }, [props.show, props.principle]);
+
+  // handle backend call to add a new principle
+  function handleCreate() {
+    const promise = mutateCreate
+      .mutateAsync()
+      .catch((err) => {
+        alert.current = {
+          message: "Error: " + err.response.data.message,
+        };
+        throw err;
+      })
+      .then(() => {
+        props.onHide();
+        alert.current = {
+          message: "Principle Created!",
+        };
+      });
+    toast.promise(promise, {
+      loading: "Creating Principle...",
+      success: () => `${alert.current.message}`,
+      error: () => `${alert.current.message}`,
+    });
+  }
+
+  // handle backend call to update an existing principle
+  function handleUpdate() {
+    const promise = mutateUpdate
+      .mutateAsync()
+      .catch((err) => {
+        alert.current = {
+          message: "Error: " + err.response.data.message,
+        };
+        throw err;
+      })
+      .then(() => {
+        props.onHide();
+        alert.current = {
+          message: "Principle Updated!",
+        };
+      });
+    toast.promise(promise, {
+      loading: "Updating Principle...",
+      success: () => `${alert.current.message}`,
+      error: () => `${alert.current.message}`,
+    });
+  }
+
+  return (
+    <Modal
+      {...props}
+      size="lg"
+      aria-labelledby="contained-modal-title-vcenter"
+      centered
+    >
+      <Modal.Header className="bg-success text-white" closeButton>
+        <Modal.Title id="contained-modal-title-vcenter">
+          <FaFile className="me-2" />{" "}
+          {props.principle === null ? "Create new" : "Edit"} Principle
+        </Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        <div>
+          <Row>
+            <Col xs={3}>
+              <InputGroup className="mt-2">
+                <OverlayTrigger
+                  key="top"
+                  placement="top"
+                  overlay={
+                    <Tooltip id={`tooltip-top`}>
+                      Acronym to quickly distinguish the Principle item
+                    </Tooltip>
+                  }
+                >
+                  <InputGroup.Text id="label-principle-pri">
+                    <FaInfoCircle className="me-2" /> Pri (*):
+                  </InputGroup.Text>
+                </OverlayTrigger>
+                <Form.Control
+                  id="input-principle-pri"
+                  value={principleInput.pri}
+                  onChange={(e) => {
+                    setPrincipleInput({
+                      ...principleInput,
+                      pri: e.target.value,
+                    });
+                  }}
+                  aria-describedby="label-principle-pri"
+                />
+              </InputGroup>
+              {showErrors && principleInput.pri === "" && (
+                <span className="text-danger">Required</span>
+              )}
+            </Col>
+            <Col>
+              <InputGroup className="mt-2">
+                <OverlayTrigger
+                  key="top"
+                  placement="top"
+                  overlay={
+                    <Tooltip id={`tooltip-top`}>
+                      Label (Name) of the principle item
+                    </Tooltip>
+                  }
+                >
+                  <InputGroup.Text id="label-principle-label">
+                    <FaInfoCircle className="me-2" /> Label (*):
+                  </InputGroup.Text>
+                </OverlayTrigger>
+                <Form.Control
+                  id="input-principle-label"
+                  aria-describedby="label-principle-label"
+                  value={principleInput.label}
+                  onChange={(e) => {
+                    setPrincipleInput({
+                      ...principleInput,
+                      label: e.target.value,
+                    });
+                  }}
+                />
+              </InputGroup>
+              {showErrors && principleInput.label === "" && (
+                <span className="text-danger">Required</span>
+              )}
+            </Col>
+          </Row>
+          <Row className="mt-2">
+            <Col className="mt-1">
+              <OverlayTrigger
+                key="top"
+                placement="top"
+                overlay={
+                  <Tooltip id={`tooltip-top`}>
+                    Short description of this principle item
+                  </Tooltip>
+                }
+              >
+                <span id="label-principle-description">
+                  <FaInfoCircle className="ms-1 me-2" /> Description (*):
+                </span>
+              </OverlayTrigger>
+              <Form.Control
+                className="mt-1"
+                as="textarea"
+                rows={2}
+                value={principleInput.description}
+                onChange={(e) => {
+                  setPrincipleInput({
+                    ...principleInput,
+                    description: e.target.value,
+                  });
+                }}
+              />
+              {showErrors && principleInput.description === "" && (
+                <span className="text-danger">Required</span>
+              )}
+            </Col>
+          </Row>
+        </div>
+      </Modal.Body>
+      <Modal.Footer className="d-flex justify-content-between">
+        <Button className="btn-secondary" onClick={props.onHide}>
+          Close
+        </Button>
+        <Button
+          className="btn-success"
+          onClick={() => {
+            if (handleValidate() === true) {
+              if (props.principle === null) {
+                handleCreate();
+              } else {
+                handleUpdate();
+              }
+            }
+          }}
+        >
+          {props.principle === null ? "Create" : "Update"}
+        </Button>
+      </Modal.Footer>
+    </Modal>
+  );
+}

--- a/src/types/assessment.ts
+++ b/src/types/assessment.ts
@@ -33,7 +33,7 @@ export interface Assessment {
   actor: AssessmentActor;
   organisation: AssessmentOrg;
   result: AssessmentResult;
-  principles: Principle[];
+  principles: AssessmentPrinciple[];
   published: boolean;
   shared_with_user: boolean;
 }
@@ -76,7 +76,7 @@ export interface AssessmentResult {
 }
 
 /** An assessment contains a list of principles */
-export interface Principle {
+export interface AssessmentPrinciple {
   id: string;
   name: string;
   criteria: Criterion[];

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -3,3 +3,4 @@ export * from "./profile";
 export * from "./validation";
 export * from "./assessment";
 export * from "./motivation";
+export * from "./principle";

--- a/src/types/principle.ts
+++ b/src/types/principle.ts
@@ -1,0 +1,18 @@
+import { ResponsePage } from "./common";
+
+export interface Principle {
+  id: string;
+  pri: string;
+  label: string;
+  description: string;
+  populated_by: string | null;
+  last_touch: string;
+}
+
+export interface PrincipleInput {
+  pri: string;
+  label: string;
+  description: string;
+}
+
+export type PrincipleResponse = ResponsePage<Principle[]>;


### PR DESCRIPTION
## Goal
Support
- Viewing list of principles
- View Principle details
- Update Principle details
- Create new Principle
- Delete Principle

## Implementation
- Convert old principe type to AssessmentPrinciple to distinguish it and avoid conflicts with new Principle type declarations
- Implement Principle related types
- Implement Principle related backend service query/mutation hooks (create, read, update, delete)
- Implement Principles component to display list of principles
- Implement PrinciplesDetails component to display detailed view of a principle
- Implement PrincipleModal to insert/edit details for a principle
- Use DeleteItem Modal to confirm deletion of a principle
- Minor cleanup and fixes (back button, delete icon)