### PR TITLE
CAT-634 Update backend calls for objects for v2 assessments

### DIFF
--- a/src/api/services/actors.ts
+++ b/src/api/services/actors.ts
@@ -1,6 +1,5 @@
 import { AxiosError } from "axios";
 import {
-  ActorListResponse,
   ApiOptions,
   ApiPaginationOptions,
   RegistryActorListResponse,
@@ -13,8 +12,8 @@ export const useGetActors = ({ size, page, sortBy }: ApiPaginationOptions) =>
   useQuery({
     queryKey: ["actors", { size, page, sortBy }],
     queryFn: async () => {
-      const response = await APIClient("").get<ActorListResponse>(
-        `/v1/codelist/actors?size=${size}&page=${page}&sortby=${sortBy}`,
+      const response = await APIClient("").get<RegistryActorListResponse>(
+        `/v1/codelist/registry-actors?size=${size}&page=${page}&sortby=${sortBy}`,
       );
       return response.data;
     },

--- a/src/api/services/assessments.ts
+++ b/src/api/services/assessments.ts
@@ -80,13 +80,13 @@ export const useGetAssessments = ({
   subject_type,
   isPublic,
   actorId,
-  assessmentTypeId,
+  motivationId,
 }: ApiAssessments) =>
   useQuery({
     queryKey: ["assessments"],
     queryFn: async () => {
       let url = isPublic
-        ? `/v1/assessments/by-type/${assessmentTypeId}/by-actor/${actorId}?size=${size}&page=${page}`
+        ? `/v2/assessments/by-motivation/${motivationId}/by-actor/${actorId}?size=${size}&page=${page}`
         : `/v2/assessments?size=${size}&page=${page}`;
 
       subject_name ? (url = `${url}&subject_name=${subject_name}`) : null;
@@ -243,8 +243,8 @@ export function useGetObjects({
   actorId,
 }: ApiObjects) {
   const url = actorId
-    ? `/v1/assessments/public-objects/by-type/${assessmentTypeId}/by-actor/${actorId}?size=${size}&page=${page}`
-    : `/v1/assessments/objects?size=${size}&page=${page}`;
+    ? `/v2/assessments/public-objects/by-motivation/${assessmentTypeId}/by-actor/${actorId}?size=${size}&page=${page}`
+    : `/v2/assessments/objects?size=${size}&page=${page}`;
 
   return useQuery({
     queryKey: ["objects"],

--- a/src/pages/assessments/AssessmentView.tsx
+++ b/src/pages/assessments/AssessmentView.tsx
@@ -75,7 +75,7 @@ const AssessmentView = ({ isPublic }: { isPublic: boolean }) => {
   const stats = gatherStats(assessment);
 
   return (
-    <div>
+    <div className={isPublic ? "container bg-light p-2 mb-5 rounded" : ""}>
       {assessment && (
         <div className="">
           <Row>

--- a/src/pages/assessments/Assessments.tsx
+++ b/src/pages/assessments/Assessments.tsx
@@ -33,28 +33,28 @@ function Assessments() {
   const cardProps: CardProps[] = [];
 
   const cardImgs: Record<string, string> = {
-    "PID Scheme": schemesImg,
-    "PID Manager": manageImg,
-    "PID Service Provider": serviceImg,
-    "PID Owner": ownersImg,
-    "PID Authority": authImg,
+    "PID Scheme (Component)": schemesImg,
+    "PID Manager (Role)": manageImg,
+    "PID Service Provider (Role)": serviceImg,
+    "PID Owner (Role)": ownersImg,
+    "PID Authority (Role)": authImg,
   };
 
   // generate the cards when actor data is loaded
   if (!actorsData.isLoading && actorsData.data) {
     actorsData.data.content.forEach((actorItem) => {
       // get the image
-      const cardImg = cardImgs[actorItem.name] || null;
+      const cardImg = cardImgs[actorItem.label] || null;
       if (cardImg) {
         cardProps.push({
           id: parseInt(actorItem.id),
-          title: actorItem.name,
+          title: actorItem.label,
           description: actorItem.description,
           image: cardImg,
           linkText: `View public assessments`,
           link: `/public-assessments?actor-id=${
             actorItem.id
-          }&assessment-type-id=${1}&actor-name=${actorItem.name}`,
+          }&motivation-id=${"pid_graph:3E109BBA"}&actor-name=${actorItem.label}`,
         });
       }
     });

--- a/src/pages/assessments/AssessmentsList.tsx
+++ b/src/pages/assessments/AssessmentsList.tsx
@@ -86,7 +86,7 @@ function AssessmentsList({ listPublic = false }: AssessmentListProps) {
   const urlParams = new URLSearchParams(location.search);
   const actorName = urlParams.get("actor-name");
   const actorIdParam = urlParams.get("actor-id");
-  const assessmentTypeIdParam = urlParams.get("assessment-type-id");
+  const motivationIdParam = urlParams.get("motivation-id");
 
   const [opts, setOpts] = useState<Pagination>({
     page: 1,
@@ -137,7 +137,7 @@ function AssessmentsList({ listPublic = false }: AssessmentListProps) {
     subject_type: filters.subject_type,
     isPublic: listPublic,
     actorId: actorIdParam || "",
-    assessmentTypeId: assessmentTypeIdParam || "",
+    motivationId: motivationIdParam || "",
   });
 
   // refetch users when parameters change
@@ -149,7 +149,7 @@ function AssessmentsList({ listPublic = false }: AssessmentListProps) {
     size: 100,
     page: 1,
     token: keycloak?.token || "",
-    assessmentTypeId: assessmentTypeIdParam || "",
+    assessmentTypeId: motivationIdParam || "",
     actorId: actorIdParam || "",
   });
 
@@ -246,7 +246,7 @@ function AssessmentsList({ listPublic = false }: AssessmentListProps) {
   const assessments: AssessmentListItem[] = data ? data?.content : [];
 
   return (
-    <div>
+    <div className={listPublic ? "container bg-light p-2 mb-5 rounded" : ""}>
       <ShareModal
         show={shareModalConfig.show}
         name={shareModalConfig.name}

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -124,7 +124,7 @@ export type ApiAssessments = ApiOptions & {
   subject_type: string;
   subject_name: string;
   actorId: string;
-  assessmentTypeId: string;
+  motivationId: string;
 };
 
 export type ApiValidations = ApiOptions & {


### PR DESCRIPTION
### Goal
Update backend calls to fetch objects for public and non-public assessments. Update assess page to show v2 public assessment per v2 actors

### Implementations
- [x] Update useGetActor backend call to fetch new actors 
- [x] Update backend calls to fetch objects for `v2/assessments`
- [x] Update Assessments welcome page to create cards based on new actors and motivation EOSC PID policy (hardcoded)
- [x] Update AssessmentList to show public assessments per motivation and actor
- [x] Update types