### PR TITLE
CAT-591 Manage motivation's criteria and principles

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -375,6 +375,10 @@ footer a {
   width: max-content;
 }
 
+.cat-vh-40 {
+  height: 40vh;
+}
+
 .cat-vh-60 {
   height: 60vh;
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -35,6 +35,7 @@ import PrincipleDetails from "./pages/principles/PrincipleDetails";
 import MotivationActorCriteria from "./pages/motivations/MotivationActorCriteria";
 import AssessmentView from "./pages/assessments/AssessmentView";
 import { MotivationAssessmentEditor } from "./pages/assessments/MotivationAssessmentEditor";
+import MotivationCriteriaPrinciples from "./pages/motivations/MotivationCriteriaPrinciples";
 
 const queryClient = new QueryClient();
 
@@ -216,6 +217,12 @@ function App() {
                   </Route>
                   <Route path="/motivations/:id" element={<ProtectedRoute />}>
                     <Route index element={<MotivationDetails />} />
+                  </Route>
+                  <Route
+                    path="/motivations/:mtvId/manage-criteria-principles"
+                    element={<ProtectedRoute />}
+                  >
+                    <Route index element={<MotivationCriteriaPrinciples />} />
                   </Route>
                   <Route
                     path="/motivations/:mtvId/actors/:actId"

--- a/src/api/services/motivations.ts
+++ b/src/api/services/motivations.ts
@@ -17,6 +17,7 @@ import {
   MotivationInput,
   MotivationResponse,
   MotivationTypeResponse,
+  PrincipleCriterion,
   PrincipleResponse,
   RelationResponse,
 } from "@/types";
@@ -103,6 +104,29 @@ export const useGetAllActors = ({ token, isRegistered, size }: ApiOptions) =>
     queryFn: async ({ pageParam = 1 }) => {
       const response = await APIClient(token).get<MotivationActorResponse>(
         `/registry/actors?size=${size}&page=${pageParam}`,
+      );
+      return response.data;
+    },
+    getNextPageParam: (lastPage) => {
+      if (lastPage.number_of_page < lastPage.total_pages) {
+        return lastPage.number_of_page + 1;
+      } else {
+        return undefined;
+      }
+    },
+    onError: (error: AxiosError) => {
+      return handleBackendError(error);
+    },
+    retry: false,
+    enabled: isRegistered,
+  });
+
+export const useGetAllCriteria = ({ token, isRegistered, size }: ApiOptions) =>
+  useInfiniteQuery({
+    queryKey: ["all-criteria"],
+    queryFn: async ({ pageParam = 1 }) => {
+      const response = await APIClient(token).get<CriterionResponse>(
+        `/registry/criteria?size=${size}&page=${pageParam}`,
       );
       return response.data;
     },
@@ -385,6 +409,25 @@ export function useUpdateMotivationActorCriteria(
     // on change refresh motivation-actor-criteria list
     onSuccess: () => {
       queryClient.invalidateQueries(["motivation-actor-criteria"]);
+    },
+  });
+}
+
+export function useUpdateMotivationPrinciplesCriteria(
+  token: string,
+  mtvId: string,
+) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (putData: PrincipleCriterion[]) => {
+      return APIClient(token).put(
+        `/registry/motivations/${mtvId}/principles-criteria`,
+        putData,
+      );
+    },
+    // on change refresh motivation-principle-criteria list
+    onSuccess: () => {
+      queryClient.invalidateQueries(["motivation-principles-criteria"]);
     },
   });
 }

--- a/src/config.json
+++ b/src/config.json
@@ -8,6 +8,7 @@
   },
   "relation_ids": {
     "motivation_principle": "isSupportedBy",
-    "motivation_actor": "dcterms:isRequiredBy"
+    "motivation_actor": "dcterms:isRequiredBy",
+    "motivation_principle_criterion": "maintainedBy"
   }
 }

--- a/src/config.tsx
+++ b/src/config.tsx
@@ -5,4 +5,6 @@ const API: ApiT = config.api;
 
 const relMtvActorId = config.relation_ids.motivation_actor;
 const relMtvPrincipleId = config.relation_ids.motivation_principle;
-export { API, relMtvActorId, relMtvPrincipleId };
+const relMtvPrincpleCriterion =
+  config.relation_ids.motivation_principle_criterion;
+export { API, relMtvActorId, relMtvPrincipleId, relMtvPrincpleCriterion };

