### PR TITLE
CAT-521 Fix evidence url validation - trim input

### DIFF
--- a/src/pages/assessments/components/tests/EvidenceURLS.tsx
+++ b/src/pages/assessments/components/tests/EvidenceURLS.tsx
@@ -97,7 +97,7 @@ export const EvidenceURLS = (props: EvidenceURLSProps) => {
               id="input-add-url"
               value={newURL.url}
               onChange={(e) => {
-                setNewURL({ ...newURL, url: e.target.value });
+                setNewURL({ ...newURL, url: e.target.value.trim() });
                 setError("");
               }}
               aria-describedby="label-add-url"


### PR DESCRIPTION
Trim the input value on Evidence URL field before validating