### PR TITLE
CAT-568 Manage parameters in Value Tests

### DIFF
--- a/src/pages/assessments/components/CriteriaTabs.tsx
+++ b/src/pages/assessments/components/CriteriaTabs.tsx
@@ -3,9 +3,11 @@ import {
   Col,
   ListGroup,
   Nav,
+  OverlayTrigger,
   // OverlayTrigger,
   Row,
   Tab,
+  Tooltip,
   // Tooltip,
 } from "react-bootstrap";
 import {
@@ -29,6 +31,7 @@ import {
   TestBinary,
   TestValue,
   TestBinaryParam,
+  TestValueParam,
   // MetricAlgorithm,
 } from "@/types";
 import {
@@ -39,6 +42,7 @@ import { FaCheckCircle, FaInfoCircle, FaTimesCircle } from "react-icons/fa";
 import { useEffect, useState } from "react";
 import { CriterionProgress } from "./CriterionProgress";
 import { TestBinaryParamForm } from "./tests/TestBinaryParam";
+import { TestValueFormParam } from "./tests/TestValueFormParam";
 
 type CriteriaTabsProps = {
   principles: AssessmentPrinciple[];
@@ -213,11 +217,7 @@ export function CriteriaTabs(props: CriteriaTabsProps) {
                 </div>
               </div>,
             );
-          } else if (
-            test.type === "value" ||
-            test.type === "Number-Manual" ||
-            test.type === "Number-Auto"
-          ) {
+          } else if (test.type === "value") {
             testList.push(
               <div className="border mt-4" key={test.id}>
                 <div className="cat-test-div">
@@ -227,6 +227,26 @@ export function CriteriaTabs(props: CriteriaTabsProps) {
                     criterionId={criterion.id}
                     principleId={principle.id}
                     handleGuide={props.handleGuide}
+                  />
+                </div>
+              </div>,
+            );
+          } else if (
+            test.type === "Number-Manual" ||
+            test.type === "Number-Auto" ||
+            test.type === "Ratio-Manual" ||
+            test.type === "Percent-Manual" ||
+            test.type === "TRL-Manual" ||
+            test.type === "Years-Manual"
+          ) {
+            testList.push(
+              <div className="border mt-4" key={test.id}>
+                <div className="cat-test-div">
+                  <TestValueFormParam
+                    test={test as TestValueParam}
+                    onTestChange={props.onTestChange}
+                    criterionId={criterion.id}
+                    principleId={principle.id}
                   />
                 </div>
               </div>,
@@ -270,11 +290,18 @@ export function CriteriaTabs(props: CriteriaTabsProps) {
                   <span className="align-middle">
                     part of principle {principle.id}: {principle.name}{" "}
                   </span>
-
-                  <FaInfoCircle
-                    title={principle.description}
-                    className="text-secondary opacity-50 align-middle"
-                  />
+                  <OverlayTrigger
+                    placement="top"
+                    overlay={
+                      <Tooltip id={`tip-pri-${principle.id}`}>
+                        {principle.description}
+                      </Tooltip>
+                    }
+                  >
+                    <span>
+                      <FaInfoCircle className="text-secondary opacity-50 align-middle" />
+                    </span>
+                  </OverlayTrigger>
                 </div>
               </div>
             </div>

--- a/src/pages/assessments/components/tests/TestBinaryParam.tsx
+++ b/src/pages/assessments/components/tests/TestBinaryParam.tsx
@@ -1,12 +1,12 @@
 /**
- * Component to display and edit a specific binary test
+ * Component to display and edit a specific binary test with parameters
  */
 
 // import { useState } from "react"
-import { Col, Form, OverlayTrigger, Row, Tooltip } from "react-bootstrap";
+import { Col, Form, Row } from "react-bootstrap";
 import { EvidenceURLS } from "./EvidenceURLS";
+import { TestToolTip } from "./TestToolTip";
 import { AssessmentTest, EvidenceURL, TestBinaryParam } from "@/types";
-import { FaQuestionCircle } from "react-icons/fa";
 
 interface AssessmentTestProps {
   test: TestBinaryParam;
@@ -18,25 +18,6 @@ interface AssessmentTestProps {
     newTest: AssessmentTest,
   ): void;
 }
-
-const TestToolTip = ({
-  tipId,
-  tipText,
-}: {
-  tipId: string;
-  tipText: string;
-}) => {
-  return (
-    <OverlayTrigger
-      placement="top"
-      overlay={<Tooltip id={tipId}>{tipText}</Tooltip>}
-    >
-      <span>
-        <FaQuestionCircle className="text-secondary opacity-50" />
-      </span>
-    </OverlayTrigger>
-  );
-};
 
 export const TestBinaryParamForm = (props: AssessmentTestProps) => {
   const handleValueChange = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -56,7 +37,7 @@ export const TestBinaryParamForm = (props: AssessmentTestProps) => {
     props.onTestChange(props.principleId, props.criterionId, newTest);
   }
 
-  // break descriptions
+  // break parameters
   const textParams = props.test.text.split("|");
   const tipParams = props.test.tool_tip.split("|");
   const testParams = props.test.params.split("|");

--- a/src/pages/assessments/components/tests/TestToolTip.tsx
+++ b/src/pages/assessments/components/tests/TestToolTip.tsx
@@ -1,0 +1,21 @@
+import { OverlayTrigger, Tooltip } from "react-bootstrap";
+import { FaQuestionCircle } from "react-icons/fa";
+
+export const TestToolTip = ({
+  tipId,
+  tipText,
+}: {
+  tipId: string;
+  tipText: string;
+}) => {
+  return (
+    <OverlayTrigger
+      placement="top"
+      overlay={<Tooltip id={tipId}>{tipText}</Tooltip>}
+    >
+      <span>
+        <FaQuestionCircle className="text-secondary opacity-50" />
+      </span>
+    </OverlayTrigger>
+  );
+};

--- a/src/pages/assessments/components/tests/TestValueFormParam.tsx
+++ b/src/pages/assessments/components/tests/TestValueFormParam.tsx
@@ -1,0 +1,231 @@
+/**
+ * Component to display and edit a specific a value test
+ */
+
+// import { useState } from "react"
+import { Alert, Col, Form, InputGroup, Row } from "react-bootstrap";
+import { EvidenceURLS } from "./EvidenceURLS";
+import { AssessmentTest, EvidenceURL, TestValueParam } from "@/types";
+import { useState } from "react";
+import { TestToolTip } from "./TestToolTip";
+import { FaCogs } from "react-icons/fa";
+
+interface AssessmentTestProps {
+  test: TestValueParam;
+  principleId: string;
+  criterionId: string;
+  onTestChange(
+    principleId: string,
+    criterionId: string,
+    newTest: AssessmentTest,
+  ): void;
+}
+
+enum TestValueEventType {
+  Value = "value",
+  Threshold = "threshold",
+}
+
+export const TestValueFormParam = (props: AssessmentTestProps) => {
+  const [localValue, setLocalValue] = useState<string>(
+    props.test.value?.toString() || "",
+  );
+  const [localThreshold, setLocalThreshold] = useState<string>(
+    props.test.threshold?.toString() || "",
+  );
+
+  const handleValueChange = (
+    eventType: TestValueEventType,
+    event: React.ChangeEvent<HTMLInputElement>,
+  ) => {
+    const newTest = { ...props.test };
+    // keep only number digits as input
+    const numberOnlyVal = event.target.value.replace(/[^0-9.]/g, "");
+
+    if (eventType === TestValueEventType.Value) {
+      setLocalValue(numberOnlyVal);
+      newTest.value = parseFloat(numberOnlyVal);
+    } else {
+      setLocalThreshold(numberOnlyVal);
+      newTest.threshold = parseFloat(numberOnlyVal);
+    }
+
+    // evaluate result - benchmark till now supports only equal_greater_than
+    // this will change in the future
+    let comparisonMode = "";
+    let comparisonValue = 0;
+    let result: number | null = null;
+
+    // find comparisonMode
+
+    if (newTest.benchmark) {
+      const modes = ["equal_greater_than", "equal_less_than", "equal"];
+
+      for (const mode of modes) {
+        if (mode in newTest.benchmark) {
+          comparisonMode = mode;
+          break;
+        }
+      }
+
+      if (comparisonMode in newTest.benchmark) {
+        if (typeof newTest.benchmark[comparisonMode] === "number") {
+          comparisonValue = newTest.benchmark[comparisonMode] as number;
+        } else if (
+          newTest.benchmark[comparisonMode] === "threshold" &&
+          newTest.threshold
+        ) {
+          comparisonValue = newTest.threshold;
+        }
+      }
+
+      if (newTest.value) {
+        if (comparisonMode === "equal_greater_than") {
+          result = newTest.value >= comparisonValue ? 1 : 0;
+        } else if (comparisonMode === "equal_less_than") {
+          result = newTest.value <= comparisonValue ? 1 : 0;
+        } else {
+          result = newTest.value === comparisonValue ? 1 : 0;
+        }
+      }
+    } else {
+      result = newTest.value;
+    }
+    console.log(result);
+    newTest.result = result;
+    props.onTestChange(props.principleId, props.criterionId, newTest);
+  };
+
+  function onURLChange(newURLS: EvidenceURL[]) {
+    const newTest = { ...props.test, evidence_url: newURLS };
+    props.onTestChange(props.principleId, props.criterionId, newTest);
+  }
+
+  // break parameters
+  const textParams = props.test.text.split("|");
+  const tipParams = props.test.tool_tip.split("|");
+  const testParams = props.test.params.split("|");
+
+  // check if test is automated
+  const automated = props.test.type.endsWith("Auto");
+
+  return (
+    <div>
+      <Row>
+        <Col>
+          <h6>
+            <small className="text-muted badge badge-pill border bg-light m">
+              <span className="me-4">{props.test.id}</span>
+              {props.test.name}
+            </small>
+          </h6>
+        </Col>
+        <Col xs={1} className="text-start"></Col>
+      </Row>
+
+      <Row>
+        <Col>
+          <div>
+            <h5>{textParams[0]}</h5>
+            {automated && (
+              <Alert variant="warning">
+                <div>
+                  <FaCogs /> This test is meant to be automated{" "}
+                  <em>(Work in progress...)</em>
+                </div>
+                <div>
+                  <small>
+                    For the time being you can fill in manually the{" "}
+                    <code className="text-muted">responseVariable</code> value
+                  </small>
+                </div>
+              </Alert>
+            )}
+            <Row>
+              <InputGroup className="mt-1">
+                <InputGroup.Text id="label-first-value">
+                  <TestToolTip
+                    tipId={"params-1-" + props.test.id}
+                    tipText={tipParams[0]}
+                  />
+                  <span className="ms-2">{testParams[0]}</span>:
+                </InputGroup.Text>
+                <Form.Control
+                  value={automated ? "" : localValue || ""}
+                  type="text"
+                  id="input-value-control"
+                  onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                    // use this input only if the test is not automated
+                    if (!automated) {
+                      handleValueChange(TestValueEventType.Value, e);
+                    }
+                  }}
+                  disabled={automated}
+                />
+              </InputGroup>
+            </Row>
+            {testParams.length > 1 && testParams[1] !== "evidence" && (
+              <>
+                <Row className="mt-1">
+                  <InputGroup className="mt-2">
+                    <InputGroup.Text id="label-second-value">
+                      <TestToolTip
+                        tipId={"params-2-" + props.test.id}
+                        tipText={tipParams[1]}
+                      />
+                      <span className="ms-2">{testParams[1]}</span>:
+                    </InputGroup.Text>
+                    <Form.Control
+                      value={localThreshold || ""}
+                      type="text"
+                      id="input-value-community"
+                      onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                        handleValueChange(TestValueEventType.Threshold, e)
+                      }
+                      disabled={automated}
+                    />
+                  </InputGroup>
+                </Row>
+              </>
+            )}
+            {automated &&
+              testParams.length > 2 &&
+              testParams[2] !== "evidence" && (
+                <>
+                  <Row className="mt-1">
+                    <InputGroup className="mt-2">
+                      <InputGroup.Text id="label-second-value">
+                        <TestToolTip
+                          tipId={"params-3-" + props.test.id}
+                          tipText={tipParams[2]}
+                        />
+                        <span className="ms-2">{testParams[2]}</span>:
+                      </InputGroup.Text>
+                      <Form.Control
+                        value={localValue || ""}
+                        type="text"
+                        id="input-value-community"
+                        onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                          if (automated) {
+                            handleValueChange(TestValueEventType.Value, e);
+                          }
+                        }}
+                      />
+                    </InputGroup>
+                  </Row>
+                </>
+              )}
+          </div>
+
+          {testParams[testParams.length - 1] === "evidence" && (
+            <EvidenceURLS
+              urls={props.test.evidence_url || []}
+              onListChange={onURLChange}
+              noTitle={true}
+            />
+          )}
+        </Col>
+      </Row>
+    </div>
+  );
+};

--- a/src/pages/assessments/components/tests/index.ts
+++ b/src/pages/assessments/components/tests/index.ts
@@ -1,5 +1,6 @@
 import { TestBinaryForm } from "./TestBinaryForm";
 import { TestValueForm } from "./TestValueForm";
 import { EvidenceURLS } from "./EvidenceURLS";
+import { TestToolTip } from "./TestToolTip";
 
-export { TestBinaryForm, TestValueForm, EvidenceURLS };
+export { TestBinaryForm, TestValueForm, EvidenceURLS, TestToolTip };

--- a/src/types/assessment.ts
+++ b/src/types/assessment.ts
@@ -158,7 +158,7 @@ export interface TestValue {
   name: string;
   description?: string;
   guidance?: Guidance;
-  type: "value" | "Number-Manual" | "Number-Auto";
+  type: "value";
   text: string;
   result: number | null;
   value: number | null;
@@ -169,6 +169,38 @@ export interface TestValue {
   benchmark: Benchmark;
   evidence_url?: EvidenceURL[];
 }
+
+export interface TestValueParam {
+  id: string;
+  name: string;
+  description?: string;
+  guidance?: Guidance;
+  type:
+    | "Number-Manual"
+    | "Number-Auto"
+    | "Ratio-Manual"
+    | "Percent-Manual"
+    | "TRL-Manual"
+    | "Years-Manual";
+  text: string;
+  result: number | null;
+  value: number | null;
+  threshold?: number | null;
+  value_name: string;
+  threshold_name?: string;
+  threshold_locked?: boolean;
+  tool_tip: string;
+  params: string;
+  benchmark: Benchmark;
+  evidence_url?: EvidenceURL[];
+}
+
+/** Supported tests: Binary | Value | BinaryParam | ValueParam **/
+export type AssessmentTest =
+  | TestValue
+  | TestBinary
+  | TestBinaryParam
+  | TestValueParam;
 
 export interface EvidenceURL {
   url: string;
@@ -255,9 +287,6 @@ export interface AssessmentDetailsResponse {
   shared_to_user: boolean;
   assessment_doc: Assessment;
 }
-
-/** Each assessment test will gonna have different types - right now only two types: binary/value test are supported  */
-export type AssessmentTest = TestValue | TestBinary | TestBinaryParam;
 
 export interface ObjectListItem {
   id: string;


### PR DESCRIPTION
### Goal
Handle correctly parameters in new Value Tests

### Implementation
- [x] Extract TestTooltip as a separate component (to provide tooltips in different parts of the test)
- [x] Create a new type TestValueParam
- [x] Create a new visual component: TestValueParamForm
- [x] Parse test.params test.tool_tip and test.text for delimited lists and extract parameters
- [x] Plan and present input boxes according to parameters present
- [x] Based on test type recognise Automated tests and handle them specifically. AutomatedTests receive a warning and display three paremeters (method, api request and response). User is notified that this test will be Automated in the future. In the meantime user is guided to manually enter a response value

### Extras:
- [x] Fix criterion principle hover to be consistent with others 