--- a/src/pages/motivations/MotivationCriteriaPrinciples.tsx
+++ b/src/pages/motivations/MotivationCriteriaPrinciples.tsx
@@ -1,62 +1,84 @@
 import {
-  useGetAllImperatives,
-  useGetMotivationActorCriteria,
+  useGetAllCriteria,
+  useGetAllPrinciples,
   useGetMotivationCriteria,
-  useUpdateMotivationActorCriteria,
+  useUpdateMotivationPrinciplesCriteria,
 } from "@/api/services/motivations";
 import { AuthContext } from "@/auth";
-import { AlertInfo, Criterion, Imperative } from "@/types";
+import { AlertInfo, Criterion, Principle } from "@/types";
 import { useState, useContext, useEffect, useRef } from "react";
 import { Button, Col, Row, OverlayTrigger, Tooltip } from "react-bootstrap";
 import toast from "react-hot-toast";
-import { FaAward, FaInfo, FaMinusCircle, FaPlusCircle } from "react-icons/fa";
+import {
+  FaAward,
+  FaExclamationTriangle,
+  FaInfo,
+  FaMinusCircle,
+  FaPlusCircle,
+  FaTags,
+} from "react-icons/fa";
 import { FaTrashCan } from "react-icons/fa6";
-import {} from "react-icons/fa6";
 import { useParams, useNavigate } from "react-router-dom";
+import MotivationPrinciplesModal from "./components/MotivationPrinciplesModal";
 
