### PR TITLE
CAT-670 Update Assessment evaluation to handle Sum, Max, And, Or and …

### DIFF
--- a/src/pages/assessments/components/tests/TestValueFormParam.tsx
+++ b/src/pages/assessments/components/tests/TestValueFormParam.tsx
@@ -91,7 +91,6 @@ export const TestValueFormParam = (props: AssessmentTestProps) => {
     } else {
       result = newTest.value;
     }
-    console.log(result);
     newTest.result = result;
     props.onTestChange(props.principleId, props.criterionId, newTest);
   };

--- a/src/types/assessment.ts
+++ b/src/types/assessment.ts
@@ -102,13 +102,13 @@ export enum AssessmentCriterionImperative {
 
 /** Each criterion includes a SINGLE metric */
 export interface Metric {
-  type: MetricType;
-  algorithm: MetricAlgorithm;
-  benchmark: Benchmark;
+  type: string;
+  label_algorithm_type: string;
+  label_type_metric: string;
+  benchmark_value: number;
   value: number | null;
   result: number | null;
   tests: AssessmentTest[];
-  benchmark_value?: number;
 }
 
 /** Each metric has a type. For now, we only deal with type: number  */


### PR DESCRIPTION
…Inverse in metrics

### Goal
Update support for new AssessmentMetrics. Handle information about metric algorithm, benchmark value and metric type
Assessment Evaluation now supports:
- `Simple Maximum` and `Simple Sum` as aggregation types. 
- It supports `AND`, `OR` type aggregations in metrics that have multiple tests. OR signifies that only one of the tests needs to pass in order for the whole criterion to pass
- Support `Inverse` when checking benchmark values. `Inverse` in the metric type means that the value of the metric should be lower than the value of the benchmark.

