### PR TITLE
CAT-663 Allow to add new criteria when managing them in a motivation

### DIFF
--- a/src/api/services/criteria.ts
+++ b/src/api/services/criteria.ts
@@ -137,6 +137,7 @@ export const useCreateCriterion = (
       },
       onSuccess: () => {
         queryClient.invalidateQueries(["criteria"]);
+        queryClient.invalidateQueries(["all-criteria"]);
       },
     },
   );

--- a/src/pages/criteria/components/CriterionModal.tsx
+++ b/src/pages/criteria/components/CriterionModal.tsx
@@ -326,73 +326,11 @@ export function CriterionModal(props: CriterionModalProps) {
                   key="top"
                   placement="top"
                   overlay={
-                    <Tooltip id={`tooltip-top`}>
-                      Select the type of criterion
-                    </Tooltip>
-                  }
-                >
-                  <InputGroup.Text id="label-motivation-type">
-                    <FaInfoCircle className="me-2" /> Type (*):
-                  </InputGroup.Text>
-                </OverlayTrigger>
-                <Form.Select
-                  id="input-motivation-type"
-                  aria-describedby="label-motivation-type"
-                  placeholder="Select a Motivation type"
-                  value={
-                    criterionInput.type_criterion_id
-                      ? criterionInput.type_criterion_id
-                      : ""
-                  }
-                  onChange={(e) => {
-                    setCriterionInput({
-                      ...criterionInput,
-                      type_criterion_id: e.target.value,
-                    });
-                  }}
-                >
-                  <>
-                    <option value="" disabled>
-                      Select criterion type
-                    </option>
-                    {criterionTypes.map((item) => (
-                      <option key={item.id} value={item.id}>
-                        {item.label}
-                      </option>
-                    ))}
-                  </>
-                </Form.Select>
-              </InputGroup>
-              {showErrors && criterionInput.type_criterion_id === "" && (
-                <span className="text-danger">Required</span>
-              )}
-              {criterionInput.type_criterion_id != "" && (
-                <div className="bg-light text-secondary border rounded mt-2 p-3">
-                  <small>
-                    <em>
-                      {
-                        criterionTypes.find(
-                          (item) => item.id == criterionInput.type_criterion_id,
-                        )?.description
-                      }
-                    </em>
-                  </small>
-                </div>
-              )}
-            </Col>
-          </Row>
-          <Row>
-            <Col>
-              <InputGroup className="mt-2">
-                <OverlayTrigger
-                  key="top"
-                  placement="top"
-                  overlay={
                     <Tooltip id={`tooltip-top`}>Select the Imperative</Tooltip>
                   }
                 >
                   <InputGroup.Text id="label-motivation-type">
-                    <FaInfoCircle className="me-2" /> Type (*):
+                    <FaInfoCircle className="me-2" /> Imperative (*):
                   </InputGroup.Text>
                 </OverlayTrigger>
                 <Form.Select

--- a/src/pages/motivations/MotivationCriteriaPrinciples.tsx
+++ b/src/pages/motivations/MotivationCriteriaPrinciples.tsx
@@ -8,6 +8,7 @@ import {
   FaExclamationTriangle,
   FaInfo,
   FaMinusCircle,
+  FaPlus,
   FaPlusCircle,
   FaTags,
 } from "react-icons/fa";
@@ -22,6 +23,7 @@ import {
   useGetMotivationCriteria,
   useUpdateMotivationPrinciplesCriteria,
 } from "@/api";
+import { CriterionModal } from "../criteria/components/CriterionModal";
 
 export default function MotivationCriteriaPrinciples() {
   const navigate = useNavigate();
@@ -38,6 +40,8 @@ export default function MotivationCriteriaPrinciples() {
     null,
   );
   const [showManagePrinciples, setShowManagePrinciples] = useState(false);
+
+  const [showCreate, setShowCreate] = useState(false);
 
   const alert = useRef<AlertInfo>({
     message: "",
@@ -183,6 +187,13 @@ export default function MotivationCriteriaPrinciples() {
 
   return (
     <div className="pb-4">
+      <CriterionModal
+        criterion={null}
+        show={showCreate}
+        onHide={() => {
+          setShowCreate(false);
+        }}
+      />
       <MotivationPrinciplesModal
         principles={availablePrinciples}
         criterion={targetCriterion}
@@ -244,11 +255,24 @@ export default function MotivationCriteriaPrinciples() {
       </Row>
       <Row className="mt-4  pb-4">
         <Col className="px-4">
-          <div>
-            <strong className="p-1">Available Criteria</strong>
-            <span className="ms-1 badge bg-primary rounded-pill fs-6">
-              {availableCriteria.length}
-            </span>
+          <div className="d-flex justify-content-between">
+            <div>
+              <strong className="p-1">Available Criteria</strong>
+              <span className="ms-1 badge bg-primary rounded-pill fs-6">
+                {availableCriteria.length}
+              </span>
+            </div>
+            <div>
+              <Button
+                size="sm"
+                variant="warning"
+                onClick={() => {
+                  setShowCreate(true);
+                }}
+              >
+                <FaPlus /> Create New Criterion
+              </Button>
+            </div>
           </div>
           <div className="alert alert-primary p-2 mt-1">
             <small>

--- a/src/pages/motivations/MotivationDetails.tsx
+++ b/src/pages/motivations/MotivationDetails.tsx
@@ -325,15 +325,6 @@ export default function MotivationDetails() {
             >
               Update Details
             </Link>
-            {motivation !== undefined && (
-              <Link
-                id="manage-motivation-criteria-principles"
-                to={`/admin/motivations/${motivation.id}/manage-criteria-principles`}
-                className="btn btn-dark mt-4"
-              >
-                Manage Criteria & Principles
-              </Link>
-            )}
           </div>
         </Col>
         <Col className="col-md-auto col-lg-9 border-right">

--- a/src/pages/motivations/components/MotivationCriteria.tsx
+++ b/src/pages/motivations/components/MotivationCriteria.tsx
@@ -13,7 +13,8 @@ import {
 } from "react-bootstrap";
 import notavailImg from "@/assets/thumb_notavail.png";
 import { MotivationCriMetricModal } from "./MotivationCriMetricModal";
-import { FaBars } from "react-icons/fa";
+import { FaBars, FaEdit } from "react-icons/fa";
+import { Link } from "react-router-dom";
 
 interface MetricModalConfig {
   show: boolean;
@@ -74,6 +75,16 @@ export const MotivationCriteria = ({ mtvId }: { mtvId: string }) => {
             </span>
           </p>
         </h5>
+        <div>
+          <Link
+            id="manage-motivation-criteria-principles"
+            to={`/admin/motivations/${mtvId}/manage-criteria-principles`}
+            className="btn btn-warning mt-4"
+          >
+            <FaEdit className="me-2" />
+            Manage Criteria
+          </Link>
+        </div>
       </div>
       <div>
         <ListGroup>

--- a/src/pages/motivations/components/MotivationPrinciplesModal.tsx
+++ b/src/pages/motivations/components/MotivationPrinciplesModal.tsx
@@ -10,7 +10,7 @@ import {
 } from "react-bootstrap";
 
 import { FaAward, FaMinusCircle, FaPlusCircle, FaTags } from "react-icons/fa";
-import { FaTrashCan } from "react-icons/fa6";
+import { FaTrashCan, FaTriangleExclamation } from "react-icons/fa6";
 
 interface MotivationPrinciplesModalProps {
   criterion: Criterion | null;
@@ -75,21 +75,32 @@ export default function MotivationPrinciplesModal(
               </span>
             </div>
             <div className="alert alert-primary p-2 mt-1">
-              <small>
-                <FaPlusCircle className="me-2" /> Click an item below to add
-                it...
-              </small>
+              {selectedPrinciples.length === 0 ? (
+                <small>
+                  <FaPlusCircle className="me-2" />
+                  Click an item below to add it...
+                </small>
+              ) : (
+                <small>
+                  <FaTriangleExclamation className="me-2" />
+                  You can only assign one item to the right
+                </small>
+              )}
             </div>
-            <div className="cat-vh-40 overflow-auto">
+            <div
+              className={`cat-vh-40 overflow-auto ${selectedPrinciples.length > 0 ? "text-muted" : ""}`}
+            >
               {availablePrinciples?.map((item) => (
                 <div
                   key={item.pri}
                   className="mb-4 p-2 cat-select-item"
                   onClick={() => {
-                    setSelectedPrinciples([...selectedPrinciples, item]);
-                    setAvailablePrinciples(
-                      availablePrinciples.filter((pri) => pri.id != item.id),
-                    );
+                    if (selectedPrinciples.length == 0) {
+                      setSelectedPrinciples([...selectedPrinciples, item]);
+                      setAvailablePrinciples(
+                        availablePrinciples.filter((pri) => pri.id != item.id),
+                      );
+                    }
                   }}
                 >
                   <div className="d-inline-flex align-items-center">


### PR DESCRIPTION
### Goal
Move manage criteria button to the criteria tab. Update manage criteria view to allow to add new criteria. Allow only one principle to each criterion

### Implementation
- [x] Move Manage Criteria and Principles button to Criteria tab and rename it to Manage Criteria
- [x] Add Create new Criterion button in the Manage Criteria view
- [x] Add CriterionModal component in Manage Criteria view
- [x] Update react query mutation hook for creating a new criterion to invalidate criteria query and all-criteria query (the one that browses by page and fetches all criteria)
- [x] Allow issuing only one principle per criterion in Principle Modal