### PR TITLE
CAT-549 View Assessment per Assessment Type in Motivation Details

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -111,6 +111,34 @@
   background-color: #e8e8e8;
 }
 
+.cat-eval-fail {
+  color: #842029;
+  background: #f8d7da;
+  border: 1px solid #f5c2c7;
+  border-top-left-radius: 8px;
+  border-top-right-radius: 8px;
+}
+
+.cat-eval-unknown {
+  color: #41464b;
+  background: #e2e3e5;
+  border: 1px solid #d3d6d8;
+  border-top-left-radius: 8px;
+  border-top-right-radius: 8px;
+}
+
+.cat-eval-pass {
+  color: #0f5132;
+  background: #d1e7dd;
+  border: 1px solid #badbcc;
+  border-top-left-radius: 8px;
+  border-top-right-radius: 8px;
+}
+
+.cat-eval-separator {
+  border-bottom: 1px solid black;
+}
+
 .cat-hash-link {
   color: grey;
   border-bottom: 1px dotted grey;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -34,6 +34,7 @@ import Principles from "./pages/principles/Principles";
 import PrincipleDetails from "./pages/principles/PrincipleDetails";
 import MotivationActorCriteria from "./pages/motivations/MotivationActorCriteria";
 import AssessmentView from "./pages/assessments/AssessmentView";
+import { MotivationAssessmentEditor } from "./pages/assessments/MotivationAssessmentEditor";
 
 const queryClient = new QueryClient();
 
@@ -221,6 +222,12 @@ function App() {
                     element={<ProtectedRoute />}
                   >
                     <Route index element={<MotivationActorCriteria />} />
+                  </Route>
+                  <Route
+                    path="/motivations/:mtvId/templates/actors/:actId"
+                    element={<ProtectedRoute />}
+                  >
+                    <Route index element={<MotivationAssessmentEditor />} />
                   </Route>
                   <Route path="/principles" element={<ProtectedRoute />}>
                     <Route index element={<Principles />} />

--- a/src/api/services/templates.ts
+++ b/src/api/services/templates.ts
@@ -1,5 +1,5 @@
 import { AxiosError } from "axios";
-import { TemplateResponse } from "@/types";
+import { Assessment, TemplateResponse } from "@/types";
 import { APIClient } from "@/api";
 import { useQuery } from "@tanstack/react-query";
 import { handleBackendError } from "@/utils";
@@ -23,5 +23,27 @@ export const useGetTemplate = (
       return handleBackendError(error);
     },
     enabled: !!token && isRegistered && actorId !== undefined,
+    refetchOnWindowFocus: false,
+  });
+
+export const useGetMotivationAssessmentType = (
+  mtvId: string,
+  actId: string,
+  token: string,
+  isRegistered: boolean,
+) =>
+  useQuery({
+    queryKey: ["assessment-type"],
+    queryFn: async () => {
+      const response = await APIClient(token).get<Assessment>(
+        `/templates/by-motivation/${mtvId}/by-actor/${actId}`,
+      );
+      return response.data;
+    },
+    onError: (error: AxiosError) => {
+      return handleBackendError(error);
+    },
+    enabled:
+      !!token && isRegistered && mtvId !== undefined && actId !== undefined,
     refetchOnWindowFocus: false,
   });

