### PR TITLE
CAT-678 Fix Assessment View and PDF errors

### DIFF
--- a/src/pages/assessments/AssessmentPdf.tsx
+++ b/src/pages/assessments/AssessmentPdf.tsx
@@ -98,7 +98,7 @@ const AssessmentPdf = (props: AssessmentPdfProps) => {
             borderBottom: "1px solid black",
           }}
         >
-          <View>
+          <View style={{ width: "30%" }}>
             <Image
               src={
                 assessment.result.compliance === null
@@ -107,10 +107,10 @@ const AssessmentPdf = (props: AssessmentPdfProps) => {
                     ? imgAssessmentBadgePassed
                     : imgAssessmentBadgeFailed
               }
-              style={{ width: "15vh" }}
+              style={{ width: "100%" }}
             />
           </View>
-          <View style={{ marginLeft: "10" }}>
+          <View style={{ marginLeft: "10", width: "30%" }}>
             <Text style={{ fontSize: "12", fontFamily: "Helvetica-Bold" }}>
               Statistics
             </Text>
@@ -161,70 +161,99 @@ const AssessmentPdf = (props: AssessmentPdfProps) => {
               </Text>
             </View>
           </View>
-          <View
-            style={{
-              padding: "10",
-              border: "1px solid grey",
-              marginLeft: "20",
-              borderRadius: "5",
-            }}
-          >
-            <Text style={{ fontSize: "14", fontFamily: "Helvetica-Bold" }}>
-              Details
-            </Text>
+          <View style={{ width: "500px" }}>
             <View
               style={{
-                marginTop: 5,
-                flexDirection: "row",
-                paddingBottom: 5,
-                borderBottom: "1px solid grey",
+                padding: "10",
+                border: "1px solid grey",
+                marginLeft: "20",
+                borderRadius: "5",
               }}
             >
-              <Text style={{ fontSize: "12", fontFamily: "Helvetica-Bold" }}>
-                Actor:{" "}
+              <Text style={{ fontSize: "14", fontFamily: "Helvetica-Bold" }}>
+                Details
               </Text>
-              <Text style={{ fontSize: "12" }}>
-                {props.assessmentDoc.actor.name}
-              </Text>
-            </View>
-            <View
-              style={{
-                marginTop: 5,
-                flexDirection: "row",
-                paddingBottom: 5,
-                borderBottom: "1px solid grey",
-              }}
-            >
-              <Text style={{ fontSize: "12", fontFamily: "Helvetica-Bold" }}>
-                Organization:{" "}
-              </Text>
-              <Text style={{ fontSize: "12" }}>
-                {props.assessmentDoc.organisation.name}
-              </Text>
-            </View>
-            <View
-              style={{
-                marginTop: 5,
-                flexDirection: "row",
-                paddingBottom: 5,
-                borderBottom: "1px solid grey",
-              }}
-            >
-              <Text style={{ fontSize: "12", fontFamily: "Helvetica-Bold" }}>
-                Subject:{" "}
-              </Text>
-              <Text style={{ fontSize: "12" }}>
-                {props.assessmentDoc.subject.name} /{" "}
-                {props.assessmentDoc.subject.type}{" "}
-              </Text>
-            </View>
-            <View style={{ marginTop: 5, flexDirection: "row" }}>
-              <Text style={{ fontSize: "12", fontFamily: "Helvetica-Bold" }}>
-                Latest Update:{" "}
-              </Text>
-              <Text style={{ fontSize: "12" }}>
-                {props.assessmentDoc.timestamp.split(" ")[0]}
-              </Text>
+              <View
+                style={{
+                  marginTop: 5,
+                  flexDirection: "row",
+                  justifyContent: "space-between",
+                  paddingBottom: 5,
+                  borderBottom: "1px solid grey",
+                }}
+              >
+                <View>
+                  <Text
+                    style={{ fontSize: "12", fontFamily: "Helvetica-Bold" }}
+                  >
+                    Actor:
+                  </Text>
+                </View>
+                <View style={{ width: "200px" }}>
+                  <Text style={{ fontSize: "12" }}>
+                    {props.assessmentDoc.actor.name}
+                  </Text>
+                </View>
+              </View>
+              <View
+                style={{
+                  marginTop: 5,
+                  flexDirection: "row",
+                  justifyContent: "space-between",
+                  paddingBottom: 5,
+                  borderBottom: "1px solid grey",
+                }}
+              >
+                <View>
+                  <Text
+                    style={{ fontSize: "12", fontFamily: "Helvetica-Bold" }}
+                  >
+                    Organization:
+                  </Text>
+                </View>
+                <View style={{ width: "200px" }}>
+                  <Text style={{ fontSize: "12" }}>
+                    {props.assessmentDoc.organisation.name}
+                  </Text>
+                </View>
+              </View>
+              <View
+                style={{
+                  marginTop: 5,
+                  flexDirection: "row",
+                  justifyContent: "space-between",
+                  paddingBottom: 5,
+                  borderBottom: "1px solid grey",
+                }}
+              >
+                <View>
+                  <Text
+                    style={{ fontSize: "12", fontFamily: "Helvetica-Bold" }}
+                  >
+                    Subject:
+                  </Text>
+                </View>
+                <View style={{ width: "200px" }}>
+                  <Text style={{ fontSize: "12" }}>
+                    {props.assessmentDoc.subject.name} /{" "}
+                    {props.assessmentDoc.subject.type}{" "}
+                  </Text>
+                </View>
+              </View>
+              <View style={{ marginTop: 5, flexDirection: "row" }}>
+                <View>
+                  <Text
+                    style={{ fontSize: "12", fontFamily: "Helvetica-Bold" }}
+                  >
+                    Latest Update:
+                  </Text>
+                </View>
+                <View>
+                  <Text style={{ fontSize: "12" }}>
+                    {props.assessmentDoc.timestamp.split(" ")[0]}
+                  </Text>
+                </View>
+              </View>
             </View>
           </View>
         </View>
@@ -329,6 +358,12 @@ const AssessmentPdf = (props: AssessmentPdfProps) => {
                         }}
                       >
                         {cri.metric.tests.map((test) => {
+                          const textTokens = test.text.split("|");
+                          const reqEvidence = test.type.endsWith("-Evidence");
+                          const params = test.params
+                            .split("|")
+                            .filter((item) => item !== "evidence");
+
                           return (
                             <View key={test.id} style={{ marginBottom: "15" }}>
                               <Text
@@ -349,8 +384,8 @@ const AssessmentPdf = (props: AssessmentPdfProps) => {
                                 >
                                   Q:{" "}
                                 </Text>
-                                <Text style={{ fontSize: "12" }}>
-                                  {test.text}
+                                <Text style={{ fontSize: "12", width: "90%" }}>
+                                  {textTokens[0]}
                                 </Text>
                               </View>
                               <View style={{ flexDirection: "row" }}>
@@ -366,7 +401,7 @@ const AssessmentPdf = (props: AssessmentPdfProps) => {
                                   "binary",
                                   "Binary-Binary",
                                   "Binary-Manual",
-                                  "Binary-Manual-Evicence",
+                                  "Binary-Manual-Evidence",
                                 ].includes(test.type) ? (
                                   <Text style={{ fontSize: "12" }}>
                                     {test.result === null
@@ -376,9 +411,68 @@ const AssessmentPdf = (props: AssessmentPdfProps) => {
                                         : "No"}
                                   </Text>
                                 ) : (
-                                  <Text style={{ fontSize: "12" }}>Values</Text>
+                                  <View style={{ fontSize: "12" }}>
+                                    {params.map((item, indx) => {
+                                      return indx === params.length - 1 ? (
+                                        <Text>
+                                          {item}
+                                          {": "}
+                                          {test.value || "n/a"}
+                                        </Text>
+                                      ) : (
+                                        <Text>
+                                          {item}
+                                          {": n/a"}
+                                        </Text>
+                                      );
+                                    })}
+                                  </View>
                                 )}
                               </View>
+                              {reqEvidence && textTokens.length > 1 && (
+                                <View
+                                  style={{ fontSize: "11", color: "#696969" }}
+                                >
+                                  <View
+                                    style={{
+                                      marginTop: "5",
+                                      marginBottom: "5",
+                                    }}
+                                  >
+                                    <Text>{textTokens[1]}</Text>
+                                  </View>
+                                  {test.evidence_url &&
+                                  test.evidence_url.length > 0 ? (
+                                    <View>
+                                      {test.evidence_url.map((item, indx) => {
+                                        return (
+                                          <View
+                                            key={indx}
+                                            style={{
+                                              marginBottom: "2",
+                                              flexDirection: "row",
+                                            }}
+                                          >
+                                            <View>
+                                              <Text>[{indx}] </Text>
+                                            </View>
+                                            <View style={{ width: "90%" }}>
+                                              <Text>{item.url}</Text>
+                                              {item.description && (
+                                                <Text>{item.description}</Text>
+                                              )}
+                                            </View>
+                                          </View>
+                                        );
+                                      })}
+                                    </View>
+                                  ) : (
+                                    <View>
+                                      <Text> - No evidence provided</Text>
+                                    </View>
+                                  )}
+                                </View>
+                              )}
                             </View>
                           );
                         })}

--- a/src/pages/assessments/AssessmentView.tsx
+++ b/src/pages/assessments/AssessmentView.tsx
@@ -310,64 +310,86 @@ const AssessmentView = ({ isPublic }: { isPublic: boolean }) => {
                               </small>
                             </div>
                             <div className="m-1">
-                              {cri.metric.tests.map((test) => (
-                                <div key={test.id} className="mb-4">
-                                  <span className="badge rounded-pill text-bg-light text-info">
-                                    {test.id} - {test.name}
-                                  </span>
-                                  <br />
-                                  <strong>Q.</strong>
-                                  <span className="text-secondary p-2">
-                                    {test.text}
-                                  </span>
-                                  <br />
-                                  <strong>A.</strong>
-                                  {test.type === "value" ? (
-                                    <span className="text-primary p-2">
-                                      <strong>F=</strong>
-                                      {test.value} <strong>P=</strong>
-                                      {test.threshold}
+                              {cri.metric.tests.map((test) => {
+                                const params = test.params
+                                  .split("|")
+                                  .filter((item) => item !== "evidence");
+                                return (
+                                  <div key={test.id} className="mb-4">
+                                    <span className="badge rounded-pill text-bg-light text-info">
+                                      {test.id} - {test.name}
                                     </span>
-                                  ) : test.result === 1 ? (
-                                    <span className="text-primary p-2">
-                                      <strong>YES</strong>
+                                    <br />
+                                    <strong>Q.</strong>
+                                    <span className="text-secondary p-2">
+                                      {test.text}
                                     </span>
-                                  ) : test.result === 0 ? (
-                                    <span className="text-primary p-2">
-                                      <strong>NO</strong>
-                                    </span>
-                                  ) : (
-                                    <span className="text-warning p-2">
-                                      <strong>N/A</strong>
-                                    </span>
-                                  )}
-                                  <br />
-
-                                  {test.evidence_url &&
-                                    test.evidence_url?.length > 0 && (
-                                      <div>
-                                        {test.evidence_url.map((ev) => (
-                                          <div key={ev.url}>
-                                            {" "}
-                                            <a href={ev.url}>
-                                              <span className="p-2">
-                                                <FaArrowUpRightFromSquare />
-                                              </span>
-                                            </a>
-                                            {ev.description && (
-                                              <a
-                                                href={ev.url}
-                                                className="plain"
-                                              >
-                                                <span>{ev.description}</span>
-                                              </a>
-                                            )}
-                                          </div>
-                                        ))}
-                                      </div>
+                                    <br />
+                                    <strong>A.</strong>
+                                    {[
+                                      "binary",
+                                      "Binary-Binary",
+                                      "Binary-Manual",
+                                      "Binary-Manual-Evidence",
+                                    ].includes(test.type) ? (
+                                      test.result === 1 ? (
+                                        <span className="text-primary p-2">
+                                          <strong>YES</strong>
+                                        </span>
+                                      ) : test.result === 0 ? (
+                                        <span className="text-primary p-2">
+                                          <strong>NO</strong>
+                                        </span>
+                                      ) : (
+                                        <span className="text-warning p-2">
+                                          <strong>N/A</strong>
+                                        </span>
+                                      )
+                                    ) : (
+                                      <span className="text-primary p-2">
+                                        {params.map((item, indx) => {
+                                          return indx === params.length - 1 ? (
+                                            <span className="me-4">
+                                              <strong>{item}:</strong>
+                                              {test.value || "n/a"}
+                                            </span>
+                                          ) : (
+                                            <span className="me-4">
+                                              <strong>{item}:</strong> n/a
+                                            </span>
+                                          );
+                                        })}
+                                      </span>
                                     )}
-                                </div>
-                              ))}
+
+                                    <br />
+
+                                    {test.evidence_url &&
+                                      test.evidence_url?.length > 0 && (
+                                        <div>
+                                          {test.evidence_url.map((ev) => (
+                                            <div key={ev.url}>
+                                              {" "}
+                                              <a href={ev.url}>
+                                                <span className="p-2">
+                                                  <FaArrowUpRightFromSquare />
+                                                </span>
+                                              </a>
+                                              {ev.description && (
+                                                <a
+                                                  href={ev.url}
+                                                  className="plain"
+                                                >
+                                                  <span>{ev.description}</span>
+                                                </a>
+                                              )}
+                                            </div>
+                                          ))}
+                                        </div>
+                                      )}
+                                  </div>
+                                );
+                              })}
                             </div>
                           </Accordion.Body>
                         </Accordion.Item>

--- a/src/types/assessment.ts
+++ b/src/types/assessment.ts
@@ -134,6 +134,7 @@ export interface TestBinary {
   guidance?: Guidance;
   type: "binary";
   text: string;
+  params: string;
   result: number | null;
   value: boolean | null;
   evidence_url?: EvidenceURL[];
@@ -167,6 +168,7 @@ export interface TestValue {
   threshold_name?: string;
   threshold_locked?: boolean;
   benchmark: Benchmark;
+  params: string;
   evidence_url?: EvidenceURL[];
 }
 


### PR DESCRIPTION
- [x] Fix Assessment View results when displaying value tests. Display all available parameters and the answered value 
- [x] Fix Assessment PDF layout issues with rows that had multiple columns. Specify hard margins (in pixels or percentages so that the text can wrap-up inside the div)
- [x] Add ability to display evidence in Assessment PDF 
- [x] Add ability to display parameters/values in ValueTests in Assessment PDF