### PR TITLE
CAT-582 Support new actors and motivations in assessment editor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@hookform/error-message": "^2.0.1",
         "@react-pdf/renderer": "^4.0.0",
         "@tanstack/react-query": "^4.35.0",
+        "@tanstack/react-query-devtools": "^4.36.1",
         "@tanstack/react-table": "^8.9.8",
         "axios": "^1.7.7",
         "bootstrap": "^5.3.1",
@@ -1532,6 +1533,22 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@tanstack/match-sorter-utils": {
+      "version": "8.19.4",
+      "resolved": "https://registry.npmjs.org/@tanstack/match-sorter-utils/-/match-sorter-utils-8.19.4.tgz",
+      "integrity": "sha512-Wo1iKt2b9OT7d+YGhvEPD3DXvPv2etTusIMhMUoG7fbhmxcXCtIjJDEygy91Y2JFlwGyjqiBPRozme7UD8hoqg==",
+      "license": "MIT",
+      "dependencies": {
+        "remove-accents": "0.5.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
     "node_modules/@tanstack/query-core": {
       "version": "4.36.1",
       "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-4.36.1.tgz",
@@ -1565,6 +1582,26 @@
         "react-native": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@tanstack/react-query-devtools": {
+      "version": "4.36.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-4.36.1.tgz",
+      "integrity": "sha512-WYku83CKP3OevnYSG8Y/QO9g0rT75v1om5IvcWUwiUZJ4LanYGLVCZ8TdFG5jfsq4Ej/lu2wwDAULEUnRIMBSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/match-sorter-utils": "^8.7.0",
+        "superjson": "^1.10.0",
+        "use-sync-external-store": "^1.2.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "@tanstack/react-query": "^4.36.1",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/@tanstack/react-table": {
@@ -2933,6 +2970,21 @@
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
       "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A=="
+    },
+    "node_modules/copy-anything": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-3.0.5.tgz",
+      "integrity": "sha512-yCEafptTtb4bk7GLEQoM8KVJpxAfdBJYaXyzQEgQQQgYrZiDp8SJmGKlYza6CYjEDNstAdNdKA3UuoULlEbS6w==",
+      "license": "MIT",
+      "dependencies": {
+        "is-what": "^4.1.8"
+      },
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
     },
     "node_modules/copy-to-clipboard": {
       "version": "3.3.3",
@@ -5543,6 +5595,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-what": {
+      "version": "4.1.16",
+      "resolved": "https://registry.npmjs.org/is-what/-/is-what-4.1.16.tgz",
+      "integrity": "sha512-ZhMwEosbFJkA0YhFnNDgTM4ZxDRsS6HqTo7qsZM08fehyRYIYa0yHu5R6mgo1n/8MgaPBXiPimPD77baVFYg+A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
     "node_modules/is-wsl": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
@@ -7844,6 +7908,12 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/remove-accents": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.5.0.tgz",
+      "integrity": "sha512-8g3/Otx1eJaVD12e31UbJj1YzdtVvzH85HV7t+9MJYk/u3XmkOUJ5Ys9wQrf9PCPK8+xn4ymzqYCiZl6QWKn+A==",
+      "license": "MIT"
+    },
     "node_modules/request-progress": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-3.0.0.tgz",
@@ -8750,6 +8820,18 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
       "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw=="
+    },
+    "node_modules/superjson": {
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/superjson/-/superjson-1.13.3.tgz",
+      "integrity": "sha512-mJiVjfd2vokfDxsQPOwJ/PtanO87LhpYY88ubI5dUB1Ab58Txbyje3+jpm+/83R/fevaq/107NNhtYBLuoTrFg==",
+      "license": "MIT",
+      "dependencies": {
+        "copy-anything": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/supports-color": {
       "version": "5.5.0",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@hookform/error-message": "^2.0.1",
     "@react-pdf/renderer": "^4.0.0",
     "@tanstack/react-query": "^4.35.0",
+    "@tanstack/react-query-devtools": "^4.36.1",
     "@tanstack/react-table": "^8.9.8",
     "axios": "^1.7.7",
     "bootstrap": "^5.3.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,4 @@
 import { BrowserRouter, Routes, Route } from "react-router-dom";
-
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 import { AuthProvider, ProtectedRoute, KeycloakLogout } from "@/auth";

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -5,11 +5,11 @@ export const APIClient = (token?: string) => {
   // if token is provided create a client with auth header
   const client = token
     ? axios.create({
-        baseURL: `${API.base_url}/${API.version}/`,
+        baseURL: `${API.base_url}`,
         headers: { Authorization: `Bearer ${token}` },
       })
     : axios.create({
-        baseURL: `${API.base_url}/${API.version}/`,
+        baseURL: `${API.base_url}`,
       });
 
   client.defaults.headers.common["Content-Type"] = "application/json";

--- a/src/api/services/actors.ts
+++ b/src/api/services/actors.ts
@@ -14,7 +14,7 @@ export const useGetActors = ({ size, page, sortBy }: ApiPaginationOptions) =>
     queryKey: ["actors", { size, page, sortBy }],
     queryFn: async () => {
       const response = await APIClient("").get<ActorListResponse>(
-        `/codelist/actors?size=${size}&page=${page}&sortby=${sortBy}`,
+        `/v1/codelist/actors?size=${size}&page=${page}&sortby=${sortBy}`,
       );
       return response.data;
     },
@@ -32,7 +32,7 @@ export const useGetAllRegistryActors = ({
     queryKey: ["all-registry-actors"],
     queryFn: async ({ pageParam = 1 }) => {
       const response = await APIClient(token).get<RegistryActorListResponse>(
-        `/codelist/registry-actors?size=${size}&page=${pageParam}`,
+        `/v1/codelist/registry-actors?size=${size}&page=${pageParam}`,
       );
       return response.data;
     },

--- a/src/api/services/assessments.ts
+++ b/src/api/services/assessments.ts
@@ -26,7 +26,7 @@ export function useCreateAssessment(token: string) {
   const navigate = useNavigate();
   return useMutation({
     mutationFn: (postData: { assessment_doc: Assessment }) => {
-      return APIClient(token).post("/assessments", postData);
+      return APIClient(token).post("/v2/assessments", postData);
     },
     // for the time being redirect to assessment list
     onSuccess: () => {
@@ -39,7 +39,7 @@ export function useDeleteAssessment(token: string) {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (assessmentId: string) => {
-      return APIClient(token).delete(`/assessments/${assessmentId}`);
+      return APIClient(token).delete(`/v2/assessments/${assessmentId}`);
     },
     // on success refresh assessments query (so that the deleted assessment dissapears from list)
     onSuccess: () => {
@@ -55,7 +55,7 @@ export function useUpdateAssessment(
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (putData: { assessment_doc: Assessment }) => {
-      return APIClient(token).put(`/assessments/${assessmentID}`, putData);
+      return APIClient(token).put(`/v1/assessments/${assessmentID}`, putData);
     },
     // optimistically update the cached data
     onMutate: (newData) => {
@@ -86,8 +86,8 @@ export const useGetAssessments = ({
     queryKey: ["assessments"],
     queryFn: async () => {
       let url = isPublic
-        ? `/assessments/by-type/${assessmentTypeId}/by-actor/${actorId}?size=${size}&page=${page}`
-        : `/assessments?size=${size}&page=${page}`;
+        ? `/v1/assessments/by-type/${assessmentTypeId}/by-actor/${actorId}?size=${size}&page=${page}`
+        : `/v2/assessments?size=${size}&page=${page}`;
 
       subject_name ? (url = `${url}&subject_name=${subject_name}`) : null;
       subject_type ? (url = `${url}&subject_type=${subject_type}`) : null;
@@ -115,7 +115,7 @@ export function useGetAssessmentShares({
   return useQuery({
     queryKey: ["assessment-shares", id],
     queryFn: async () => {
-      const url = `/assessments/${id}/shared-users`;
+      const url = `/v1/assessments/${id}/shared-users`;
       const response = await APIClient(token).get<SharedUsers>(url);
       return response.data;
     },
@@ -132,7 +132,7 @@ export function useShareAssessment(token: string, id: string) {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (postData: { shared_with_user: string }) => {
-      return APIClient(token).post(`/assessments/${id}/share`, postData);
+      return APIClient(token).post(`/v1/assessments/${id}/share`, postData);
     },
     // for the time being redirect to assessment list
     onSuccess: () => {
@@ -159,9 +159,9 @@ export function useGetAssessment({
     queryFn: async () => {
       let url: string;
       if (isPublic) {
-        url = `/assessments/public/${id}`;
+        url = `/v2/assessments/public/${id}`;
       } else {
-        url = `/assessments/${id}`;
+        url = `/v2/assessments/${id}`;
       }
       const response =
         await APIClient(token).get<AssessmentDetailsResponse>(url);
@@ -192,7 +192,7 @@ export function useGetAdminAssessment({
       let totalPages = 1;
 
       do {
-        const url = `/admin/assessments?page=${page}&size=10`;
+        const url = `/v1/admin/assessments?page=${page}&size=10`;
         const response =
           await APIClient(token).get<AssessmentAdminDetailsResponse>(url);
         const data = response.data;
@@ -223,7 +223,7 @@ export function useGetAdminAssessmentById({
   return useQuery({
     queryKey: ["assessment", id],
     queryFn: async () => {
-      const url = `/admin/assessments/${id}`;
+      const url = `/v1/admin/assessments/${id}`;
       const response =
         await APIClient(token).get<AssessmentDetailsResponse>(url);
       return response.data;
@@ -243,8 +243,8 @@ export function useGetObjects({
   actorId,
 }: ApiObjects) {
   const url = actorId
-    ? `/assessments/public-objects/by-type/${assessmentTypeId}/by-actor/${actorId}?size=${size}&page=${page}`
-    : `/assessments/objects?size=${size}&page=${page}`;
+    ? `/v1/assessments/public-objects/by-type/${assessmentTypeId}/by-actor/${actorId}?size=${size}&page=${page}`
+    : `/v1/assessments/objects?size=${size}&page=${page}`;
 
   return useQuery({
     queryKey: ["objects"],
@@ -270,7 +270,7 @@ export function useGetAssessmentTypes({
   return useQuery({
     queryKey: ["assessmentTypes"],
     queryFn: async () => {
-      const url = `/codelist/assessment-types?size=100&page=1`;
+      const url = `/v1/codelist/assessment-types?size=100&page=1`;
       const response = await APIClient(token).get<AssessmentTypeResponse>(url);
       return response.data.content;
     },
@@ -290,7 +290,7 @@ export const useGetAssessmentComments = (
     queryKey: ["assessment-comments", id],
     queryFn: async ({ pageParam = 1 }) => {
       const response = await APIClient(token).get<AssessmentCommentResponse>(
-        `/assessments/${id}/comments?size=${size}&page=${pageParam}`,
+        `/v1/assessments/${id}/comments?size=${size}&page=${pageParam}`,
       );
       return response.data;
     },
@@ -313,7 +313,7 @@ export function useAssessmentCommentAdd(token: string, id: string) {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (postData: { text: string }) => {
-      return APIClient(token).post(`/assessments/${id}/comments`, postData);
+      return APIClient(token).post(`/v1/assessments/${id}/comments`, postData);
     },
     // update query cache
     onSuccess: () => {
@@ -332,7 +332,7 @@ export function useAssessmentCommentUpdate(
   return useMutation({
     mutationFn: (putData: { text: string }) => {
       return APIClient(token).put(
-        `/assessments/${id}/comments/${cid}`,
+        `/v1/assessments/${id}/comments/${cid}`,
         putData,
       );
     },
@@ -352,7 +352,7 @@ export function useAssessmentCommentDelete(
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: () => {
-      return APIClient(token).delete(`/assessments/${id}/comments/${cid}`);
+      return APIClient(token).delete(`/v1/assessments/${id}/comments/${cid}`);
     },
     // update query cache
     onSuccess: () => {

--- a/src/api/services/criteria.ts
+++ b/src/api/services/criteria.ts
@@ -26,7 +26,7 @@ export const useGetCriteria = ({
     queryKey: ["criteria", { size, page }],
     queryFn: async () => {
       const response = await APIClient(token).get<CriterionResponse>(
-        `/registry/criteria?size=${size}&page=${page}`,
+        `/v1/registry/criteria?size=${size}&page=${page}`,
       );
       return response.data;
     },
@@ -51,7 +51,7 @@ export const useGetCriterion = ({
       let response = null;
 
       response = await APIClient(token).get<Criterion>(
-        `/registry/criteria/${id}`,
+        `/v1/registry/criteria/${id}`,
       );
       return response.data;
     },
@@ -66,7 +66,7 @@ export const useGetAllCriteria = ({ token, isRegistered, size }: ApiOptions) =>
     queryKey: ["all-criteria"],
     queryFn: async ({ pageParam = 1 }) => {
       const response = await APIClient(token).get<CriterionResponse>(
-        `/registry/criteria?size=${size}&page=${pageParam}`,
+        `/v1/registry/criteria?size=${size}&page=${pageParam}`,
       );
       return response.data;
     },
@@ -93,7 +93,7 @@ export const useGetAllImperatives = ({
     queryKey: ["all-imperatives"],
     queryFn: async ({ pageParam = 1 }) => {
       const response = await APIClient(token).get<ImperativeResponse>(
-        `/registry/imperatives?size=${size}&page=${pageParam}`,
+        `/v1/registry/imperatives?size=${size}&page=${pageParam}`,
       );
       return response.data;
     },
@@ -119,7 +119,7 @@ export const useCreateCriterion = (
   return useMutation(
     async () => {
       const response = await APIClient(token).post<CriterionResponse>(
-        `/registry/criteria`,
+        `/v1/registry/criteria`,
         {
           cri,
           label,
@@ -151,7 +151,7 @@ export const useGetAllCriterionTypes = ({
     queryKey: ["motivation-types"],
     queryFn: async ({ pageParam = 1 }) => {
       const response = await APIClient(token).get<CriterionTypeResponse>(
-        `/registry/criterion-types?size=${size}&page=${pageParam}`,
+        `/v1/registry/criterion-types?size=${size}&page=${pageParam}`,
       );
       return response.data;
     },
@@ -178,7 +178,7 @@ export const useUpdateCriterion = (
   return useMutation(
     async () => {
       const response = await APIClient(token).patch<CriterionResponse>(
-        `/registry/criteria/${id}`,
+        `/v1/registry/criteria/${id}`,
         {
           cri,
           label,
@@ -203,7 +203,7 @@ export function useDeleteCriterion(token: string) {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (criterionId: string) => {
-      return APIClient(token).delete(`/registry/criteria/${criterionId}`);
+      return APIClient(token).delete(`/v1/registry/criteria/${criterionId}`);
     },
     // on success refresh criteria query (so that the deleted criterion dissapears from list)
     onSuccess: () => {

--- a/src/api/services/motivations.ts
+++ b/src/api/services/motivations.ts
@@ -35,7 +35,7 @@ export const useGetMotivations = ({
     queryKey: ["motivations", { size, page, sortBy }],
     queryFn: async () => {
       const response = await APIClient(token).get<MotivationResponse>(
-        `/registry/motivations?size=${size}&page=${page}&sort=${sortBy}&order=${sortOrder}${search ? "&search=" + search : ""}`,
+        `/v1/registry/motivations?size=${size}&page=${page}&sort=${sortBy}&order=${sortOrder}${search ? "&search=" + search : ""}`,
       );
       return response.data;
     },
@@ -60,7 +60,7 @@ export const useGetMotivation = ({
       let response = null;
 
       response = await APIClient(token).get<Motivation>(
-        `/registry/motivations/${id}`,
+        `/v1/registry/motivations/${id}`,
       );
       return response.data;
     },
@@ -79,7 +79,7 @@ export const useGetMotivationTypes = ({
     queryKey: ["motivation-types"],
     queryFn: async ({ pageParam = 1 }) => {
       const response = await APIClient(token).get<MotivationTypeResponse>(
-        `/registry/motivation-types?size=${size}&page=${pageParam}`,
+        `/v1/registry/motivation-types?size=${size}&page=${pageParam}`,
       );
       return response.data;
     },
@@ -102,7 +102,7 @@ export const useGetAllActors = ({ token, isRegistered, size }: ApiOptions) =>
     queryKey: ["all-actors"],
     queryFn: async ({ pageParam = 1 }) => {
       const response = await APIClient(token).get<MotivationActorResponse>(
-        `/registry/actors?size=${size}&page=${pageParam}`,
+        `/v1/registry/actors?size=${size}&page=${pageParam}`,
       );
       return response.data;
     },
@@ -125,7 +125,7 @@ export const useGetRelations = ({ token, isRegistered, size }: ApiOptions) =>
     queryKey: ["relations"],
     queryFn: async ({ pageParam = 1 }) => {
       const response = await APIClient(token).get<RelationResponse>(
-        `/registry/relations?size=${size}&page=${pageParam}`,
+        `/v1/registry/relations?size=${size}&page=${pageParam}`,
       );
       return response.data;
     },
@@ -151,7 +151,7 @@ export const useCreateMotivation = (
   return useMutation(
     async () => {
       const response = await APIClient(token).post<MotivationResponse>(
-        `/registry/motivations`,
+        `/v1/registry/motivations`,
         {
           mtv,
           label,
@@ -183,7 +183,7 @@ export const useUpdateMotivation = (
   return useMutation(
     async () => {
       const response = await APIClient(token).patch<MotivationResponse>(
-        `/registry/motivations/${id}`,
+        `/v1/registry/motivations/${id}`,
         {
           mtv,
           label,
@@ -215,7 +215,7 @@ export const useMotivationAddActor = (
   return useMutation(
     async () => {
       const response = await APIClient(token).post<MotivationResponse>(
-        `/registry/motivations/${motivationId}/actors`,
+        `/v1/registry/motivations/${motivationId}/actors`,
         [
           {
             actor_id: actorId,
@@ -244,7 +244,7 @@ export const useGetMotivationPrinciples = (
     queryKey: ["motivation-principles"],
     queryFn: async ({ pageParam = 1 }) => {
       const response = await APIClient(token).get<PrincipleResponse>(
-        `/registry/motivations/${mtvId}/principles?size=${size}&page=${pageParam}`,
+        `/v1/registry/motivations/${mtvId}/principles?size=${size}&page=${pageParam}`,
       );
       return response.data;
     },
@@ -270,7 +270,7 @@ export const useGetMotivationCriteria = (
     queryKey: ["motivation-criteria"],
     queryFn: async ({ pageParam = 1 }) => {
       const response = await APIClient(token).get<CriterionResponse>(
-        `/registry/motivations/${mtvId}/criteria?size=${size}&page=${pageParam}`,
+        `/v1/registry/motivations/${mtvId}/criteria?size=${size}&page=${pageParam}`,
       );
       return response.data;
     },
@@ -297,7 +297,7 @@ export const useGetMotivationActorCriteria = (
     queryKey: ["motivation-actor-criteria"],
     queryFn: async ({ pageParam = 1 }) => {
       const response = await APIClient(token).get<CriterionResponse>(
-        `/registry/motivations/${mtvId}/actors/${actId}/criteria?size=${size}&page=${pageParam}`,
+        `/v1/registry/motivations/${mtvId}/actors/${actId}/criteria?size=${size}&page=${pageParam}`,
       );
       return response.data;
     },
@@ -324,7 +324,7 @@ export function useUpdateMotivationActorCriteria(
   return useMutation({
     mutationFn: (putData: CriImp[]) => {
       return APIClient(token).put(
-        `/registry/motivations/${mtvId}/actors/${actId}/criteria`,
+        `/v1/registry/motivations/${mtvId}/actors/${actId}/criteria`,
         putData,
       );
     },
@@ -343,7 +343,7 @@ export function useUpdateMotivationPrinciplesCriteria(
   return useMutation({
     mutationFn: (putData: PrincipleCriterion[]) => {
       return APIClient(token).put(
-        `/registry/motivations/${mtvId}/principles-criteria`,
+        `/v1/registry/motivations/${mtvId}/principles-criteria`,
         putData,
       );
     },

--- a/src/api/services/organisations.ts
+++ b/src/api/services/organisations.ts
@@ -18,7 +18,7 @@ export const useOrganisationRORSearch = ({
       const response = await APIClient(
         token,
       ).get<OrganisationRORSearchResponse>(
-        `/integrations/organisations/ROR/${name}?page=${page}`,
+        `/v1/integrations/organisations/ROR/${name}?page=${page}`,
       );
       return response.data;
     },

--- a/src/api/services/principles.ts
+++ b/src/api/services/principles.ts
@@ -24,7 +24,7 @@ export const useGetPrinciples = ({
     queryKey: ["principles", { size, page }],
     queryFn: async () => {
       const response = await APIClient(token).get<PrincipleResponse>(
-        `/registry/principles?size=${size}&page=${page}`,
+        `/v1/registry/principles?size=${size}&page=${page}`,
       );
       return response.data;
     },
@@ -49,7 +49,7 @@ export const useGetPrinciple = ({
       let response = null;
 
       response = await APIClient(token).get<Principle>(
-        `/registry/principles/${id}`,
+        `/v1/registry/principles/${id}`,
       );
       return response.data;
     },
@@ -68,7 +68,7 @@ export const useGetAllPrinciples = ({
     queryKey: ["all-principles"],
     queryFn: async ({ pageParam = 1 }) => {
       const response = await APIClient(token).get<PrincipleResponse>(
-        `/registry/principles?size=${size}&page=${pageParam}`,
+        `/v1/registry/principles?size=${size}&page=${pageParam}`,
       );
       return response.data;
     },
@@ -94,7 +94,7 @@ export const useCreatePrinciple = (
   return useMutation(
     async () => {
       const response = await APIClient(token).post<PrincipleResponse>(
-        `/registry/principles`,
+        `/v1/registry/principles`,
         {
           pri,
           label,
@@ -124,7 +124,7 @@ export const useUpdatePrinciple = (
   return useMutation(
     async () => {
       const response = await APIClient(token).patch<PrincipleResponse>(
-        `/registry/principles/${id}`,
+        `/v1/registry/principles/${id}`,
         {
           pri,
           label,

--- a/src/api/services/subjects.ts
+++ b/src/api/services/subjects.ts
@@ -16,7 +16,7 @@ export const useGetSubjects = ({
     queryKey: ["subjects"],
     queryFn: async () => {
       const response = await APIClient(token).get<SubjectListResponse>(
-        `/subjects?size=${size}&page=${page}&sortby=${sortBy}`,
+        `/v1/subjects?size=${size}&page=${page}&sortby=${sortBy}`,
       );
       return response.data;
     },
@@ -39,7 +39,9 @@ export function useGetSubject({
   return useQuery({
     queryKey: ["subject", id],
     queryFn: async () => {
-      const response = await APIClient(token).get<Subject>(`/subjects/${id}`);
+      const response = await APIClient(token).get<Subject>(
+        `/v1/subjects/${id}`,
+      );
       return response.data;
     },
     onError: (error: AxiosError) => {
@@ -58,7 +60,7 @@ export function useCreateSubject(token: string) {
       name: string;
       type: string;
     }) => {
-      return APIClient(token).post("/subjects", postData);
+      return APIClient(token).post("/v1/subjects", postData);
     },
     onSuccess: () => {
       queryClient.invalidateQueries(["subjects"]);
@@ -71,7 +73,7 @@ export function useUpdateSubject(token: string) {
   return useMutation(
     async (data: Subject) => {
       const response = await APIClient(token).patch<Subject>(
-        `/subjects/${data.id}`,
+        `/v1/subjects/${data.id}`,
         data,
       );
       if (response.status == 200) {
@@ -92,7 +94,7 @@ export function useDeleteSubject(token: string) {
   const queryClient = useQueryClient();
   return useMutation(
     async (id: number) => {
-      const response = await APIClient(token).delete(`/subjects/${id}`);
+      const response = await APIClient(token).delete(`/v1/subjects/${id}`);
       if (response.status == 200) {
         queryClient.invalidateQueries(["subjects"]);
         queryClient.invalidateQueries(["subject", id]);

--- a/src/api/services/templates.ts
+++ b/src/api/services/templates.ts
@@ -15,7 +15,7 @@ export const useGetTemplate = (
     queryKey: ["template", templateTypeId],
     queryFn: async () => {
       const response = await APIClient(token).get<TemplateResponse>(
-        `/templates/by-type/${templateTypeId}/by-actor/${actorId}`,
+        `/v1/templates/by-type/${templateTypeId}/by-actor/${actorId}`,
       );
       return response.data;
     },
@@ -26,6 +26,27 @@ export const useGetTemplate = (
     refetchOnWindowFocus: false,
   });
 
+export const useGetMotivationTemplate = (
+  mtvId: string,
+  actId: string,
+  token: string,
+  isRegistered: boolean,
+) =>
+  useQuery({
+    queryKey: ["assessment-type", mtvId, actId],
+    queryFn: async () => {
+      const response = await APIClient(token).get<Assessment>(
+        `/v1/templates/by-motivation/${mtvId}/by-actor/${actId}`,
+      );
+      return response.data;
+    },
+    onError: (error: AxiosError) => {
+      return handleBackendError(error);
+    },
+    enabled: !!token && isRegistered && mtvId !== "" && actId !== "",
+    refetchOnWindowFocus: false,
+  });
+
 export const useGetMotivationAssessmentType = (
   mtvId: string,
   actId: string,
@@ -33,10 +54,10 @@ export const useGetMotivationAssessmentType = (
   isRegistered: boolean,
 ) =>
   useQuery({
-    queryKey: ["assessment-type"],
+    queryKey: ["assessment-type", mtvId, actId],
     queryFn: async () => {
       const response = await APIClient(token).get<Assessment>(
-        `/registry/motivations/${mtvId}/by-actor/${actId}/template`,
+        `/v1/registry/motivations/${mtvId}/by-actor/${actId}/template`,
       );
       return response.data;
     },

--- a/src/api/services/users.ts
+++ b/src/api/services/users.ts
@@ -22,7 +22,7 @@ export const useGetProfile = ({ token, isRegistered }: ApiOptions) =>
     queryKey: ["profile"],
     queryFn: async () => {
       const response =
-        await APIClient(token).get<UserResponse>(`/users/profile`);
+        await APIClient(token).get<UserResponse>(`/v1/users/profile`);
       return response.data;
     },
     onError: (error: AxiosError) => {
@@ -41,7 +41,7 @@ export const useGetAsmtEligibility = ({
     queryKey: ["assessment-eligibility"],
     queryFn: async ({ pageParam = 1 }) => {
       const response = await APIClient(token).get<AsmtEligibilityResponse>(
-        `/users/assessment-eligibility?size=${size}&page=${pageParam}`,
+        `/v1/users/registry-assessment-eligibility?size=${size}&page=${pageParam}`,
       );
       return response.data;
     },
@@ -70,7 +70,7 @@ export const useGetAdminUsers = ({
     queryKey: ["users", { size, page, sortBy }],
     queryFn: async () => {
       const response = await APIClient(token).get<UserListResponse>(
-        `/admin/users?size=${size}&page=${page}&sort=${sortBy}`,
+        `/v1/admin/users?size=${size}&page=${page}&sort=${sortBy}`,
       );
       return response.data;
     },
@@ -85,7 +85,7 @@ export const useGetViewUsers = ({ id, token, isRegistered }: ApiViewUsers) =>
     queryKey: ["users", { id }],
     queryFn: async () => {
       const response = await APIClient(token).get<UserView>(
-        `/admin/users/${id}`,
+        `/v1/admin/users/${id}`,
       );
       return response.data;
     },
@@ -109,7 +109,7 @@ export const useAdminGetUsers = ({
   useQuery({
     queryKey: ["users"],
     queryFn: async () => {
-      let url = `/admin/users?size=${size}&page=${page}&sort=${sortBy}&order=${sortOrder}`;
+      let url = `/v1/admin/users?size=${size}&page=${page}&sort=${sortBy}&order=${sortOrder}`;
       search ? (url = `${url}&search=${search}`) : null;
       type ? (url = `${url}&type=${type}`) : null;
       status ? (url = `${url}&status=${status}`) : null;
@@ -127,7 +127,7 @@ export const useUserRegister = () =>
   useMutation(
     async (token: string) => {
       try {
-        const response = await APIClient(token).post(`/users/register`);
+        const response = await APIClient(token).post(`/v1/users/register`);
         if (response.status === 200) {
           return true;
         } else {
@@ -154,7 +154,7 @@ export function useDeleteUser(token: string) {
   return useMutation(
     async (data: UserAccess) => {
       const response = await APIClient(token).put<UserAccess>(
-        "/admin/users/deny-access",
+        "/v1/admin/users/deny-access",
         data,
       );
       if (response.status == 200) {
@@ -176,7 +176,7 @@ export function useRestoreUser(token: string) {
   return useMutation(
     async (data: UserAccess) => {
       const response = await APIClient(token).put<UserAccess>(
-        "/admin/users/permit-access",
+        "/v1/admin/users/permit-access",
         data,
       );
       if (response.status == 200) {

--- a/src/api/services/validations.ts
+++ b/src/api/services/validations.ts
@@ -25,7 +25,7 @@ export const useAdminGetValidations = ({
   useQuery({
     queryKey: ["validations"],
     queryFn: async () => {
-      let url = `/admin/validations?size=${size}&page=${page}`;
+      let url = `/v1/admin/validations?size=${size}&page=${page}`;
       sortBy ? (url = `${url}&sort=${sortBy}`) : null;
       sortOrder ? (url = `${url}&order=${sortOrder}`) : null;
       type ? (url = `${url}&type=${type}`) : null;
@@ -51,7 +51,7 @@ export const useGetValidationList = ({
     queryKey: ["validations", { size, page, sortBy }],
     queryFn: async () => {
       const response = await APIClient(token).get<APIValidationResponse>(
-        `/validations?size=${size}&page=${page}&sortby=${sortBy}`,
+        `/v1/validations?size=${size}&page=${page}&sortby=${sortBy}`,
       );
       return response.data;
     },
@@ -73,7 +73,7 @@ export const useAdminValidations = ({
     queryKey: ["admin_validations", { size, page, sortBy }],
     queryFn: async () => {
       const response = await APIClient(token).get<APIValidationResponse>(
-        `/admin/validations?size=${size}&page=${page}&sortby=${sortBy}`,
+        `/v1/admin/validations?size=${size}&page=${page}&sortby=${sortBy}`,
       );
       return response.data;
     },
@@ -96,11 +96,11 @@ export const useGetValidationDetails = ({
       let response = null;
       if (adminMode) {
         response = await APIClient(token).get<ValidationResponse>(
-          `/admin/validations/${validation_id}`,
+          `/v1/admin/validations/${validation_id}`,
         );
       } else {
         response = await APIClient(token).get<ValidationResponse>(
-          `/validations/${validation_id}`,
+          `/v1/validations/${validation_id}`,
         );
       }
 
@@ -128,7 +128,7 @@ export const useValidationRequest = ({
   useMutation(
     async () => {
       const response = await APIClient(token).post<ValidationResponse>(
-        `/validations`,
+        `/v1/validations`,
         {
           organisation_role,
           organisation_id,
@@ -157,7 +157,7 @@ export const useValidationStatusUpdate = ({
   useMutation(
     async () => {
       const response = await APIClient(token).put<ValidationResponse>(
-        `/admin/validations/${validation_id}/update-status`,
+        `/v1/admin/validations/${validation_id}/update-status`,
         {
           status,
           rejection_reason,

--- a/src/pages/ProfileUpdate.tsx
+++ b/src/pages/ProfileUpdate.tsx
@@ -45,7 +45,7 @@ export default function ProfileUpdate() {
     }
     try {
       const response = await APIClient(keycloak?.token || "").put<FormData>(
-        `/users/profile`,
+        `/v1/users/profile`,
         data,
       );
       if (response.status === 200) {

--- a/src/pages/assessments/components/AssessmentSelectActor.tsx
+++ b/src/pages/assessments/components/AssessmentSelectActor.tsx
@@ -9,20 +9,20 @@ import { ActorOrgAsmtType } from "@/types";
 interface AssessmentSelectActorProps {
   actorMap: ActorOrgAsmtType[];
   asmtId?: string;
-  templateDataActorId?: number;
+  templateDataActorId?: string;
   templateDataOrgId?: string;
-  templateDataAsmtTypeId?: number;
-  actorId?: number;
+  templateDataAsmtTypeId?: string;
+  actorId?: string;
   orgId?: string;
-  asmtTypeId?: number;
-  importAsmtTypeId?: number;
-  importActorId?: number;
+  asmtTypeId?: string;
+  importAsmtTypeId?: string;
+  importActorId?: string;
   onSelectActor: (
-    actorId: number,
+    actorId: string,
     actorName: string,
     orgId: string,
     orgName: string,
-    asmtTypeId: number,
+    asmtTypeId: string,
     asmtTypeName: string,
   ) => void;
 }

--- a/src/types/assessment.ts
+++ b/src/types/assessment.ts
@@ -10,7 +10,7 @@ export interface TemplateResponse {
 
 /** Assessment type part of TemplateResponse from API */
 export interface AssessmentType {
-  id: number;
+  id: string;
   name: string;
   description: string;
 }
@@ -38,14 +38,14 @@ export interface Assessment {
   shared_with_user: boolean;
 }
 
-/** Reference with numerical id */
-export interface RefNumID {
-  id: number;
+/** Reference with string id */
+export interface RefID {
+  id: string;
   name: string;
 }
 
-export interface AssessmentActor extends RefNumID {}
-export interface AssessmentType extends RefNumID {}
+export interface AssessmentActor extends RefID {}
+export interface AssessmentType extends RefID {}
 
 /** Assessment subject */
 export interface AssessmentSubject {
@@ -221,12 +221,21 @@ export interface ResultStats {
   optional: number;
 }
 
+// export type ActorOrgAsmtType = {
+//   actor_id: number;
+//   actor_name: string;
+//   organisation_id: string;
+//   organisation_name: string;
+//   assessment_type_id: number;
+//   assessment_type_name: string;
+// };
+
 export type ActorOrgAsmtType = {
-  actor_id: number;
+  actor_id: string;
   actor_name: string;
   organisation_id: string;
   organisation_name: string;
-  assessment_type_id: number;
+  assessment_type_id: string;
   assessment_type_name: string;
 };
 


### PR DESCRIPTION

- In Assessment Editor wizard updated Step-1 list to fetch new assessment-types (actor-motivations)
- Created two query hooks for fetch templates (one for admins, one for verified users)
- Updated assessment evaluation methods in step-3 of the editor
- API client used the `/v1` prefix from config.json - that meant that backend calls could only be made on one version of the api. Removed the preconfigured prefix and declared it as a part of the path of each method. This allows to make calls to both /v1 and /v2 endpoints
- Updated CREATE, READ, DELETE assessment methods to use /v2/assessment backend calls
- Updated assessment list components to use /v2/assessment methods

⚠️ Breaking-Changes: 
What needs to be updated on the backend to work with the new assessments (/v2):
 - /v1/assessments/{id}/shared-users 
 - /v1/assessments/objects/by-actor/{actor-id}
 - /v1/assessments/by-type/{type-id}/by-actor/{actor-id}
 - /v1/assessments/public-objects/by-type/{type-id}/by-actor/{actor-id}
 - /v1/assessments/public/{id}
 
 Comments seem to work even if calls are in /v1/  