### PR TITLE
CAT-628 Use new assessment update call

### DIFF
--- a/src/api/services/assessments.ts
+++ b/src/api/services/assessments.ts
@@ -55,7 +55,7 @@ export function useUpdateAssessment(
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (putData: { assessment_doc: Assessment }) => {
-      return APIClient(token).put(`/v1/assessments/${assessmentID}`, putData);
+      return APIClient(token).put(`/v2/assessments/${assessmentID}`, putData);
     },
     // optimistically update the cached data
     onMutate: (newData) => {


### PR DESCRIPTION
Update backend hook `useUpdateAssessment` to use the new /v2/ version of the cat-api call