### PR TITLE
CAT-581 Use new actor ids in validations

### DIFF
--- a/src/api/services/actors.ts
+++ b/src/api/services/actors.ts
@@ -1,7 +1,12 @@
 import { AxiosError } from "axios";
-import { ActorListResponse, ApiPaginationOptions } from "@/types";
+import {
+  ActorListResponse,
+  ApiOptions,
+  ApiPaginationOptions,
+  RegistryActorListResponse,
+} from "@/types";
 import { APIClient } from "@/api";
-import { useQuery } from "@tanstack/react-query";
+import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
 import { handleBackendError } from "@/utils";
 
 export const useGetActors = ({ size, page, sortBy }: ApiPaginationOptions) =>
@@ -16,4 +21,31 @@ export const useGetActors = ({ size, page, sortBy }: ApiPaginationOptions) =>
     onError: (error: AxiosError) => {
       return handleBackendError(error);
     },
+  });
+
+export const useGetAllRegistryActors = ({
+  token,
+  isRegistered,
+  size,
+}: ApiOptions) =>
+  useInfiniteQuery({
+    queryKey: ["all-registry-actors"],
+    queryFn: async ({ pageParam = 1 }) => {
+      const response = await APIClient(token).get<RegistryActorListResponse>(
+        `/codelist/registry-actors?size=${size}&page=${pageParam}`,
+      );
+      return response.data;
+    },
+    getNextPageParam: (lastPage) => {
+      if (lastPage.number_of_page < lastPage.total_pages) {
+        return lastPage.number_of_page + 1;
+      } else {
+        return undefined;
+      }
+    },
+    onError: (error: AxiosError) => {
+      return handleBackendError(error);
+    },
+    retry: false,
+    enabled: isRegistered,
   });

--- a/src/api/services/validations.ts
+++ b/src/api/services/validations.ts
@@ -122,7 +122,7 @@ export const useValidationRequest = ({
   organisation_source,
   organisation_name,
   organisation_website,
-  actor_id,
+  registry_actor_id,
   token,
 }: ValidationRequestParams) =>
   useMutation(
@@ -135,7 +135,7 @@ export const useValidationRequest = ({
           organisation_source,
           organisation_name,
           organisation_website,
-          actor_id,
+          registry_actor_id,
           token,
         },
       );

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -19,12 +19,20 @@ export interface ResponsePage<T> {
   content: T;
 }
 
+export interface RegistryActor {
+  id: string;
+  act: string;
+  label: string;
+  description: string;
+}
+
 export interface Actor {
   id: string;
   name: string;
   description: string;
 }
 
+export type RegistryActorListResponse = ResponsePage<RegistryActor[]>;
 export type ActorListResponse = ResponsePage<Actor[]>;
 export type SubjectListResponse = ResponsePage<Subject[]>;
 

--- a/src/types/validation.ts
+++ b/src/types/validation.ts
@@ -11,13 +11,15 @@ export type ValidationResponse = {
   organisation_source: string;
   organisation_name: string;
   organisation_website: string;
-  actor_id: number;
-  actor_name: string;
+  actor_id?: number;
+  actor_name?: string;
   status: string;
   created_on: string;
   validated_on: string;
   validated_by: string;
   rejection_reason: string;
+  registry_actor_id?: string;
+  registry_actor_name?: string;
 };
 
 export type APIValidationResponse = ResponsePage<ValidationResponse[]>;
@@ -28,7 +30,8 @@ export interface ValidationRequest {
   organisation_source: string;
   organisation_name: string;
   organisation_website: string;
-  actor_id: number;
+  actor_id?: number;
+  registry_actor_id?: string;
 }
 
 export interface ValidationDetailsRequest {


### PR DESCRIPTION
### Goal
Validation Requests should use the new actor ids (example: `pidgraph:333990)

### Implementation
- [x] Implement new backend method to fetch all registry actors (using backends `/codelist/registry-actors`
- [x] Update types to accomodate RegistryActor object that has all the necessary fields of the new actors
- [x] Update validation backend request to use the `registry_actor_id` parameter
- [x] Update the Validation Request form to fetch the new actors and populate the correct elements
