### PR TITLE
CAT-566 Update metric to be single object instead of array in assessm…

### DIFF
--- a/src/pages/assessments/AssessmentEdit.tsx
+++ b/src/pages/assessments/AssessmentEdit.tsx
@@ -486,10 +486,6 @@ const AssessmentEdit = ({
           const newCriteria = principle.criteria.map((criterion) => {
             let resultCriterion: AssessmentCriterion;
             if (criterion.id === criterionID) {
-              // if criterion has an array of metrics use the one as single nested element
-              if (Array.isArray(criterion.metric)) {
-                criterion.metric = criterion.metric[0];
-              }
               const newTests = criterion.metric.tests.map((test) => {
                 if (test.id === newTest.id) {
                   return newTest;
@@ -524,10 +520,6 @@ const AssessmentEdit = ({
 
       newAssessment.principles.forEach((principle) => {
         principle.criteria.forEach((criterion) => {
-          // if criterion has an array of metrics use the one as single nested element
-          if (Array.isArray(criterion.metric)) {
-            criterion.metric = criterion.metric[0];
-          }
           if (criterion.imperative === AssessmentCriterionImperative.Must) {
             mandatory.push(criterion.metric.result);
           } else {

--- a/src/pages/assessments/AssessmentView.tsx
+++ b/src/pages/assessments/AssessmentView.tsx
@@ -36,10 +36,6 @@ function gatherStats(assessment: Assessment | undefined): Stats {
     assessment.principles.forEach((pri) => {
       total_criteria += pri.criteria.length;
       pri.criteria.forEach((cri) => {
-        // if criterion has an array of metrics use the one as single nested element
-        if (Array.isArray(cri.metric)) {
-          cri.metric = cri.metric[0];
-        }
         if (cri.imperative == AssessmentCriterionImperative.Must) {
           total_mandatory += 1;
           if (cri.metric.result !== null) completed_mandatory = +1;
@@ -248,10 +244,6 @@ const AssessmentView = ({ isPublic }: { isPublic: boolean }) => {
                 <div className="m-3">
                   <Accordion defaultActiveKey="0">
                     {pri.criteria.map((cri) => {
-                      // if criterion has an array of metrics use the one as single nested element
-                      if (Array.isArray(cri.metric)) {
-                        cri.metric = cri.metric[0];
-                      }
                       return (
                         <Accordion.Item eventKey={cri.id} key={cri.id}>
                           <Accordion.Header>

--- a/src/pages/assessments/MotivationAssessmentEditor.tsx
+++ b/src/pages/assessments/MotivationAssessmentEditor.tsx
@@ -4,7 +4,7 @@ import { useContext, useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { DebugJSON } from "./components/DebugJSON";
 import { CriteriaTabs } from "./components";
-import { Button, Col } from "react-bootstrap";
+import { Alert, Button, Col } from "react-bootstrap";
 import {
   Assessment,
   AssessmentCriterion,
@@ -13,6 +13,7 @@ import {
 } from "@/types";
 import { evalAssessment, evalMetric } from "@/utils";
 import { AssessmentEvalStats } from "./components/AssessmentEvalStats";
+import { FaExclamationTriangle } from "react-icons/fa";
 
 export const MotivationAssessmentEditor = () => {
   // get actId and mtvId as routing parameters
@@ -20,7 +21,7 @@ export const MotivationAssessmentEditor = () => {
   const [resetCriterionTab, setResetCriterionTab] = useState(false);
   const { keycloak, registered } = useContext(AuthContext)!;
   const [assessment, setAssessment] = useState<Assessment>();
-  const { data } = useGetMotivationAssessmentType(
+  const { data, isLoading } = useGetMotivationAssessmentType(
     params.mtvId || "",
     params.actId || "",
     keycloak?.token || "",
@@ -48,10 +49,6 @@ export const MotivationAssessmentEditor = () => {
           const newCriteria = principle.criteria.map((criterion) => {
             let resultCriterion: AssessmentCriterion;
             if (criterion.id === criterionID) {
-              // if criterion has an array of metrics use the one as single nested element
-              if (Array.isArray(criterion.metric)) {
-                criterion.metric = criterion.metric[0];
-              }
               const newTests = criterion.metric.tests.map((test) => {
                 if (test.id === newTest.id) {
                   return newTest;
@@ -86,10 +83,6 @@ export const MotivationAssessmentEditor = () => {
 
       newAssessment.principles.forEach((principle) => {
         principle.criteria.forEach((criterion) => {
-          // if criterion has an array of metrics use the one as single nested element
-          if (Array.isArray(criterion.metric)) {
-            criterion.metric = criterion.metric[0];
-          }
           if (
             criterion.imperative === AssessmentCriterionImperative.Must ||
             criterion.imperative === AssessmentCriterionImperative.MUST
@@ -149,7 +142,11 @@ export const MotivationAssessmentEditor = () => {
           </h2>
         </Col>
       </div>
-      {assessment ? (
+      {isLoading ? (
+        <div>
+          <Alert variant="light">Loading ...</Alert>
+        </div>
+      ) : assessment ? (
         <div className="p-4">
           {evalResult && assessment?.result && (
             <AssessmentEvalStats
@@ -169,7 +166,12 @@ export const MotivationAssessmentEditor = () => {
           <DebugJSON assessment={assessment} />
         </div>
       ) : (
-        <span>No data</span>
+        <div>
+          <Alert variant="warning">
+            <FaExclamationTriangle />
+            No Data found ...
+          </Alert>
+        </div>
       )}
       <Button
         variant="secondary"

--- a/src/pages/assessments/components/CriteriaTabs.tsx
+++ b/src/pages/assessments/components/CriteriaTabs.tsx
@@ -126,10 +126,6 @@ export function CriteriaTabs(props: CriteriaTabsProps) {
       </div>,
     );
     principle.criteria.forEach((criterion) => {
-      // if criterion has an array of metrics use the one as single nested element
-      if (Array.isArray(criterion.metric)) {
-        criterion.metric = criterion.metric[0];
-      }
       navs.push(
         <Nav.Item key={principle.id + criterion.id} className="cat-crit-tab">
           <Nav.Link

--- a/src/pages/assessments/components/tests/EvidenceURLS.tsx
+++ b/src/pages/assessments/components/tests/EvidenceURLS.tsx
@@ -29,7 +29,7 @@ export const EvidenceURLS = (props: EvidenceURLSProps) => {
         const updatedURLs = [...urlList, newURL];
         setUrlList(updatedURLs);
         props.onListChange(updatedURLs);
-        setNewURL({ url: "" });
+        setNewURL({ url: "", description: "" });
         setError("");
       } else {
         setError(

--- a/src/types/assessment.ts
+++ b/src/types/assessment.ts
@@ -88,7 +88,7 @@ export interface AssessmentCriterion {
   id: string;
   name: string;
   imperative: AssessmentCriterionImperative;
-  metric: Metric | Metric[];
+  metric: Metric;
   description?: string;
 }
 

--- a/src/utils/assessment.ts
+++ b/src/utils/assessment.ts
@@ -68,10 +68,6 @@ export function evalAssessment(
   if (assessment.principles) {
     assessment.principles.forEach((principle) => {
       principle.criteria.forEach((criterion) => {
-        // if criterion has an array of metrics use the one as single nested element
-        if (Array.isArray(criterion.metric)) {
-          criterion.metric = criterion.metric[0];
-        }
         if (
           criterion.imperative === AssessmentCriterionImperative.Must ||
           criterion.imperative === AssessmentCriterionImperative.MUST


### PR DESCRIPTION
…ent type

To be merged after: https://github.com/FC4E-CAT/fc4e-cat-api/pull/307

- [x] Handle metric as single element in new template instead of array. Remove metric array to object translation
- [x] Add loading prompt in Assessment Preview
- [x] Clear evidence description when adding a new evidence url