-export default function MotivationActorCriteria() {
+import { relMtvPrincpleCriterion } from "@/config";
+
+export default function MotivationCriteriaPrinciples() {
   const navigate = useNavigate();
   const params = useParams();
 
   const { keycloak, registered } = useContext(AuthContext)!;
 
-  const [imperatives, setImperatives] = useState<Map<string, Imperative>>(
-    new Map(),
-  );
   const [availableCriteria, setAvailableCriteria] = useState<Criterion[]>([]);
-  const [selectedCriteria, setSelectedCriteria] = useState<Criterion[]>([]);
-
-  const mutationUpdate = useUpdateMotivationActorCriteria(
-    keycloak?.token || "",
-    params.mtvId || "",
-    params.actId || "",
+  const [availablePrinciples, setAvailablePrinciples] = useState<Principle[]>(
+    [],
   );
+  const [selectedCriteria, setSelectedCriteria] = useState<Criterion[]>([]);
+  const [targetCriterion, setTargetCriterion] = useState<Criterion | null>(
+    null,
+  );
+  const [showManagePrinciples, setShowManagePrinciples] = useState(false);
 
   const alert = useRef<AlertInfo>({
     message: "",
   });
 
-  const tooltipDeletePrinciple = (
-    <Tooltip id="tip-restore">
-      Delete this principle from the list of Principles for this actor.
-    </Tooltip>
-  );
-
   const {
-    data: impData,
-    fetchNextPage: impFetchNextPage,
-    hasNextPage: impHasNextPage,
-  } = useGetAllImperatives({
+    data: priData,
+    fetchNextPage: priFetchNextPage,
+    hasNextPage: priHasNextPage,
+  } = useGetAllPrinciples({
     size: 5,
     token: keycloak?.token || "",
     isRegistered: registered,
   });
 
+  useEffect(() => {
+    // gather all available principles in one array
+    let tmpPri: Principle[] = [];
+
+    // iterate over backend pages and gather all items in the pri array
+    if (priData?.pages) {
+      priData.pages.map((page) => {
+        tmpPri = [...tmpPri, ...page.content];
+      });
+      if (priHasNextPage) {
+        priFetchNextPage();
+      }
+    }
+    setAvailablePrinciples(tmpPri);
+  }, [priData, priHasNextPage, priFetchNextPage]);
+
+  const mutationUpdate = useUpdateMotivationPrinciplesCriteria(
+    keycloak?.token || "",
+    params.mtvId || "",
+  );
+
   const {
     data: criData,
     fetchNextPage: criFetchNextPage,
     hasNextPage: criHasNextPage,
-  } = useGetMotivationCriteria(params.mtvId || "", {
+  } = useGetAllCriteria({
     size: 5,
     token: keycloak?.token || "",
     isRegistered: registered,
@@ -66,28 +88,11 @@ export default function MotivationActorCriteria() {
     data: selCriData,
     fetchNextPage: selCriFetchNextPage,
     hasNextPage: selCriHasNextPage,
-  } = useGetMotivationActorCriteria(params.mtvId || "", params.actId || "", {
+  } = useGetMotivationCriteria(params.mtvId || "", {
     size: 5,
     token: keycloak?.token || "",
     isRegistered: registered,
   });
-
-  useEffect(() => {
-    // gather all imperatives in one dictionary
-    const tmpImp: Map<string, Imperative> = new Map();
-    // iterate over backend pages and gather all items in the imp dictionary, keyed by imp id
-    if (impData?.pages) {
-      impData.pages.map((page) => {
-        page.content.forEach((item) => {
-          tmpImp.set(item.id, item);
-        });
-      });
-      if (impHasNextPage) {
-        impFetchNextPage();
-      }
-    }
-    setImperatives(tmpImp);
-  }, [impData, impHasNextPage, impFetchNextPage]);
 
   useEffect(() => {
     // gather all motivation actor criteria in one array
@@ -126,53 +131,68 @@ export default function MotivationActorCriteria() {
     setAvailableCriteria(tmpCri.filter((item) => !selCri.includes(item.cri)));
   }, [criData, criHasNextPage, criFetchNextPage, selectedCriteria]);
 
-  function handleUpdateImperative(
-    index: number,
-    criImp: Imperative | undefined,
-  ) {
-    if (criImp === undefined) return;
-    setSelectedCriteria((prevSelCriteria) =>
-      prevSelCriteria.map((selCri, selCriIndx) =>
-        selCriIndx === index
-          ? {
-              ...selCri,
-              imperative: criImp,
-            }
-          : selCri,
-      ),
-    );
-  }
-
   function handleUpdate() {
-    if (selectedCriteria.length > 0) {
-      const criImp = selectedCriteria.map((item) => ({
-        criterion_id: item.id,
-        imperative_id: item.imperative.id,
-      }));
+    if (selectedCriteria) {
+      const priCri = selectedCriteria.flatMap((cri) =>
+        cri.principles.map((pri) => ({
+          criterion_id: cri.id,
+          principle_id: pri.id,
+          annotation_url: "",
+          annotation_text: "",
+          relation: relMtvPrincpleCriterion,
+        })),
+      );
       const promise = mutationUpdate
-        .mutateAsync(criImp)
+        .mutateAsync(priCri)
         .catch((err) => {
           alert.current = {
-            message: "Error during saving Assessment Type Criteria!",
+            message: "Error during saving Motivation Criteria & Principles!",
           };
           throw err;
         })
         .then(() => {
           alert.current = {
-            message: "Assessment Type Criteria Saved!",
+            message: "Motivation Criteria & Principles Saved!",
           };
-          navigate(-1);
+          navigate(`/motivations/${params.mtvId}`);
         });
       toast.promise(promise, {
-        loading: "Saving Assessment Type Criteria...",
+        loading: "Saving Motivation Criteria & Principles...",
         success: () => `${alert.current.message}`,
         error: () => `${alert.current.message}`,
       });
     }
   }
 
+  const handleUpdatePrinciples = (
+    criterionId: string,
+    principles: Principle[],
+  ) => {
+    setSelectedCriteria((prevSelCriteria) =>
+      prevSelCriteria.map((criterion) =>
+        criterion.id === criterionId
+          ? { ...criterion, principles: principles }
+          : criterion,
+      ),
+    );
+  };
+
+  const allPrinciplesSet = selectedCriteria.every(
+    (item) => item.principles && item.principles.length > 0,
+  );
+
   return (
     <div className="pb-4">
+      <MotivationPrinciplesModal
+        principles={availablePrinciples}
+        criterion={targetCriterion}
+        show={showManagePrinciples}
+        onHide={() => {
+          setShowManagePrinciples(false);
+          setTargetCriterion(null);
+        }}
+        handleUpdatePrinciples={handleUpdatePrinciples}
+      />
       <Row className="cat-view-heading-block row border-bottom">
         <Col>
           <h2 className="text-muted cat-view-heading ">
@@ -225,17 +245,15 @@ export default function MotivationActorCriteria() {
       <Row className="mt-4  pb-4">
         <Col className="px-4">
           <div>
-            <strong className="p-1">
-              Available Criteria in this motivation{" "}
-            </strong>
-            <span className="badge bg-primary rounded-pill fs-6">
+            <strong className="p-1">Available Criteria</strong>
+            <span className="ms-1 badge bg-primary rounded-pill fs-6">
               {availableCriteria.length}
             </span>
           </div>
           <div className="alert alert-primary p-2 mt-1">
             <small>
               <FaPlusCircle className="me-2" /> Click an item below to add it to
-              this assessment type...
+              this Motivation...
             </small>
           </div>
           <div className="cat-vh-60 overflow-auto">
@@ -259,14 +277,15 @@ export default function MotivationActorCriteria() {
 
                 <div className="text-muted text-sm">{item.description}</div>
                 <div>
-                  {item.principles.map((principle) => (
-                    <span
-                      key={principle.id}
-                      className="badge bg-light text-dark me-1 text-ms border"
-                    >
-                      {principle.pri} - {principle.label}
-                    </span>
-                  ))}
+                  {item.principles &&
+                    item.principles.map((principle) => (
+                      <span
+                        key={principle.id}
+                        className="badge bg-light text-dark me-1 text-ms border"
+                      >
+                        {principle.pri} - {principle.label}
+                      </span>
+                    ))}
                 </div>
               </div>
             ))}
@@ -275,7 +294,7 @@ export default function MotivationActorCriteria() {
         <Col>
           <div>
             <strong className="p-1">
-              Criteria included in the Assessment Type
+              Criteria included in this motivation
             </strong>
             <span className="badge bg-primary rounded-pill fs-6">
               {selectedCriteria.length}
@@ -289,38 +308,49 @@ export default function MotivationActorCriteria() {
           </div>
           <div>
             <div className="cat-vh-60 overflow-auto">
-              {selectedCriteria?.map((item, index) => (
-                <div key={item.cri} className="mb-4 p-2 cat-select-item">
+              {selectedCriteria?.map((item) => (
+                <div
+                  key={item.cri}
+                  className={`mb-4 p-2 cat-select-item ${!item.principles || item.principles.length === 0 ? "border rounded border-danger" : null}`}
+                >
+                  {(!item.principles || item.principles.length === 0) && (
+                    <div className="text-danger mb-1">
+                      <small>
+                        <FaExclamationTriangle /> No principles defined! -
+                        Please use the button below to manage them...
+                      </small>
+                    </div>
+                  )}
                   <div className="d-inline-flex align-items-center">
                     <div>
                       <FaAward className="me-2" />
                       <strong>
                         {item.cri} - {item.label}
                       </strong>
-                      <select
-                        className="ms-2 badge badge-sm bg-light text-success border border-success"
-                        value={item.imperative.id}
-                        onChange={(e) => {
-                          handleUpdateImperative(
-                            index,
-                            imperatives.get(e.target.value),
-                          );
-                        }}
-                      >
-                        {Array.from(imperatives.values()).map((impItem) => (
-                          <option key={impItem.id} value={impItem.id}>
-                            {impItem.label}
-                          </option>
-                        ))}
-                      </select>
                       <OverlayTrigger
                         placement="top"
-                        overlay={tooltipDeletePrinciple}
+                        overlay={<Tooltip>Manage Principles</Tooltip>}
                       >
                         <Button
                           size="sm"
                           variant="light"
                           className="ms-4"
+                          onClick={() => {
+                            setTargetCriterion(item);
+                            setShowManagePrinciples(true);
+                          }}
+                        >
+                          <FaTags className="text-dark" />
+                        </Button>
+                      </OverlayTrigger>
+                      <OverlayTrigger
+                        placement="top"
+                        overlay={<Tooltip>Delete Criterion</Tooltip>}
+                      >
+                        <Button
+                          size="sm"
+                          variant="light"
+                          className="ms-2"
                           onClick={() => {
                             setSelectedCriteria(
                               selectedCriteria.filter(
@@ -337,14 +367,15 @@ export default function MotivationActorCriteria() {
 
                   <div className="text-muted text-sm">{item.description}</div>
                   <div>
-                    {item.principles.map((principle) => (
-                      <span
-                        key={principle.pri}
-                        className="badge bg-light text-dark me-1 text-ms border"
-                      >
-                        {principle.pri} - {principle.label}
-                      </span>
-                    ))}
+                    {item.principles &&
+                      item.principles.map((principle) => (
+                        <span
+                          key={principle.pri}
+                          className="badge bg-light text-dark me-1 text-ms border"
+                        >
+                          {principle.pri} - {principle.label}
+                        </span>
+                      ))}
                   </div>
                 </div>
               ))}
@@ -356,7 +387,7 @@ export default function MotivationActorCriteria() {
         <Button
           variant="secondary"
           onClick={() => {
-            navigate(-1);
+            navigate(`/motivations/${params.mtvId}`);
           }}
         >
           Back
@@ -366,6 +397,7 @@ export default function MotivationActorCriteria() {
           onClick={() => {
             handleUpdate();
           }}
+          disabled={!allPrinciplesSet}
         >
           Save
         </Button>

--- a/src/pages/motivations/MotivationDetails.tsx
+++ b/src/pages/motivations/MotivationDetails.tsx
@@ -172,6 +172,15 @@ export default function MotivationDetails() {
             >
               Update Details
             </Link>
+            {motivation !== undefined && (
+              <Link
+                id="manage-motivation-criteria-principles"
+                to={`/motivations/${motivation.id}/manage-criteria-principles`}
+                className="btn btn-dark mt-4"
+              >
+                Manage Criteria & Principles
+              </Link>
+            )}
           </div>
         </Col>
         <Col className="col-md-auto col-lg-9 border-right">
@@ -435,7 +444,7 @@ export default function MotivationDetails() {
         <Button
           variant="secondary"
           onClick={() => {
-            navigate(-1);
+            navigate(`/motivations`);
           }}
         >
           Back

--- a/src/pages/motivations/components/MotivationPrinciplesModal.tsx
+++ b/src/pages/motivations/components/MotivationPrinciplesModal.tsx
@@ -1,0 +1,191 @@
+import { Criterion, Principle } from "@/types";
+import { useState, useEffect } from "react";
+import {
+  Button,
+  Col,
+  Row,
+  OverlayTrigger,
+  Tooltip,
+  Modal,
+} from "react-bootstrap";
+
+import { FaAward, FaMinusCircle, FaPlusCircle, FaTags } from "react-icons/fa";
+import { FaTrashCan } from "react-icons/fa6";
+
+interface MotivationPrinciplesModalProps {
+  criterion: Criterion | null;
+  principles: Principle[];
+  show: boolean;
+  onHide: () => void;
+  handleUpdatePrinciples: (criterionId: string, princples: Principle[]) => void;
+}
+
+export default function MotivationPrinciplesModal(
+  props: MotivationPrinciplesModalProps,
+) {
+  const [availablePrinciples, setAvailablePrinciples] = useState<Principle[]>(
+    [],
+  );
+  const [selectedPrinciples, setSelectedPrinciples] = useState<Principle[]>([]);
+
+  useEffect(() => {
+    const selIds = props.criterion?.principles
+      ? props.criterion?.principles.map((item) => item.id)
+      : [];
+    setSelectedPrinciples(
+      props.principles.filter((item) => selIds.includes(item.id)),
+    );
+    setAvailablePrinciples(
+      props.principles.filter((item) => !selIds.includes(item.id)),
+    );
+  }, [props]);
+
+  return (
+    <Modal
+      show={props.show}
+      onHide={props.onHide}
+      size="lg"
+      aria-labelledby="contained-modal-title-vcenter"
+      centered
+    >
+      <Modal.Header className="bg-success text-white" closeButton>
+        <Modal.Title id="contained-modal-title-vcenter">
+          <FaTags className="me-2" /> Manage Principles
+        </Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        {props.criterion && (
+          <Row className="border-bottom pb-2">
+            <div>
+              <strong>
+                <FaAward /> {props.criterion.cri} - {props.criterion.label}
+              </strong>
+            </div>
+            <div>
+              <small>{props.criterion.description}</small>
+            </div>
+          </Row>
+        )}
+        <Row className="mt-4  pb-4">
+          <Col className="px-4">
+            <div>
+              <strong className="p-1">Available Principles</strong>
+              <span className="ms-1 badge bg-primary rounded-pill fs-6">
+                {availablePrinciples.length}
+              </span>
+            </div>
+            <div className="alert alert-primary p-2 mt-1">
+              <small>
+                <FaPlusCircle className="me-2" /> Click an item below to add
+                it...
+              </small>
+            </div>
+            <div className="cat-vh-40 overflow-auto">
+              {availablePrinciples?.map((item) => (
+                <div
+                  key={item.pri}
+                  className="mb-4 p-2 cat-select-item"
+                  onClick={() => {
+                    setSelectedPrinciples([...selectedPrinciples, item]);
+                    setAvailablePrinciples(
+                      availablePrinciples.filter((pri) => pri.id != item.id),
+                    );
+                  }}
+                >
+                  <div className="d-inline-flex align-items-center">
+                    <FaTags className="me-2" />
+                    <strong>
+                      {item.pri} - {item.label}
+                    </strong>
+                  </div>
+
+                  <div className="text-muted text-sm">{item.description}</div>
+                </div>
+              ))}
+            </div>
+          </Col>
+          <Col>
+            <div>
+              <strong className="p-1">
+                Principles linked to this criterion
+              </strong>
+              <span className="badge bg-primary rounded-pill fs-6">
+                {selectedPrinciples.length}
+              </span>
+            </div>
+            <div className="alert alert-primary p-2 mt-1">
+              <small>
+                <FaMinusCircle className="me-2" /> Click an item below to remove
+                it...
+              </small>
+            </div>
+            <div>
+              <div className="cat-vh-40 overflow-auto">
+                {selectedPrinciples?.map((item) => (
+                  <div key={item.pri} className="mb-4 p-2 cat-select-item">
+                    <div className="d-inline-flex align-items-center">
+                      <div>
+                        <FaTags className="me-2" />
+                        <strong>
+                          {item.pri} - {item.label}
+                        </strong>
+                        <OverlayTrigger
+                          placement="top"
+                          overlay={<Tooltip>Delete Principle</Tooltip>}
+                        >
+                          <Button
+                            size="sm"
+                            variant="light"
+                            className="ms-4"
+                            onClick={() => {
+                              setSelectedPrinciples(
+                                selectedPrinciples.filter(
+                                  (selItem) => selItem.id != item.id,
+                                ),
+                              );
+                              setAvailablePrinciples([
+                                ...availablePrinciples,
+                                item,
+                              ]);
+                            }}
+                          >
+                            <FaTrashCan className="text-danger" />
+                          </Button>
+                        </OverlayTrigger>
+                      </div>
+                    </div>
+                    <div className="text-muted text-sm">{item.description}</div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </Col>
+        </Row>
+        <Modal.Footer className="d-flex justify-content-between">
+          <Button
+            variant="secondary"
+            onClick={() => {
+              props.onHide();
+              setSelectedPrinciples([]);
+            }}
+          >
+            Cancel
+          </Button>
+          <Button
+            variant="success"
+            onClick={() => {
+              props.onHide();
+              props.handleUpdatePrinciples(
+                props.criterion?.id || "",
+                selectedPrinciples,
+              );
+              setSelectedPrinciples([]);
+            }}
+          >
+            Update
+          </Button>
+        </Modal.Footer>
+      </Modal.Body>
+    </Modal>
+  );
+}

--- a/src/types/motivation.ts
+++ b/src/types/motivation.ts
@@ -74,6 +74,14 @@ export type MotivationTypeResponse = ResponsePage<MotivationType[]>;
 
 export type MotivationActorResponse = ResponsePage<MotivationActor[]>;
 
+export type PrincipleCriterion = {
+  criterion_id: string;
+  principle_id: string;
+  annotation_url: string;
+  annotation_text: string;
+  relation: string;
+};
+
 export interface MotivationMessage {
   code: string;
   messages: string[];


### PR DESCRIPTION
### Goal
Allow user to define which criteria and principles take part in a specific Motivation. User selects the criteria and connects them with principles that describe them. 

### Implementation
- [x] Implement MotivationPrincipleCriteria view that displays a list of all available (in the system criteria) and allows the user to select some
- [x] Implement MotivationPrincipleModal component that displays a modal for managing principles for a specific Criterion
- [x] Implement useGetAllCriteria backend method to retrieve all available criteria in the system
- [x] Implement useUpdateMotivationPrinciplesCriteria method to update criteria and principles connections under a motivation
- [x] Add PrincipleCriterion type
