### PR TITLE
CAT-555 Fix share badges in new Assessment Table

### DIFF
--- a/src/api/services/assessments.ts
+++ b/src/api/services/assessments.ts
@@ -83,7 +83,7 @@ export const useGetAssessments = ({
   assessmentTypeId,
 }: ApiAssessments) =>
   useQuery({
-    queryKey: ["users"],
+    queryKey: ["assessments"],
     queryFn: async () => {
       let url = isPublic
         ? `/assessments/by-type/${assessmentTypeId}/by-actor/${actorId}?size=${size}&page=${page}`

--- a/src/pages/assessments/AssessmentsList.tsx
+++ b/src/pages/assessments/AssessmentsList.tsx
@@ -11,6 +11,7 @@ import {
   FaFileImport,
   FaShare,
   FaEye,
+  FaUsers,
 } from "react-icons/fa";
 import {
   Alert,
@@ -21,6 +22,7 @@ import {
   OverlayTrigger,
   Tooltip,
   Table,
+  Badge,
 } from "react-bootstrap";
 import { AssessmentListItem, AssessmentFiltersType, AlertInfo } from "@/types";
 import {
@@ -302,7 +304,6 @@ function AssessmentsList({ listPublic = false }: AssessmentListProps) {
                     setFilters({ ...filters, subject_type: e.target.value });
                     refetch();
                   }}
-                  defaultValue=""
                   value={filters.subject_type}
                 >
                   <option value="">Select subject type...</option>
@@ -333,7 +334,6 @@ function AssessmentsList({ listPublic = false }: AssessmentListProps) {
                     setFilters({ ...filters, subject_name: e.target.value });
                     refetch();
                   }}
-                  defaultValue=""
                   value={filters.subject_name}
                 >
                   <option value={""}>Select subject name...</option>
@@ -400,7 +400,29 @@ function AssessmentsList({ listPublic = false }: AssessmentListProps) {
                 {assessments.map((item) => {
                   return (
                     <tr key={item.id}>
-                      <td className="align-middle">{item.name}</td>
+                      <td className="align-middle">
+                        <div>{item.name}</div>
+                        {item.shared_to_user && (
+                          <Badge
+                            pill
+                            bg="light"
+                            text="secondary"
+                            className="border"
+                          >
+                            shared with me <FaUsers className="ms-1" />
+                          </Badge>
+                        )}
+                        {item.shared_by_user && (
+                          <Badge
+                            pill
+                            bg="light"
+                            text="secondary"
+                            className="border"
+                          >
+                            shared <FaUsers className="ms-1" />
+                          </Badge>
+                        )}
+                      </td>
                       <td className="align-middle">{item.type}</td>
                       <td className="align-middle">
                         {item.compliance === null ? (

--- a/src/types/assessment.ts
+++ b/src/types/assessment.ts
@@ -219,6 +219,7 @@ export interface AssessmentListItem {
   template_id: number;
   published: boolean;
   shared_to_user: boolean;
+  shared_by_user: boolean;
   shared: boolean;
   subject_type: string;
   subject_name: string;


### PR DESCRIPTION
- [x] Add missing share badges in new Assessment Table
- [x] Use shared_by_user as a share indication so that the user can see what has shared to others
- [x] Fix backend query cache key for assessment list
- [x] Remove defaultValue param from filter Select elements - keep only value param