### PR TITLE
CAT-567 In BinaryTests manage list of params and tooltips given

### DIFF
--- a/src/pages/assessments/components/CriteriaTabs.tsx
+++ b/src/pages/assessments/components/CriteriaTabs.tsx
@@ -28,6 +28,7 @@ import {
   AssessmentCriterionImperative,
   TestBinary,
   TestValue,
+  TestBinaryParam,
   // MetricAlgorithm,
 } from "@/types";
 import {
@@ -37,6 +38,7 @@ import {
 import { FaCheckCircle, FaInfoCircle, FaTimesCircle } from "react-icons/fa";
 import { useEffect, useState } from "react";
 import { CriterionProgress } from "./CriterionProgress";
+import { TestBinaryParamForm } from "./tests/TestBinaryParam";
 
 type CriteriaTabsProps = {
   principles: AssessmentPrinciple[];
@@ -180,12 +182,7 @@ export function CriteriaTabs(props: CriteriaTabsProps) {
 
       criterion.metric.tests &&
         criterion.metric.tests.forEach((test) => {
-          if (
-            test.type === "binary" ||
-            test.type === "Binary-Manual-Evidence" ||
-            test.type === "Binary-Binary" ||
-            test.type === "Binary-Manual"
-          ) {
+          if (test.type === "binary") {
             testList.push(
               <div className="border mt-4" key={test.id}>
                 <div className="cat-test-div">
@@ -200,11 +197,27 @@ export function CriteriaTabs(props: CriteriaTabsProps) {
               </div>,
             );
           } else if (
+            test.type === "Binary-Manual-Evidence" ||
+            test.type === "Binary-Binary" ||
+            test.type === "Binary-Manual"
+          ) {
+            testList.push(
+              <div className="border mt-4" key={test.id}>
+                <div className="cat-test-div">
+                  <TestBinaryParamForm
+                    test={test as TestBinaryParam}
+                    onTestChange={props.onTestChange}
+                    criterionId={criterion.id}
+                    principleId={principle.id}
+                  />
+                </div>
+              </div>,
+            );
+          } else if (
             test.type === "value" ||
             test.type === "Number-Manual" ||
             test.type === "Number-Auto"
           ) {
-            console.log(criterion.name + " " + test.type);
             testList.push(
               <div className="border mt-4" key={test.id}>
                 <div className="cat-test-div">

--- a/src/pages/assessments/components/tests/EvidenceURLS.tsx
+++ b/src/pages/assessments/components/tests/EvidenceURLS.tsx
@@ -9,6 +9,7 @@ import { InputGroup, Form, Row, Col } from "react-bootstrap";
 interface EvidenceURLSProps {
   urls: EvidenceURL[];
   onListChange(newURLs: EvidenceURL[]): void;
+  noTitle?: boolean;
 }
 
 export const EvidenceURLS = (props: EvidenceURLSProps) => {
@@ -40,10 +41,12 @@ export const EvidenceURLS = (props: EvidenceURLSProps) => {
   };
 
   return (
-    <div className="mt-4">
-      <small>
-        <strong>Evidence:</strong>
-      </small>
+    <div className="mt-1">
+      {!props.noTitle && (
+        <small>
+          <strong>Evidence:</strong>
+        </small>
+      )}
 
       {urlList.length > 0 && (
         <ul className="list-group mt-2">

--- a/src/pages/assessments/components/tests/TestBinaryParam.tsx
+++ b/src/pages/assessments/components/tests/TestBinaryParam.tsx
@@ -1,0 +1,134 @@
+/**
+ * Component to display and edit a specific binary test
+ */
+
+// import { useState } from "react"
+import { Col, Form, OverlayTrigger, Row, Tooltip } from "react-bootstrap";
+import { EvidenceURLS } from "./EvidenceURLS";
+import { AssessmentTest, EvidenceURL, TestBinaryParam } from "@/types";
+import { FaQuestionCircle } from "react-icons/fa";
+
+interface AssessmentTestProps {
+  test: TestBinaryParam;
+  principleId: string;
+  criterionId: string;
+  onTestChange(
+    principleId: string,
+    criterionId: string,
+    newTest: AssessmentTest,
+  ): void;
+}
+
+const TestToolTip = ({
+  tipId,
+  tipText,
+}: {
+  tipId: string;
+  tipText: string;
+}) => {
+  return (
+    <OverlayTrigger
+      placement="top"
+      overlay={<Tooltip id={tipId}>{tipText}</Tooltip>}
+    >
+      <span>
+        <FaQuestionCircle className="text-secondary opacity-50" />
+      </span>
+    </OverlayTrigger>
+  );
+};
+
+export const TestBinaryParamForm = (props: AssessmentTestProps) => {
+  const handleValueChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    let result: 0 | 1 = 0;
+    let value: boolean = false;
+    if (event.target.value === "1") {
+      value = true;
+      result = 1;
+    }
+    const newTest = { ...props.test, result: result, value: value };
+
+    props.onTestChange(props.principleId, props.criterionId, newTest);
+  };
+
+  function onURLChange(newURLS: EvidenceURL[]) {
+    const newTest = { ...props.test, evidence_url: newURLS };
+    props.onTestChange(props.principleId, props.criterionId, newTest);
+  }
+
+  // break descriptions
+  const textParams = props.test.text.split("|");
+  const tipParams = props.test.tool_tip.split("|");
+  const testParams = props.test.params.split("|");
+
+  return (
+    <div>
+      <Row>
+        <Col>
+          <h6>
+            <small className="text-muted badge badge-pill border bg-light">
+              <span className="me-4">{props.test.id}</span>
+              {props.test.name}
+            </small>
+          </h6>
+        </Col>
+        <Col xs={3} className="text-start"></Col>
+      </Row>
+
+      <Row>
+        <Col>
+          <div className="">
+            <Form className="form-binary-test" onSubmit={() => false}>
+              <h5>
+                {textParams[0]}{" "}
+                <TestToolTip
+                  tipId={"text-" + props.test.id}
+                  tipText={tipParams[0]}
+                />
+              </h5>
+
+              <Form.Check
+                inline
+                label="Yes"
+                value="1"
+                name="test-input-group"
+                type="radio"
+                id="test-check-yes"
+                checked={props.test.value === true}
+                onChange={handleValueChange}
+              />
+              <Form.Check
+                inline
+                label="No"
+                value="0"
+                name="test-input-group"
+                type="radio"
+                id="test-check-no"
+                checked={props.test.value === false}
+                onChange={handleValueChange}
+              />
+              {/* here ends the binary test */}
+            </Form>
+          </div>
+
+          {testParams[testParams.length - 1] === "evidence" && (
+            <div className="mt-2">
+              <h6>
+                {textParams[1]}{" "}
+                <TestToolTip
+                  tipId={"evidence-" + props.test.id}
+                  tipText={tipParams[1]}
+                />
+              </h6>
+              <EvidenceURLS
+                urls={props.test.evidence_url || []}
+                onListChange={onURLChange}
+                noTitle={true}
+              />
+            </div>
+          )}
+        </Col>
+      </Row>
+    </div>
+  );
+};

--- a/src/types/assessment.ts
+++ b/src/types/assessment.ts
@@ -132,11 +132,25 @@ export interface TestBinary {
   name: string;
   description?: string;
   guidance?: Guidance;
-  type: "binary" | "Binary-Binary" | "Binary-Manual" | "Binary-Manual-Evidence";
+  type: "binary";
   text: string;
   result: number | null;
   value: boolean | null;
   evidence_url?: EvidenceURL[];
+}
+
+export interface TestBinaryParam {
+  id: string;
+  name: string;
+  description?: string;
+  guidance?: Guidance;
+  type: "Binary-Binary" | "Binary-Manual" | "Binary-Manual-Evidence";
+  text: string;
+  result: number | null;
+  value: boolean | null;
+  params: string;
+  evidence_url?: EvidenceURL[];
+  tool_tip: string;
 }
 
 export interface TestValue {
@@ -243,7 +257,7 @@ export interface AssessmentDetailsResponse {
 }
 
 /** Each assessment test will gonna have different types - right now only two types: binary/value test are supported  */
-export type AssessmentTest = TestValue | TestBinary;
+export type AssessmentTest = TestValue | TestBinary | TestBinaryParam;
 
 export interface ObjectListItem {
   id: string;


### PR DESCRIPTION
### Goal
Support list of parameters given in new Binary Tests and display info on test forms

### Implementation

- [x] Implement new test type TestBinaryParam
- [x] Implement new visual component TestBinaryParamForm
- [x] Manage delimited lists of test.text test.tool_tips and test.params
- [x] Display evidence only when last of the available params is named "evidence"