### PR TITLE
CAT-615 Add Principle under motivation

### DIFF
--- a/src/api/services/motivations.ts
+++ b/src/api/services/motivations.ts
@@ -17,10 +17,12 @@ import {
   MotivationResponse,
   MotivationTypeResponse,
   PrincipleCriterion,
+  PrincipleInput,
   PrincipleResponse,
   RelationResponse,
 } from "@/types";
 import { CriterionResponse } from "@/types/criterion";
+import { relMtvPrincipleId } from "@/config";
 
 export const useGetMotivations = ({
   size,
@@ -299,7 +301,7 @@ export const useGetMotivationPrinciples = (
   { token, isRegistered, size }: ApiOptions,
 ) =>
   useInfiniteQuery({
-    queryKey: ["motivation-principles"],
+    queryKey: ["motivation-principles", mtvId],
     queryFn: async ({ pageParam = 1 }) => {
       const response = await APIClient(token).get<PrincipleResponse>(
         `/v1/registry/motivations/${mtvId}/principles?size=${size}&page=${pageParam}`,
@@ -426,3 +428,35 @@ export function useDeleteMotivationActor(token: string) {
     },
   });
 }
+export const useCreateMotivationPrinciple = (
+  token: string,
+  mtvId: string,
+  { pri, label, description }: PrincipleInput,
+) => {
+  const queryClient = useQueryClient();
+  return useMutation(
+    async () => {
+      const response = await APIClient(token).post<PrincipleResponse>(
+        `/v1/registry/motivations/${mtvId}/principle`,
+        {
+          principle_request: {
+            pri,
+            label,
+            description,
+          },
+          relation: relMtvPrincipleId,
+        },
+      );
+      return response.data;
+    },
+
+    {
+      onError: (error: AxiosError) => {
+        return handleBackendError(error);
+      },
+      onSuccess: () => {
+        queryClient.invalidateQueries(["motivation-principles", mtvId]);
+      },
+    },
+  );
+};

--- a/src/pages/motivations/components/MotivationPrinciples.tsx
+++ b/src/pages/motivations/components/MotivationPrinciples.tsx
@@ -2,12 +2,16 @@ import { useGetMotivationPrinciples } from "@/api/services/motivations";
 import { AuthContext } from "@/auth";
 import { Principle } from "@/types";
 import { useContext, useEffect, useState } from "react";
-import { Col, ListGroup, ListGroupItem, Row } from "react-bootstrap";
+import { Button, Col, ListGroup, ListGroupItem, Row } from "react-bootstrap";
 import notavailImg from "@/assets/thumb_notavail.png";
+import { FaPlus } from "react-icons/fa";
+import { PrincipleModal } from "@/pages/principles/components/PrincipleModal";
 
 export const MotivationPrinciples = ({ mtvId }: { mtvId: string }) => {
   const { keycloak, registered } = useContext(AuthContext)!;
   const [mtvPrinciples, setMtvPrinciples] = useState<Principle[]>([]);
+
+  const [showCreatePri, setShowCreatePri] = useState(false);
 
   const {
     data: priData,
@@ -37,6 +41,14 @@ export const MotivationPrinciples = ({ mtvId }: { mtvId: string }) => {
 
   return (
     <div className="px-5 mt-4">
+      <PrincipleModal
+        principle={null}
+        show={showCreatePri}
+        mtvId={mtvId}
+        onHide={() => {
+          setShowCreatePri(false);
+        }}
+      />
       <div className="d-flex justify-content-between mb-2">
         <h5 className="text-muted cat-view-heading ">
           List of principles
@@ -46,6 +58,23 @@ export const MotivationPrinciples = ({ mtvId }: { mtvId: string }) => {
             </span>
           </p>
         </h5>
+        {mtvPrinciples.length > 0 ? (
+          <div>
+            <Button
+              variant="warning"
+              onClick={() => {
+                setShowCreatePri(true);
+              }}
+              disabled={mtvPrinciples.length == 0}
+            >
+              <FaPlus /> Create Principle
+            </Button>
+          </div>
+        ) : (
+          <span className="text-secondary text-sm">
+            No available principles
+          </span>
+        )}
       </div>
       <div>
         <ListGroup>

--- a/src/pages/principles/components/PrincipleModal.tsx
+++ b/src/pages/principles/components/PrincipleModal.tsx
@@ -1,3 +1,4 @@
+import { useCreateMotivationPrinciple } from "@/api";
 import {
   useCreatePrinciple,
   useUpdatePrinciple,
@@ -20,6 +21,7 @@ import { FaFile, FaInfoCircle } from "react-icons/fa";
 
 interface PrincipleModalProps {
   principle: Principle | null;
+  mtvId?: string;
   show: boolean;
   onHide: () => void;
 }
@@ -52,6 +54,12 @@ export function PrincipleModal(props: PrincipleModalProps) {
 
   const mutateCreate = useCreatePrinciple(
     keycloak?.token || "",
+    principleInput,
+  );
+
+  const mutateCreateMtv = useCreateMotivationPrinciple(
+    keycloak?.token || "",
+    props.mtvId || "",
     principleInput,
   );
 
@@ -104,6 +112,28 @@ export function PrincipleModal(props: PrincipleModalProps) {
     });
   }
 
+  function handleCreateMtv() {
+    const promise = mutateCreateMtv
+      .mutateAsync()
+      .catch((err) => {
+        alert.current = {
+          message: "Error: " + err.response.data.message,
+        };
+        throw err;
+      })
+      .then(() => {
+        props.onHide();
+        alert.current = {
+          message: "Principle Created under motivation!",
+        };
+      });
+    toast.promise(promise, {
+      loading: "Creating Principle under motivation...",
+      success: () => `${alert.current.message}`,
+      error: () => `${alert.current.message}`,
+    });
+  }
+
   // handle backend call to update an existing principle
   function handleUpdate() {
     const promise = mutateUpdate
@@ -137,7 +167,8 @@ export function PrincipleModal(props: PrincipleModalProps) {
       <Modal.Header className="bg-success text-white" closeButton>
         <Modal.Title id="contained-modal-title-vcenter">
           <FaFile className="me-2" />{" "}
-          {props.principle === null ? "Create new" : "Edit"} Principle
+          {props.principle === null ? "Create new" : "Edit"} Principle{" "}
+          {props.mtvId && " (under motivation)"}
         </Modal.Title>
       </Modal.Header>
       <Modal.Body>
@@ -249,7 +280,11 @@ export function PrincipleModal(props: PrincipleModalProps) {
           onClick={() => {
             if (handleValidate() === true) {
               if (props.principle === null) {
-                handleCreate();
+                if (props.mtvId && props.mtvId !== "") {
+                  handleCreateMtv();
+                } else {
+                  handleCreate();
+                }
               } else {
                 handleUpdate();
               }

--- a/src/types/motivation.ts
+++ b/src/types/motivation.ts
@@ -1,5 +1,5 @@
 import { ResponsePage } from "./common";
-import { Principle } from "./principle";
+import { Principle, PrincipleInput } from "./principle";
 
 export interface Motivation {
   id: string;
@@ -93,4 +93,11 @@ export interface MotivationReference {
   id: string;
   mtv: string;
   label: string;
+}
+
+export interface MotivationPrincipleInput {
+  principle_request: PrincipleInput;
+  relation: string;
+  annotation?: string;
+  annotation_url?: string;
 }


### PR DESCRIPTION
### Goal
Give the ability to the user to quickly add a new principle under a motivation. This principle will also be available in the principle library

### Implementation
- [x] Add new types for Principle under motivation request
- [x] Add new useCreateMotivationPrinciple mutation hook
- [x] Update CreatePrinciple modal to optionally accept a mtvId parameter. If mtvId is specified then the CreatePrinciple modal uses the useCreateMotivationPrinciple hook instead of useCreatePrinciple