### PR TITLE
CAT-630 Toggle publish in motivations and assessment types

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -124,6 +124,10 @@
   background-color: #fff;
 }
 
+.cat-row-grey {
+  background-color: grey;
+}
+
 .cat-admin-container {
   width: 100%;
 }
@@ -349,6 +353,10 @@ footer a {
 
 .cat-text-faded {
   color: lightgrey;
+}
+
+.cat-greyscale {
+  filter: grayscale(100%);
 }
 
 .list-group-item:nth-child(even) {

--- a/src/api/services/motivations.ts
+++ b/src/api/services/motivations.ts
@@ -55,7 +55,7 @@ export const useGetMotivation = ({
   isRegistered: boolean;
 }) =>
   useQuery({
-    queryKey: ["motivation", id],
+    queryKey: ["motivations", id],
     queryFn: async () => {
       let response = null;
 
@@ -102,7 +102,7 @@ export const useGetAllActors = ({ token, isRegistered, size }: ApiOptions) =>
     queryKey: ["all-actors"],
     queryFn: async ({ pageParam = 1 }) => {
       const response = await APIClient(token).get<MotivationActorResponse>(
-        `/v1/registry/actors?size=${size}&page=${pageParam}`,
+        `/v1/codelist/registry-actors?size=${size}&page=${pageParam}`,
       );
       return response.data;
     },
@@ -174,6 +174,64 @@ export const useCreateMotivation = (
   );
 };
 
+export function usePublishMotivation(token: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (mtvId: string) => {
+      return APIClient(token).put(`/v1/registry/motivations/${mtvId}/publish`);
+    },
+    // on success refresh motivation query
+    onSuccess: () => {
+      queryClient.invalidateQueries(["motivations"]);
+    },
+  });
+}
+
+export function useUnpublishMotivation(token: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (mtvId: string) => {
+      return APIClient(token).put(
+        `/v1/registry/motivations/${mtvId}/unpublish`,
+      );
+    },
+    // on success refresh motivation query
+    onSuccess: () => {
+      queryClient.invalidateQueries(["motivations"]);
+    },
+  });
+}
+
+export function usePublishMotivationActor(token: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ mtvId, actId }: { mtvId: string; actId: string }) => {
+      return APIClient(token).put(
+        `/v1/registry/motivations/${mtvId}/actors/${actId}/publish`,
+      );
+    },
+    // on success refresh motivations/mtvId query
+    onSuccess: (_, params) => {
+      queryClient.invalidateQueries(["motivations", params.mtvId]);
+    },
+  });
+}
+
+export function useUnpublishMotivationActor(token: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ mtvId, actId }: { mtvId: string; actId: string }) => {
+      return APIClient(token).put(
+        `/v1/registry/motivations/${mtvId}/actors/${actId}/unpublish`,
+      );
+    },
+    // on success refresh motivations/mtvId query
+    onSuccess: (_, params) => {
+      queryClient.invalidateQueries(["motivations", params.mtvId]);
+    },
+  });
+}
+
 export const useUpdateMotivation = (
   token: string,
   id: string,
@@ -199,7 +257,7 @@ export const useUpdateMotivation = (
         return handleBackendError(error);
       },
       onSuccess: () => {
-        queryClient.invalidateQueries(["motivation", id]);
+        queryClient.invalidateQueries(["motivations", id]);
       },
     },
   );
@@ -230,7 +288,7 @@ export const useMotivationAddActor = (
         return handleBackendError(error);
       },
       onSuccess: () => {
-        queryClient.invalidateQueries(["motivation", motivationId]);
+        queryClient.invalidateQueries(["motivations", motivationId]);
       },
     },
   );

--- a/src/types/motivation.ts
+++ b/src/types/motivation.ts
@@ -13,6 +13,7 @@ export interface Motivation {
   last_touch: string;
   actors: MotivationActor[];
   principles: Principle[];
+  published: boolean;
 }
 
 export interface MotivationInput {
@@ -30,6 +31,7 @@ export interface MotivationActor {
   description: string;
   uri: string;
   last_touch: string;
+  published: boolean;
 }
 
 export interface MotivationType {


### PR DESCRIPTION
### Goal
Allow user to publish/unpublish motivations. Also allow the user -under a motivation- to publish/unpublish assessment types (Motivation-Actor items) 

### Implementation
- [x] Implement backend calls for publish/unpublish motivation item
- [x] Implement backend calls for publish/unpublish motivation-actor item
- [x] Update motivations list with extra publish/unpublish button and make unpublished rows more muted
- [x] Update assessment type list (in motivation details view) with extra publish/unpublish button and make unpublished rows more muted (and images grey)
- [x] Simplify predefined image assignment to specific Motivation Actors 
- [x] Update motivation types 