### PR TITLE
CAT-525 Avoid scrollups between criteria tabs and test content

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -78,6 +78,19 @@
   border-right: 3px solid yellow;
 }
 
+.cat-viewport-scroll {
+  max-height: 80vh;
+  overflow: auto;
+}
+
+.cat-view-reverse {
+  direction: rtl;
+}
+
+.cat-view-reverse-reverse {
+  direction: ltr;
+}
+
 .cat-view-heading-block {
   padding: 7px;
 }

--- a/src/pages/assessments/components/CriteriaTabs.tsx
+++ b/src/pages/assessments/components/CriteriaTabs.tsx
@@ -293,10 +293,16 @@ export function CriteriaTabs(props: CriteriaTabsProps) {
     >
       <Row className="border p-0">
         <Col sm={4} className="cat-crit-sidebar p-0">
-          <Nav className="flex-column cat-asmt-nav">{navs}</Nav>
+          <div className="cat-viewport-scroll cat-view-reverse">
+            <div className="cat-view-reverse-reverse">
+              <Nav className="flex-column cat-asmt-nav">{navs}</Nav>
+            </div>
+          </div>
         </Col>
         <Col sm={8}>
-          <Tab.Content>{tabs}</Tab.Content>
+          <div className="cat-viewport-scroll">
+            <Tab.Content>{tabs}</Tab.Content>
+          </div>
         </Col>
       </Row>
     </Tab.Container>


### PR DESCRIPTION
### Goal
Avoid scrolling up and down between criteria tabs and test content

### Solution (test locally before merge)
Add a max height of 80% of the viewport for the active assessment content (criteria and tests). Add scroll bars to these two columns (list of criteria / list of tests for each criterion). Since the criteria are displayed as tabs that change the content of the tests try to add their scrollbar to the left side to maintain the visual appearance of a tab view (even thought the tabs scroll). Might seem a bit off for some users - feedback needed