--- a/src/pages/assessments/AssessmentEdit.tsx
+++ b/src/pages/assessments/AssessmentEdit.tsx
@@ -486,6 +486,10 @@ const AssessmentEdit = ({
           const newCriteria = principle.criteria.map((criterion) => {
             let resultCriterion: AssessmentCriterion;
             if (criterion.id === criterionID) {
+              // if criterion has an array of metrics use the one as single nested element
+              if (Array.isArray(criterion.metric)) {
+                criterion.metric = criterion.metric[0];
+              }
               const newTests = criterion.metric.tests.map((test) => {
                 if (test.id === newTest.id) {
                   return newTest;
@@ -517,8 +521,13 @@ const AssessmentEdit = ({
         principles: newPrinciples,
       };
       // update criteria result reference tables
+
       newAssessment.principles.forEach((principle) => {
         principle.criteria.forEach((criterion) => {
+          // if criterion has an array of metrics use the one as single nested element
+          if (Array.isArray(criterion.metric)) {
+            criterion.metric = criterion.metric[0];
+          }
           if (criterion.imperative === AssessmentCriterionImperative.Must) {
             mandatory.push(criterion.metric.result);
           } else {
@@ -936,6 +945,10 @@ const AssessmentEdit = ({
                     assessmentResult={assessment.result}
                   />
                 )}
+                <div
+                  className="row bg-secondary"
+                  style={{ height: "1px" }}
+                ></div>
                 <CriteriaTabs
                   principles={assessment?.principles || []}
                   resetActiveTab={resetCriterionTab}

--- a/src/pages/assessments/AssessmentView.tsx
+++ b/src/pages/assessments/AssessmentView.tsx
@@ -36,6 +36,10 @@ function gatherStats(assessment: Assessment | undefined): Stats {
     assessment.principles.forEach((pri) => {
       total_criteria += pri.criteria.length;
       pri.criteria.forEach((cri) => {
+        // if criterion has an array of metrics use the one as single nested element
+        if (Array.isArray(cri.metric)) {
+          cri.metric = cri.metric[0];
+        }
         if (cri.imperative == AssessmentCriterionImperative.Must) {
           total_mandatory += 1;
           if (cri.metric.result !== null) completed_mandatory = +1;
@@ -243,122 +247,133 @@ const AssessmentView = ({ isPublic }: { isPublic: boolean }) => {
 
                 <div className="m-3">
                   <Accordion defaultActiveKey="0">
-                    {pri.criteria.map((cri) => (
-                      <Accordion.Item eventKey={cri.id} key={cri.id}>
-                        <Accordion.Header>
-                          <div className="col-md-10 d-flex justify-content-between">
-                            <div className="float-start">
-                              {cri.id} - {cri.name}
-                            </div>
-                            <div>
-                              {cri.imperative === "must" ? (
-                                <span className="ms-2 badge rounded-pill text-bg-light text-success">
-                                  {cri.imperative}
-                                </span>
-                              ) : (
-                                <span className="ms-2 badge rounded-pill text-bg-light text-warning">
-                                  {cri.imperative}
-                                </span>
-                              )}
-                              {cri.metric.result === 1 ? (
-                                <span className="ms-5 align-middle ">
-                                  <small className="ms-2">
-                                    <strong>
-                                      <span className="text-success">
-                                        Passed
-                                      </span>
-                                    </strong>
-                                  </small>
-                                </span>
-                              ) : cri.metric.result === 0 ? (
-                                <span className="ms-5 align-middle ">
-                                  <span className="badge badge-pill bg-danger me-1 flex-1"></span>
-                                  <small className="ms-2">
-                                    <strong>
-                                      <span className="text-danger">
-                                        Failed
-                                      </span>
-                                    </strong>
-                                  </small>
-                                </span>
-                              ) : (
-                                <span className="ms-5 align-middle">
-                                  <small className="ms-2">
-                                    <strong>
-                                      <span className="text-warning">n/a</span>
-                                    </strong>
-                                  </small>
-                                </span>
-                              )}
-                            </div>
-                          </div>
-                        </Accordion.Header>
-                        <Accordion.Body>
-                          <div>
-                            <small className="text-muted">
-                              {cri.description}
-                            </small>
-                          </div>
-                          <div className="m-1">
-                            {cri.metric.tests.map((test) => (
-                              <div key={test.id} className="mb-4">
-                                <span className="badge rounded-pill text-bg-light text-info">
-                                  {test.id} - {test.name}
-                                </span>
-                                <br />
-                                <strong>Q.</strong>
-                                <span className="text-secondary p-2">
-                                  {test.text}
-                                </span>
-                                <br />
-                                <strong>A.</strong>
-                                {test.type === "value" ? (
-                                  <span className="text-primary p-2">
-                                    <strong>F=</strong>
-                                    {test.value} <strong>P=</strong>
-                                    {test.threshold}
-                                  </span>
-                                ) : test.result === 1 ? (
-                                  <span className="text-primary p-2">
-                                    <strong>YES</strong>
-                                  </span>
-                                ) : test.result === 0 ? (
-                                  <span className="text-primary p-2">
-                                    <strong>NO</strong>
+                    {pri.criteria.map((cri) => {
+                      // if criterion has an array of metrics use the one as single nested element
+                      if (Array.isArray(cri.metric)) {
+                        cri.metric = cri.metric[0];
+                      }
+                      return (
+                        <Accordion.Item eventKey={cri.id} key={cri.id}>
+                          <Accordion.Header>
+                            <div className="col-md-10 d-flex justify-content-between">
+                              <div className="float-start">
+                                {cri.id} - {cri.name}
+                              </div>
+                              <div>
+                                {cri.imperative === "must" ? (
+                                  <span className="ms-2 badge rounded-pill text-bg-light text-success">
+                                    {cri.imperative}
                                   </span>
                                 ) : (
-                                  <span className="text-warning p-2">
-                                    <strong>N/A</strong>
+                                  <span className="ms-2 badge rounded-pill text-bg-light text-warning">
+                                    {cri.imperative}
                                   </span>
                                 )}
-                                <br />
-
-                                {test.evidence_url &&
-                                  test.evidence_url?.length > 0 && (
-                                    <div>
-                                      {test.evidence_url.map((ev) => (
-                                        <div key={ev.url}>
-                                          {" "}
-                                          <a href={ev.url}>
-                                            <span className="p-2">
-                                              <FaArrowUpRightFromSquare />
-                                            </span>
-                                          </a>
-                                          {ev.description && (
-                                            <a href={ev.url} className="plain">
-                                              <span>{ev.description}</span>
-                                            </a>
-                                          )}
-                                        </div>
-                                      ))}
-                                    </div>
-                                  )}
+                                {cri.metric.result === 1 ? (
+                                  <span className="ms-5 align-middle ">
+                                    <small className="ms-2">
+                                      <strong>
+                                        <span className="text-success">
+                                          Passed
+                                        </span>
+                                      </strong>
+                                    </small>
+                                  </span>
+                                ) : cri.metric.result === 0 ? (
+                                  <span className="ms-5 align-middle ">
+                                    <span className="badge badge-pill bg-danger me-1 flex-1"></span>
+                                    <small className="ms-2">
+                                      <strong>
+                                        <span className="text-danger">
+                                          Failed
+                                        </span>
+                                      </strong>
+                                    </small>
+                                  </span>
+                                ) : (
+                                  <span className="ms-5 align-middle">
+                                    <small className="ms-2">
+                                      <strong>
+                                        <span className="text-warning">
+                                          n/a
+                                        </span>
+                                      </strong>
+                                    </small>
+                                  </span>
+                                )}
                               </div>
-                            ))}
-                          </div>
-                        </Accordion.Body>
-                      </Accordion.Item>
-                    ))}
+                            </div>
+                          </Accordion.Header>
+                          <Accordion.Body>
+                            <div>
+                              <small className="text-muted">
+                                {cri.description}
+                              </small>
+                            </div>
+                            <div className="m-1">
+                              {cri.metric.tests.map((test) => (
+                                <div key={test.id} className="mb-4">
+                                  <span className="badge rounded-pill text-bg-light text-info">
+                                    {test.id} - {test.name}
+                                  </span>
+                                  <br />
+                                  <strong>Q.</strong>
+                                  <span className="text-secondary p-2">
+                                    {test.text}
+                                  </span>
+                                  <br />
+                                  <strong>A.</strong>
+                                  {test.type === "value" ? (
+                                    <span className="text-primary p-2">
+                                      <strong>F=</strong>
+                                      {test.value} <strong>P=</strong>
+                                      {test.threshold}
+                                    </span>
+                                  ) : test.result === 1 ? (
+                                    <span className="text-primary p-2">
+                                      <strong>YES</strong>
+                                    </span>
+                                  ) : test.result === 0 ? (
+                                    <span className="text-primary p-2">
+                                      <strong>NO</strong>
+                                    </span>
+                                  ) : (
+                                    <span className="text-warning p-2">
+                                      <strong>N/A</strong>
+                                    </span>
+                                  )}
+                                  <br />
+
+                                  {test.evidence_url &&
+                                    test.evidence_url?.length > 0 && (
+                                      <div>
+                                        {test.evidence_url.map((ev) => (
+                                          <div key={ev.url}>
+                                            {" "}
+                                            <a href={ev.url}>
+                                              <span className="p-2">
+                                                <FaArrowUpRightFromSquare />
+                                              </span>
+                                            </a>
+                                            {ev.description && (
+                                              <a
+                                                href={ev.url}
+                                                className="plain"
+                                              >
+                                                <span>{ev.description}</span>
+                                              </a>
+                                            )}
+                                          </div>
+                                        ))}
+                                      </div>
+                                    )}
+                                </div>
+                              ))}
+                            </div>
+                          </Accordion.Body>
+                        </Accordion.Item>
+                      );
+                    })}
                   </Accordion>
                 </div>
               </div>

--- a/src/pages/assessments/components/AssessmentEvalStats.tsx
+++ b/src/pages/assessments/components/AssessmentEvalStats.tsx
@@ -2,7 +2,7 @@
  * Component to display evaluation statistics
  */
 import { AssessmentResult, ResultStats } from "@/types";
-import { Row, Col, Alert, ProgressBar } from "react-bootstrap";
+import { Row, Col, ProgressBar } from "react-bootstrap";
 import { FaCheckCircle, FaChartLine } from "react-icons/fa";
 
 export const AssessmentEvalStats = ({
@@ -13,23 +13,23 @@ export const AssessmentEvalStats = ({
   assessmentResult: AssessmentResult;
 }) => {
   return (
-    <Row>
-      <Col>
-        <Alert
-          variant={
-            evalResult.mandatoryFilled !== evalResult.totalMandatory
-              ? "secondary"
-              : assessmentResult.compliance
-                ? "success"
-                : "danger"
-          }
-        >
-          <Row>
-            <Col>
-              <span>
+    <div className="p-0 row">
+      <div
+        className={`py-2 px-3 m-0 rounded-top ${
+          assessmentResult.compliance === null
+            ? "cat-eval-unknown"
+            : assessmentResult.compliance
+              ? "cat-eval-pass"
+              : "cat-eval-fail"
+        }`}
+      >
+        <Row>
+          <Col>
+            <div className="d-flex align-items-center">
+              <span className="mt-2">
                 <FaCheckCircle className="me-2" />
                 Compliance:
-                {evalResult.mandatoryFilled !== evalResult.totalMandatory ? (
+                {assessmentResult.compliance === null ? (
                   <span className="badge bg-secondary ms-2">UNKNOWN</span>
                 ) : assessmentResult.compliance ? (
                   <span className="badge bg-success ms-2">PASS</span>
@@ -37,42 +37,82 @@ export const AssessmentEvalStats = ({
                   <span className="badge bg-danger ms-2">FAIL</span>
                 )}
               </span>
-            </Col>
-            <Col>
-              <span>
+            </div>
+          </Col>
+          <Col>
+            <div className="d-flex align-items-center">
+              <span className="mt-2">
                 <FaChartLine className="me-2" />
-                Ranking:
-              </span>{" "}
-              {assessmentResult.ranking}
-            </Col>
-            <Col></Col>
+                Ranking: {assessmentResult.ranking}
+              </span>
+            </div>
+          </Col>
+          <Col></Col>
+          <Col xs={2}>
+            <div className="mb-2">
+              <span>
+                Mandatory: {evalResult.mandatoryFilled} /{" "}
+                {evalResult.totalMandatory}
+              </span>
+              <ProgressBar
+                style={{ backgroundColor: "darkgrey", height: "0.6rem" }}
+                className="mt-1"
+              >
+                <ProgressBar
+                  key="mandatory-pass"
+                  variant="success"
+                  now={
+                    evalResult.totalMandatory
+                      ? (evalResult.mandatory / evalResult.totalMandatory) * 100
+                      : 0
+                  }
+                />
+                <ProgressBar
+                  key="mandatory-fail"
+                  variant="danger"
+                  now={
+                    evalResult.totalMandatory
+                      ? ((evalResult.mandatoryFilled - evalResult.mandatory) /
+                          evalResult.totalMandatory) *
+                        100
+                      : 0
+                  }
+                />
+              </ProgressBar>
+            </div>
+          </Col>
+          {evalResult.totalOptional > 0 && (
             <Col xs={2}>
               <div className="mb-2">
                 <span>
-                  Mandatory: {evalResult.mandatoryFilled} /{" "}
-                  {evalResult.totalMandatory}
+                  Optional: {evalResult.optionalFilled} /{" "}
+                  {evalResult.totalOptional}
                 </span>
                 <ProgressBar
-                  style={{ backgroundColor: "darkgrey", height: "0.6rem" }}
+                  style={{
+                    backgroundColor: "darkgrey",
+                    height: "0.6rem",
+                  }}
                   className="mt-1"
                 >
                   <ProgressBar
                     key="mandatory-pass"
+                    striped
                     variant="success"
                     now={
-                      evalResult.totalMandatory
-                        ? (evalResult.mandatory / evalResult.totalMandatory) *
-                          100
+                      evalResult.totalOptional
+                        ? (evalResult.optional / evalResult.totalOptional) * 100
                         : 0
                     }
                   />
                   <ProgressBar
                     key="mandatory-fail"
+                    striped
                     variant="danger"
                     now={
-                      evalResult.totalMandatory
-                        ? ((evalResult.mandatoryFilled - evalResult.mandatory) /
-                            evalResult.totalMandatory) *
+                      evalResult.totalOptional
+                        ? ((evalResult.optionalFilled - evalResult.optional) /
+                            evalResult.totalOptional) *
                           100
                         : 0
                     }
@@ -80,50 +120,9 @@ export const AssessmentEvalStats = ({
                 </ProgressBar>
               </div>
             </Col>
-            {evalResult.totalOptional > 0 && (
-              <Col xs={2}>
-                <div className="mb-2">
-                  <span>
-                    Optional: {evalResult.optionalFilled} /{" "}
-                    {evalResult.totalOptional}
-                  </span>
-                  <ProgressBar
-                    style={{
-                      backgroundColor: "darkgrey",
-                      height: "0.6rem",
-                    }}
-                    className="mt-1"
-                  >
-                    <ProgressBar
-                      key="mandatory-pass"
-                      striped
-                      variant="success"
-                      now={
-                        evalResult.totalOptional
-                          ? (evalResult.optional / evalResult.totalOptional) *
-                            100
-                          : 0
-                      }
-                    />
-                    <ProgressBar
-                      key="mandatory-fail"
-                      striped
-                      variant="danger"
-                      now={
-                        evalResult.totalOptional
-                          ? ((evalResult.optionalFilled - evalResult.optional) /
-                              evalResult.totalOptional) *
-                            100
-                          : 0
-                      }
-                    />
-                  </ProgressBar>
-                </div>
-              </Col>
-            )}
-          </Row>
-        </Alert>
-      </Col>
-    </Row>
+          )}
+        </Row>
+      </div>
+    </div>
   );
 };

--- a/src/pages/motivations/MotivationDetails.tsx
+++ b/src/pages/motivations/MotivationDetails.tsx
@@ -292,7 +292,7 @@ export default function MotivationDetails() {
                           <OverlayTrigger placement="top" overlay={tooltipView}>
                             <Link
                               className="btn btn-light btn-sm m-1"
-                              to={`/motivations/${item.id}`}
+                              to={`/motivations/${params.id}/templates/actors/${item.id}`}
                             >
                               <FaBars />
                             </Link>

--- a/src/types/assessment.ts
+++ b/src/types/assessment.ts
@@ -88,13 +88,15 @@ export interface AssessmentCriterion {
   id: string;
   name: string;
   imperative: AssessmentCriterionImperative;
-  metric: Metric;
+  metric: Metric | Metric[];
   description?: string;
 }
 
 /** Each criterion can be either mandatory (must) or optional (should) */
 export enum AssessmentCriterionImperative {
   Must = "must",
+  MUST = "MUST",
+  SHOULD = "SHOULD",
   Should = "should",
 }
 
@@ -106,6 +108,7 @@ export interface Metric {
   value: number | null;
   result: number | null;
   tests: AssessmentTest[];
+  benchmark_value?: number;
 }
 
 /** Each metric has a type. For now, we only deal with type: number  */
@@ -123,12 +126,13 @@ export enum MetricAlgorithm {
 export type Benchmark = Record<string, string | number>;
 
 /** Each metric has a list of tests. Test can be of different kinds */
+
 export interface TestBinary {
   id: string;
   name: string;
   description?: string;
   guidance?: Guidance;
-  type: "binary";
+  type: "binary" | "Binary-Binary" | "Binary-Manual" | "Binary-Manual-Evidence";
   text: string;
   result: number | null;
   value: boolean | null;
@@ -140,7 +144,7 @@ export interface TestValue {
   name: string;
   description?: string;
   guidance?: Guidance;
-  type: "value";
+  type: "value" | "Number-Manual" | "Number-Auto";
   text: string;
   result: number | null;
   value: number | null;


### PR DESCRIPTION
### Goal
Allow to view a working Assessment Preview for each Assessment Type under Motivation

### Implementation
- [x] Update all required types to accomodate changes in new Assessment Template
- [x] Use reflection to translate slight changes in new template so that it works with old evaluation functions
- [x] Create MotivationAssessmentEditor component that renders the Assessment based on template
- [x] Add route and connect it to View button for each Assessment Type in Motivation Details
- [x] Fix some issues with Evaluation header in Assessment Edit 

Warning: Value tests input doesn't work because the schema has diverged a lot from the old one. We need to revisit that