### PR TITLE
CAT-546 Select Imperative when adding new Criteria to Assessment Type

### DIFF
--- a/src/api/services/motivations.ts
+++ b/src/api/services/motivations.ts
@@ -10,6 +10,7 @@ import { handleBackendError } from "@/utils";
 import {
   ApiOptions,
   CriImp,
+  ImperativeResponse,
   Motivation,
   MotivationActorResponse,
   MotivationInput,
@@ -125,6 +126,33 @@ export const useGetAllPrinciples = ({
     queryFn: async ({ pageParam = 1 }) => {
       const response = await APIClient(token).get<PrincipleResponse>(
         `/registry/principles?size=${size}&page=${pageParam}`,
+      );
+      return response.data;
+    },
+    getNextPageParam: (lastPage) => {
+      if (lastPage.number_of_page < lastPage.total_pages) {
+        return lastPage.number_of_page + 1;
+      } else {
+        return undefined;
+      }
+    },
+    onError: (error: AxiosError) => {
+      return handleBackendError(error);
+    },
+    retry: false,
+    enabled: isRegistered,
+  });
+
+export const useGetAllImperatives = ({
+  token,
+  isRegistered,
+  size,
+}: ApiOptions) =>
+  useInfiniteQuery({
+    queryKey: ["all-imperatives"],
+    queryFn: async ({ pageParam = 1 }) => {
+      const response = await APIClient(token).get<ImperativeResponse>(
+        `/registry/imperatives?size=${size}&page=${pageParam}`,
       );
       return response.data;
     },

--- a/src/pages/assessments/AssessmentEdit.tsx
+++ b/src/pages/assessments/AssessmentEdit.tsx
@@ -6,7 +6,7 @@ import {
   Assessment,
   AssessmentSubject,
   AssessmentTest,
-  CriterionImperative,
+  AssessmentCriterionImperative,
   AlertInfo,
   AssessmentEditMode,
   ActorOrgAsmtType,
@@ -519,7 +519,7 @@ const AssessmentEdit = ({
       // update criteria result reference tables
       newAssessment.principles.forEach((principle) => {
         principle.criteria.forEach((criterion) => {
-          if (criterion.imperative === CriterionImperative.Must) {
+          if (criterion.imperative === AssessmentCriterionImperative.Must) {
             mandatory.push(criterion.metric.result);
           } else {
             optional.push(criterion.metric.result);

--- a/src/pages/assessments/AssessmentView.tsx
+++ b/src/pages/assessments/AssessmentView.tsx
@@ -8,7 +8,7 @@ import { Button, Card, Col, Row } from "react-bootstrap";
 import { useNavigate } from "react-router-dom";
 import imgAssessmentPass from "@/assets/assessment-pass.png";
 import Accordion from "react-bootstrap/Accordion";
-import { Assessment, CriterionImperative } from "@/types";
+import { Assessment, AssessmentCriterionImperative } from "@/types";
 
 interface Stats {
   total_principles: number;
@@ -33,7 +33,7 @@ function gatherStats(assessment: Assessment | undefined): Stats {
     assessment.principles.forEach((pri) => {
       total_criteria += pri.criteria.length;
       pri.criteria.forEach((cri) => {
-        if (cri.imperative == CriterionImperative.Must) {
+        if (cri.imperative == AssessmentCriterionImperative.Must) {
           total_mandatory += 1;
           if (cri.metric.result !== null) completed_mandatory = +1;
         } else {

--- a/src/pages/assessments/components/CriteriaTabs.tsx
+++ b/src/pages/assessments/components/CriteriaTabs.tsx
@@ -25,7 +25,7 @@ import {
 import {
   AssessmentPrinciple,
   AssessmentTest,
-  CriterionImperative,
+  AssessmentCriterionImperative,
   // MetricAlgorithm,
 } from "@/types";
 import {
@@ -135,7 +135,7 @@ export function CriteriaTabs(props: CriteriaTabsProps) {
               <div className="d-flex">
                 <h6
                   className={
-                    criterion.imperative === CriterionImperative.Must
+                    criterion.imperative === AssessmentCriterionImperative.Must
                       ? "fw-bold"
                       : ""
                   }
@@ -149,7 +149,8 @@ export function CriteriaTabs(props: CriteriaTabsProps) {
                     <FaCheckCircle className="ms-2 text-success" />
                   )}
                 </h6>
-                {criterion.imperative === CriterionImperative.Must && (
+                {criterion.imperative ===
+                  AssessmentCriterionImperative.Must && (
                   <div>
                     <small
                       style={{ fontSize: "0.6rem" }}
@@ -220,7 +221,7 @@ export function CriteriaTabs(props: CriteriaTabsProps) {
                   {criterion.id}: {criterion.name}
                 </span>
 
-                {criterion.imperative === CriterionImperative.Must ? (
+                {criterion.imperative === AssessmentCriterionImperative.Must ? (
                   <span className="badge bg-success bg-small ms-4 align-middle">
                     Required
                   </span>

--- a/src/types/assessment.ts
+++ b/src/types/assessment.ts
@@ -87,13 +87,13 @@ export interface AssessmentPrinciple {
 export interface AssessmentCriterion {
   id: string;
   name: string;
-  imperative: CriterionImperative;
+  imperative: AssessmentCriterionImperative;
   metric: Metric;
   description?: string;
 }
 
 /** Each criterion can be either mandatory (must) or optional (should) */
-export enum CriterionImperative {
+export enum AssessmentCriterionImperative {
   Must = "must",
   Should = "should",
 }

--- a/src/types/criterion.ts
+++ b/src/types/criterion.ts
@@ -6,13 +6,19 @@ export interface Criterion {
   cri: string;
   label: string;
   description: string;
-  imperative: string;
+  imperative: CriterionImperative;
   type_criterion_id: string;
   url: string;
   criterion_parent_id: string;
   populated_by: string;
   last_touch: string;
   principles: Principle[];
+}
+
+export interface CriterionImperative {
+  id: string;
+  imp: string;
+  label: string;
 }
 
 export type CriterionResponse = ResponsePage<Criterion[]>;

--- a/src/types/motivation.ts
+++ b/src/types/motivation.ts
@@ -42,6 +42,15 @@ export interface MotivationType {
   version: string;
 }
 
+export interface Imperative {
+  id: string;
+  imp: string;
+  label: string;
+  description: string;
+  populated_by: string;
+  last_touch: string;
+}
+
 export interface Relation {
   id: string;
   label: string;
@@ -53,6 +62,8 @@ export interface CriImp {
   criterion_id: string;
   imperative_id: string;
 }
+
+export type ImperativeResponse = ResponsePage<Imperative[]>;
 
 export type RelationResponse = ResponsePage<Relation[]>;
 

--- a/src/utils/assessment.ts
+++ b/src/utils/assessment.ts
@@ -2,7 +2,7 @@
 
 import {
   Assessment,
-  CriterionImperative,
+  AssessmentCriterionImperative,
   Metric,
   ResultStats,
   AssessmentTest,
@@ -58,7 +58,7 @@ export function evalAssessment(
   if (assessment.principles) {
     assessment.principles.forEach((principle) => {
       principle.criteria.forEach((criterion) => {
-        if (criterion.imperative === CriterionImperative.Must) {
+        if (criterion.imperative === AssessmentCriterionImperative.Must) {
           mandatory.push(criterion.metric.result);
         } else {
           optional.push(criterion.metric.result);


### PR DESCRIPTION
- [x] Rename old CriterionImperative types to AssessmentCriterionImperative to avoid namespacing conflicts
- [x] Update Criterion schema to support Imperative object (defined as CriterionImperative type)
- [x] Implement useGetAllImperatives backend query hook
- [x] Update MotivationActorCriteria component to fetch all available imperatives
- [x] Update MotivationActorCriteria state variables to support changing imperatives per selected criteria
- [x] For each criterion in SelectedCriteria list add a dropdown element that allows selecting imperatives