### PR TITLE
CAT-646 Add motivation reference lists for principles and criteria items CAT-647 CAT-648 CAT-649

### DIFF
--- a/src/components/MotivationRefList.tsx
+++ b/src/components/MotivationRefList.tsx
@@ -1,0 +1,24 @@
+import { MotivationReference } from "@/types";
+import { Link } from "react-router-dom";
+
+/**
+ * Small component to display a short list of motivations in which the item is included.
+ */
+export const MotivationRefList = ({
+  motivations,
+}: {
+  motivations: MotivationReference[];
+}) => {
+  return (
+    <div>
+      {motivations.map((item) => (
+        <span className="badge bg-light border" key={item.id}>
+          <Link
+            className="text-black"
+            to={`/admin/motivations/${item.id}`}
+          >{`${item.label}`}</Link>
+        </span>
+      ))}
+    </div>
+  );
+};

--- a/src/pages/criteria/Criteria.tsx
+++ b/src/pages/criteria/Criteria.tsx
@@ -16,6 +16,7 @@ import { CriterionModal } from "./components/CriterionModal";
 import toast from "react-hot-toast";
 import { DeleteModal } from "@/components/DeleteModal";
 import { useDeleteCriterion, useGetCriteria } from "@/api/services/criteria";
+import { MotivationRefList } from "@/components/MotivationRefList";
 
 type Pagination = {
   page: number;
@@ -165,6 +166,9 @@ export default function Criteria() {
               <th>
                 <span>Modified</span>
               </th>
+              <th>
+                <span>Motivations</span>
+              </th>
               <th></th>
             </tr>
           </thead>
@@ -179,6 +183,11 @@ export default function Criteria() {
                     <td className="align-middle">{item.description}</td>
                     <td className="align-middle">
                       <small>{item.last_touch.split(".")[0]}</small>
+                    </td>
+                    <td>
+                      <MotivationRefList
+                        motivations={item.used_by_motivations || []}
+                      />
                     </td>
                     <td>
                       <div className="d-flex flex-nowrap">

--- a/src/pages/criteria/CriterionDetails.tsx
+++ b/src/pages/criteria/CriterionDetails.tsx
@@ -10,6 +10,7 @@ import { AlertInfo, Criterion } from "@/types";
 import { DeleteModal } from "@/components/DeleteModal";
 import toast from "react-hot-toast";
 import { useDeleteCriterion, useGetCriterion } from "@/api/services/criteria";
+import { MotivationRefList } from "@/components/MotivationRefList";
 
 interface DeleteModalConfig {
   show: boolean;
@@ -162,6 +163,16 @@ export default function CriterionDetails() {
             </div>
             <div>
               <small>{criterion?.description}</small>
+            </div>
+          </div>
+          <div>
+            <div>
+              <strong>Used in motivations:</strong>
+            </div>
+            <div className="ms-2">
+              <MotivationRefList
+                motivations={criterion?.used_by_motivations || []}
+              />
             </div>
           </div>
         </Col>

--- a/src/pages/principles/PrincipleDetails.tsx
+++ b/src/pages/principles/PrincipleDetails.tsx
@@ -10,6 +10,7 @@ import { AlertInfo, Principle } from "@/types";
 import { useDeletePrinciple, useGetPrinciple } from "@/api/services/principles";
 import { DeleteModal } from "@/components/DeleteModal";
 import toast from "react-hot-toast";
+import { MotivationRefList } from "@/components/MotivationRefList";
 
 interface DeleteModalConfig {
   show: boolean;
@@ -162,6 +163,16 @@ export default function PrincipleDetails() {
             </div>
             <div>
               <small>{principle?.description}</small>
+            </div>
+          </div>
+          <div>
+            <div>
+              <strong>Used in motivations:</strong>
+            </div>
+            <div className="ms-2">
+              <MotivationRefList
+                motivations={principle?.used_by_motivations || []}
+              />
             </div>
           </div>
         </Col>

--- a/src/pages/principles/Principles.tsx
+++ b/src/pages/principles/Principles.tsx
@@ -19,6 +19,7 @@ import { Link } from "react-router-dom";
 import { PrincipleModal } from "./components/PrincipleModal";
 import toast from "react-hot-toast";
 import { DeleteModal } from "@/components/DeleteModal";
+import { MotivationRefList } from "@/components/MotivationRefList";
 
 type Pagination = {
   page: number;
@@ -168,6 +169,9 @@ export default function Principles() {
               <th>
                 <span>Modified</span>
               </th>
+              <th>
+                <span>Motivations</span>
+              </th>
               <th></th>
             </tr>
           </thead>
@@ -182,6 +186,11 @@ export default function Principles() {
                     <td className="align-middle">{item.description}</td>
                     <td className="align-middle">
                       <small>{item.last_touch.split(".")[0]}</small>
+                    </td>
+                    <td>
+                      <MotivationRefList
+                        motivations={item.used_by_motivations || []}
+                      />
                     </td>
                     <td>
                       <div className="d-flex flex-nowrap">

--- a/src/types/criterion.ts
+++ b/src/types/criterion.ts
@@ -1,4 +1,5 @@
 import { ResponsePage } from "./common";
+import { MotivationReference } from "./motivation";
 import { Principle } from "./principle";
 
 export interface Criterion {
@@ -13,6 +14,7 @@ export interface Criterion {
   populated_by: string;
   last_touch: string;
   principles: Principle[];
+  used_by_motivations?: MotivationReference[];
 }
 
 export interface CriterionImperative {

--- a/src/types/motivation.ts
+++ b/src/types/motivation.ts
@@ -88,3 +88,9 @@ export interface MotivationMessage {
   code: string;
   messages: string[];
 }
+
+export interface MotivationReference {
+  id: string;
+  mtv: string;
+  label: string;
+}

--- a/src/types/principle.ts
+++ b/src/types/principle.ts
@@ -1,4 +1,5 @@
 import { ResponsePage } from "./common";
+import { MotivationReference } from "./motivation";
 
 export interface Principle {
   id: string;
@@ -7,6 +8,7 @@ export interface Principle {
   description: string;
   populated_by: string | null;
   last_touch: string;
+  used_by_motivations?: MotivationReference[];
 }
 
 export interface PrincipleInput {


### PR DESCRIPTION
### Goal
Add a list of motivation references for each Principle and Criterion item. This list shows in which motivations this principle or criterion takes part in

### Implementation
- [x] Add MotivationReference type
- [x] Update Principle and Criterion type to use MotivationReference type in `used_by_motivations` field (json array)
- [x] Create MotivationRefList component to display motivations as a list of tags (badges) with clickable links that transfer the user to the motivation details
- [x] Update principles list table to have a motivations column with motivation references for each item
- [x] Update criteria list tabel to have a motivations column with motivation references for each item
- [x] Update principle details page to display a motivation reference list
- [x] Update criterion details page to display a motivation reference list