### PR TITLE
CAT-587 Show Criteria Metrics in Motivation

### DIFF
--- a/src/api/services/motivations.ts
+++ b/src/api/services/motivations.ts
@@ -21,7 +21,7 @@ import {
   PrincipleResponse,
   RelationResponse,
 } from "@/types";
-import { CriterionResponse } from "@/types/criterion";
+import { CriterionMetricResponse, CriterionResponse } from "@/types/criterion";
 import { relMtvPrincipleId } from "@/config";
 
 export const useGetMotivations = ({
@@ -373,6 +373,31 @@ export const useGetMotivationActorCriteria = (
     },
     retry: false,
     enabled: isRegistered,
+  });
+
+export const useGetMotivationCriMetric = ({
+  mtvId,
+  criId,
+  token,
+}: {
+  mtvId: string;
+  criId: string;
+  token: string;
+}) =>
+  useQuery({
+    queryKey: ["motivation-criterion-metric", mtvId, criId],
+    queryFn: async () => {
+      let response = null;
+
+      response = await APIClient(token).get<CriterionMetricResponse>(
+        `/v1/registry/motivations/${mtvId}/criteria/${criId}`,
+      );
+      return response.data;
+    },
+    onError: (error: AxiosError) => {
+      return handleBackendError(error);
+    },
+    enabled: !!token,
   });
 
 export function useUpdateMotivationActorCriteria(

--- a/src/pages/motivations/components/MotivationCriMetric.tsx
+++ b/src/pages/motivations/components/MotivationCriMetric.tsx
@@ -1,0 +1,125 @@
+import { useGetMotivationCriMetric } from "@/api";
+import { AuthContext } from "@/auth";
+import { TestAutoHttpsCheckForm } from "@/pages/assessments/components/tests/TestAutoHttpsCheckForm";
+import { TestBinaryParamForm } from "@/pages/assessments/components/tests/TestBinaryParam";
+import { TestValueFormParam } from "@/pages/assessments/components/tests/TestValueFormParam";
+import { TestAutoHttpsCheck, TestBinaryParam, TestValueParam } from "@/types";
+import { useContext } from "react";
+import { Col, Row } from "react-bootstrap";
+
+export default function MotivationCriMetric({
+  mtvId,
+  criId,
+}: {
+  mtvId: string;
+  criId: string;
+}) {
+  const { keycloak } = useContext(AuthContext)!;
+
+  const { data: metricData } = useGetMotivationCriMetric({
+    mtvId: mtvId,
+    criId: criId,
+    token: keycloak?.token || "",
+  });
+
+  const testList: JSX.Element[] = [];
+
+  metricData?.metric?.tests &&
+    metricData.metric.tests.forEach((test) => {
+      if (
+        test.type === "Binary-Manual-Evidence" ||
+        test.type === "Binary-Binary" ||
+        test.type === "Binary-Manual"
+      ) {
+        testList.push(
+          <div className="border mt-4" key={test.id}>
+            <div className="cat-test-div">
+              <TestBinaryParamForm
+                test={test as TestBinaryParam}
+                onTestChange={() => {}}
+                criterionId={criId}
+                principleId={""}
+              />
+            </div>
+          </div>,
+        );
+      } else if (
+        test.type === "Number-Manual" ||
+        test.type === "Number-Auto" ||
+        test.type === "Ratio-Manual" ||
+        test.type === "Percent-Manual" ||
+        test.type === "TRL-Manual" ||
+        test.type === "Years-Manual"
+      ) {
+        testList.push(
+          <div className="border mt-4" key={test.id}>
+            <div className="cat-test-div">
+              <TestValueFormParam
+                test={test as TestValueParam}
+                onTestChange={() => {}}
+                criterionId={criId}
+                principleId={""}
+              />
+            </div>
+          </div>,
+        );
+      } else if (test.type === "Auto-Check-Url-Binary") {
+        testList.push(
+          <div className="border mt-4" key={test.id}>
+            <div className="cat-test-div">
+              <TestAutoHttpsCheckForm
+                test={test as TestAutoHttpsCheck}
+                onTestChange={() => {}}
+                criterionId={criId}
+                principleId={""}
+              />
+            </div>
+          </div>,
+        );
+      }
+    });
+
+  return (
+    <div className="pb-4">
+      <div className="p-2 rounded border">
+        <Row>
+          <Col>
+            <div>
+              <strong className="me-2">Id:</strong>
+              <span>{metricData?.metric.id}</span>
+            </div>
+            <div>
+              <strong className="me-2">Name:</strong>
+              <span>{metricData?.metric.name}</span>
+            </div>
+          </Col>
+          <Col>
+            <div>
+              <strong className="me-2">Type:</strong>
+              <span>{metricData?.metric.label_type_metric}</span>
+            </div>
+            <div>
+              <strong className="me-2">Algorithm:</strong>
+              <span>{metricData?.metric.label_algorithm_type}</span>
+            </div>
+            <div>
+              <strong className="me-2">Benchmark:</strong>
+              <span>{metricData?.metric.benchmark_value}</span>
+            </div>
+          </Col>
+        </Row>
+        <div className="border-top mt-1">
+          <h5 className="mt-3">
+            <strong>
+              Tests:
+              <span className="badge bg-primary ms-2">
+                {metricData?.metric?.tests?.length || "0"}
+              </span>
+            </strong>
+          </h5>
+          <>{testList}</>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/motivations/components/MotivationCriMetricModal.tsx
+++ b/src/pages/motivations/components/MotivationCriMetricModal.tsx
@@ -1,0 +1,39 @@
+import { Modal, Button } from "react-bootstrap";
+import MotivationCriMetric from "./MotivationCriMetric";
+
+interface MotivationCriMetricProps {
+  mtvId: string;
+  criId: string;
+  show: boolean;
+  onHide: () => void;
+}
+/**
+ * Modal component for displaying criterion metric
+ */
+export function MotivationCriMetricModal(props: MotivationCriMetricProps) {
+  return (
+    <Modal
+      show={props.show}
+      onHide={props.onHide}
+      size="lg"
+      aria-labelledby="contained-modal-title-vcenter"
+      centered
+    >
+      <Modal.Header className="bg-success text-white" closeButton>
+        <Modal.Title id="contained-modal-title-vcenter">
+          Criterion Metric/Tests
+        </Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        {props.mtvId && props.criId && (
+          <MotivationCriMetric mtvId={props.mtvId} criId={props.criId} />
+        )}
+      </Modal.Body>
+      <Modal.Footer className="d-flex justify-content-between">
+        <Button className="btn-secondary" onClick={props.onHide}>
+          Close
+        </Button>
+      </Modal.Footer>
+    </Modal>
+  );
+}

--- a/src/pages/motivations/components/MotivationCriteria.tsx
+++ b/src/pages/motivations/components/MotivationCriteria.tsx
@@ -2,12 +2,32 @@ import { useGetMotivationCriteria } from "@/api/services/motivations";
 import { AuthContext } from "@/auth";
 import { Criterion } from "@/types";
 import { useContext, useEffect, useState } from "react";
-import { Col, ListGroup, ListGroupItem, Row } from "react-bootstrap";
+import {
+  Button,
+  Col,
+  ListGroup,
+  ListGroupItem,
+  OverlayTrigger,
+  Row,
+  Tooltip,
+} from "react-bootstrap";
 import notavailImg from "@/assets/thumb_notavail.png";
+import { MotivationCriMetricModal } from "./MotivationCriMetricModal";
+import { FaBars } from "react-icons/fa";
+
+interface MetricModalConfig {
+  show: boolean;
+  criId: string;
+}
 
 export const MotivationCriteria = ({ mtvId }: { mtvId: string }) => {
   const { keycloak, registered } = useContext(AuthContext)!;
   const [mtvCriteria, setMtvCriteria] = useState<Criterion[]>([]);
+
+  const [metricModal, setMetricModal] = useState<MetricModalConfig>({
+    show: false,
+    criId: "",
+  });
 
   const {
     data: criData,
@@ -37,6 +57,14 @@ export const MotivationCriteria = ({ mtvId }: { mtvId: string }) => {
 
   return (
     <div className="px-5 mt-4">
+      <MotivationCriMetricModal
+        show={metricModal.show}
+        onHide={() => {
+          setMetricModal({ criId: "", show: false });
+        }}
+        mtvId={mtvId}
+        criId={metricModal.criId}
+      />
       <div className="d-flex justify-content-between mb-2">
         <h5 className="text-muted cat-view-heading ">
           List of criteria
@@ -82,6 +110,21 @@ export const MotivationCriteria = ({ mtvId }: { mtvId: string }) => {
                       </span>
                     ))}
                   </div>
+                </Col>
+                <Col xs="auto">
+                  <OverlayTrigger
+                    placement="top"
+                    overlay={<Tooltip>View Criterion Metric/Tests</Tooltip>}
+                  >
+                    <Button
+                      className="btn btn-light btn-sm m-1"
+                      onClick={() => {
+                        setMetricModal({ show: true, criId: item.id });
+                      }}
+                    >
+                      <FaBars />
+                    </Button>
+                  </OverlayTrigger>
                 </Col>
               </Row>
             </ListGroupItem>

--- a/src/types/criterion.ts
+++ b/src/types/criterion.ts
@@ -1,3 +1,4 @@
+import { AssessmentTest } from "./assessment";
 import { ResponsePage } from "./common";
 import { MotivationReference } from "./motivation";
 import { Principle } from "./principle";
@@ -39,6 +40,20 @@ export interface CriterionInput {
   imperative: string;
   type_criterion_id: string;
 }
+
+export interface CriterionMetric {
+  id: string;
+  name: string;
+  type: string;
+  benchmark_value: number;
+  label_algorithm_type: string;
+  label_type_metric: string;
+  tests: AssessmentTest[];
+}
+
+export type CriterionMetricResponse = {
+  metric: CriterionMetric;
+};
 
 export type CriterionResponse = ResponsePage<Criterion[]>;
 export type CriterionTypeResponse = ResponsePage<CriterionType[]>;


### PR DESCRIPTION
### Goal
In motivation -> criteria, show for each criterion information about it's metric and tests

### Implementation
- [x] Create type for MotivationCriterionMetric response 
- [x] Create useGetMotivationCriMetric backend query
- [x] Create MotivationCriMetric component that displays for a specific motivation and criterion the details of it's metric and the included tests
- [x] Create MotivationCriMetricModal component that uses MotivationCriMetric to display information in a modal
- [x] Update MotivationCriteria component to add a Show Criterion Metric/Tests button for each criterion item on list. This button configures and opens the MotivationCriMetricModal