### PR TITLE
CAT-545 Add clone motivation button

### DIFF
--- a/src/api/services/motivations.ts
+++ b/src/api/services/motivations.ts
@@ -195,7 +195,7 @@ export const useGetRelations = ({ token, isRegistered, size }: ApiOptions) =>
 
 export const useCreateMotivation = (
   token: string,
-  { mtv, label, description, motivation_type_id }: MotivationInput,
+  { mtv, label, description, motivation_type_id, based_on }: MotivationInput,
 ) => {
   const queryClient = useQueryClient();
   return useMutation(
@@ -207,6 +207,7 @@ export const useCreateMotivation = (
           label,
           description,
           motivation_type_id,
+          based_on,
         },
       );
       return response.data;

--- a/src/pages/motivations/MotivationDetails.tsx
+++ b/src/pages/motivations/MotivationDetails.tsx
@@ -72,6 +72,8 @@ export default function MotivationDetails() {
           }}
         />
         <MotivationModal
+          cloneId={null}
+          cloneName=""
           motivation={motivation || null}
           show={showUpdate}
           onHide={() => {

--- a/src/pages/motivations/Motivations.tsx
+++ b/src/pages/motivations/Motivations.tsx
@@ -7,6 +7,7 @@ import {
   FaBars,
   FaExclamationTriangle,
   FaPlus,
+  FaRegClone,
 } from "react-icons/fa";
 
 import { useGetMotivations } from "@/api/services/motivations";
@@ -19,7 +20,10 @@ type Pagination = {
   size: number;
 };
 
-const tooltipView = <Tooltip id="tip-restore">View Motivation Details</Tooltip>;
+type Clone = {
+  id: string | null;
+  name: string;
+};
 
 // the main component that lists the motivations in a table
 export default function Motivations() {
@@ -31,6 +35,7 @@ export default function Motivations() {
   });
 
   const [showCreate, setShowCreate] = useState(false);
+  const [clone, setClone] = useState<Clone>({ id: null, name: "" });
 
   // handler for changing page size
   const handleChangePageSize = (evt: { target: { value: string } }) => {
@@ -56,10 +61,13 @@ export default function Motivations() {
   return (
     <div>
       <MotivationModal
+        cloneId={clone.id}
+        cloneName={clone.name}
         motivation={null}
         show={showCreate}
         onHide={() => {
           setShowCreate(false);
+          setClone({ id: null, name: "" });
         }}
       />
       <div className="cat-view-heading-block row border-bottom">
@@ -113,13 +121,38 @@ export default function Motivations() {
                     </td>
                     <td>
                       <div className="d-flex flex-nowrap">
-                        <OverlayTrigger placement="top" overlay={tooltipView}>
+                        <OverlayTrigger
+                          placement="top"
+                          overlay={
+                            <Tooltip id="tip-view">
+                              View Motivation Details
+                            </Tooltip>
+                          }
+                        >
                           <Link
                             className="btn btn-light btn-sm m-1"
                             to={`/motivations/${item.id}`}
                           >
                             <FaBars />
                           </Link>
+                        </OverlayTrigger>
+                        <OverlayTrigger
+                          placement="top"
+                          overlay={
+                            <Tooltip id="tip-clone">
+                              Create a new motivation based on this one (clone)
+                            </Tooltip>
+                          }
+                        >
+                          <span
+                            className="btn btn-light btn-sm m-1"
+                            onClick={() => {
+                              setClone({ id: item.id, name: item.label });
+                              setShowCreate(true);
+                            }}
+                          >
+                            <FaRegClone />
+                          </span>
                         </OverlayTrigger>
                       </div>
                     </td>

--- a/src/pages/motivations/components/MotivationModal.tsx
+++ b/src/pages/motivations/components/MotivationModal.tsx
@@ -20,11 +20,15 @@ import {
   Col,
   OverlayTrigger,
   Tooltip,
+  Alert,
 } from "react-bootstrap";
 import toast from "react-hot-toast";
 import { FaFile, FaInfoCircle } from "react-icons/fa";
+import { FaTriangleExclamation } from "react-icons/fa6";
 
 interface MotivationModalProps {
+  cloneId: string | null;
+  cloneName: string;
   motivation: Motivation | null;
   show: boolean;
   onHide: () => void;
@@ -44,6 +48,7 @@ export function MotivationModal(props: MotivationModalProps) {
     label: "",
     description: "",
     motivation_type_id: "",
+    based_on: props.cloneId,
   });
   const [motivationTypes, setMotivationTypes] = useState<MotivationType[]>([]);
   const [showErrors, setShowErrors] = useState(false);
@@ -82,6 +87,7 @@ export function MotivationModal(props: MotivationModalProps) {
           label: props.motivation.label,
           description: props.motivation.description,
           motivation_type_id: props.motivation.motivation_type_id || "",
+          based_on: props.cloneId,
         });
       } else {
         setMotivationInput({
@@ -89,12 +95,13 @@ export function MotivationModal(props: MotivationModalProps) {
           label: "",
           description: "",
           motivation_type_id: "",
+          based_on: props.cloneId,
         });
       }
 
       setShowErrors(false);
     }
-  }, [props.show, props.motivation]);
+  }, [props.show, props.motivation, props.cloneId]);
 
   useEffect(() => {
     // gather all actor/org/type mappings in one array
@@ -161,7 +168,8 @@ export function MotivationModal(props: MotivationModalProps) {
 
   return (
     <Modal
-      {...props}
+      show={props.show}
+      onHide={props.onHide}
       size="lg"
       aria-labelledby="contained-modal-title-vcenter"
       centered
@@ -174,6 +182,15 @@ export function MotivationModal(props: MotivationModalProps) {
       </Modal.Header>
       <Modal.Body>
         <div>
+          {props.cloneId && (
+            <Alert variant="success">
+              <FaTriangleExclamation /> The new motivation will be based on:{" "}
+              <strong className="ms-2">{props.cloneName}</strong>{" "}
+              <span className="badge bg-light ms-2 border">
+                <code>{props.cloneId}</code>
+              </span>
+            </Alert>
+          )}
           <Row>
             <Col xs={3}>
               <InputGroup className="mt-2">

--- a/src/types/motivation.ts
+++ b/src/types/motivation.ts
@@ -20,6 +20,7 @@ export interface MotivationInput {
   label: string;
   description: string;
   motivation_type_id: string;
+  based_on: string | null;
 }
 
 export interface MotivationActor {


### PR DESCRIPTION
### Goal
Give the ability to the user to create a new motivation based on a previous one (clone)

### Implementation
- [x] Add extra parameter `based_on` in MotivationInput type
- [x] Update useCreateMotivation backend hook to use the `based_on` parameter when available
- [x] Update Motivations component to keep a state var of a clone object (id, name properties). This state var is filled when the user clicks the clone action button in a motivation table row. 
- [x] Add a clone motivation button action on Motivations table. This button fills in the state variable clone object with the motivation id and name
- [x] Pass the clone state variable to the MotivationCreate Modal
- [x] Update MotivationCreate modal to display an information box when clone object is set
- [x] Update based_on parameter based on the id of the clone object