### PR TITLE
CAT-701 Assign tests to metrics

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -37,6 +37,7 @@ import { MotivationAssessmentEditor } from "./pages/assessments/MotivationAssess
 import MotivationCriteriaPrinciples from "./pages/motivations/MotivationCriteriaPrinciples";
 import Criteria from "./pages/criteria/Criteria";
 import CriterionDetails from "./pages/criteria/CriterionDetails";
+import MotivationMetricTests from "./pages/motivations/MotivationMetricTests";
 
 const queryClient = new QueryClient();
 
@@ -210,6 +211,12 @@ function App() {
                   element={<ProtectedRoute />}
                 >
                   <Route index element={<MotivationActorCriteria />} />
+                </Route>
+                <Route
+                  path="/admin/motivations/:mtvId/metrics-tests/:mtrId"
+                  element={<ProtectedRoute />}
+                >
+                  <Route index element={<MotivationMetricTests />} />
                 </Route>
                 <Route
                   path="/admin/motivations/:mtvId/templates/actors/:actId"

--- a/src/api/services/motivations.ts
+++ b/src/api/services/motivations.ts
@@ -14,6 +14,8 @@ import {
   MetricAssignment,
   MetricInput,
   MetricResponse,
+  MetricTestInput,
+  MetricTestResponse,
   Motivation,
   MotivationActorResponse,
   MotivationInput,
@@ -378,6 +380,29 @@ export const useGetMotivationCriteria = (
     enabled: isRegistered,
   });
 
+export const useGetMotivationMetricTests = (
+  mtvId: string,
+  mtrId: string,
+  { token, isRegistered, size }: ApiOptions,
+) =>
+  useInfiniteQuery({
+    queryKey: ["motivation-metric-tests", mtvId, mtrId],
+    queryFn: async ({ pageParam = 100 }) => {
+      const response = await APIClient(token).get<MetricTestResponse>(
+        `/v1/registry/motivations/${mtvId}/metrics/${mtrId}/test?size=${size}&page=${pageParam}`,
+      );
+      return response.data;
+    },
+    getNextPageParam: () => {
+      return undefined;
+    },
+    onError: (error: AxiosError) => {
+      return handleBackendError(error);
+    },
+    retry: false,
+    enabled: isRegistered,
+  });
+
 export const useGetMotivationActorCriteria = (
   mtvId: string,
   actId: string,
@@ -581,6 +606,26 @@ export function useUpdateMotivationAssignMetric(
         mtvId,
         criId,
       ]);
+    },
+  });
+}
+
+export function useUpdateMotivationMetricTests(
+  token: string,
+  mtvId: string,
+  mtrId: string,
+) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (putData: MetricTestInput[]) => {
+      return APIClient(token).put(
+        `/v1/registry/motivations/${mtvId}/metrics/${mtrId}/tests`,
+        putData,
+      );
+    },
+    // on change refresh motivation-metric-test
+    onSuccess: () => {
+      queryClient.invalidateQueries(["motivation-metric-tests", mtvId, mtrId]);
     },
   });
 }

--- a/src/api/services/registry.ts
+++ b/src/api/services/registry.ts
@@ -3,6 +3,7 @@ import { useInfiniteQuery } from "@tanstack/react-query";
 import { APIClient } from "../client";
 import { AxiosError } from "axios";
 import { handleBackendError } from "@/utils";
+import { RegistryTestsResponse } from "@/types/tests";
 
 export const useGetAllAlgorithms = ({
   token,
@@ -68,6 +69,29 @@ export const useGetAllBenchmarkTypes = ({
     queryFn: async ({ pageParam = 1 }) => {
       const response = await APIClient(token).get<RegistryResourceResponse>(
         `/v1/registry/benchmark-types?size=${size}&page=${pageParam}`,
+      );
+      return response.data;
+    },
+    getNextPageParam: (lastPage) => {
+      if (lastPage.number_of_page < lastPage.total_pages) {
+        return lastPage.number_of_page + 1;
+      } else {
+        return undefined;
+      }
+    },
+    onError: (error: AxiosError) => {
+      return handleBackendError(error);
+    },
+    retry: false,
+    enabled: isRegistered,
+  });
+
+export const useGetAllTests = ({ token, isRegistered, size }: ApiOptions) =>
+  useInfiniteQuery({
+    queryKey: ["all-tests"],
+    queryFn: async ({ pageParam = 1 }) => {
+      const response = await APIClient(token).get<RegistryTestsResponse>(
+        `/v1/registry/tests?size=${size}&page=${pageParam}`,
       );
       return response.data;
     },

--- a/src/config.json
+++ b/src/config.json
@@ -9,7 +9,8 @@
   "relation_ids": {
     "motivation_principle": "isSupportedBy",
     "motivation_actor": "dcterms:isRequiredBy",
-    "motivation_principle_criterion": "maintainedBy"
+    "motivation_principle_criterion": "maintainedBy",
+    "motivation_metric_test": "maintainedBy"
   },
   "default_values": {
     "criterion_type": "Criterion",

--- a/src/config.tsx
+++ b/src/config.tsx
@@ -7,6 +7,7 @@ const relMtvActorId = config.relation_ids.motivation_actor;
 const relMtvPrincipleId = config.relation_ids.motivation_principle;
 const relMtvPrincpleCriterion =
   config.relation_ids.motivation_principle_criterion;
+const relMtvMetricTest = config.relation_ids?.motivation_metric_test || "";
 const defaultCriterionType = config.default_values?.criterion_type || "";
 const defaultCriterionImperative =
   config.default_values?.criterion_imperative || "";
@@ -23,6 +24,7 @@ export {
   relMtvActorId,
   relMtvPrincipleId,
   relMtvPrincpleCriterion,
+  relMtvMetricTest,
   defaultCriterionType,
   defaultCriterionImperative,
   defaultMotivationMetricAlgorithm,

--- a/src/pages/motivations/MotivationMetricTests.tsx
+++ b/src/pages/motivations/MotivationMetricTests.tsx
@@ -1,0 +1,286 @@
+import { AuthContext } from "@/auth";
+import { AlertInfo, MetricTest } from "@/types";
+import { useState, useContext, useEffect, useRef } from "react";
+import { Button, Col, Row, OverlayTrigger, Tooltip } from "react-bootstrap";
+import toast from "react-hot-toast";
+import { FaAward, FaMinusCircle, FaPlus, FaPlusCircle } from "react-icons/fa";
+import { FaTrashCan } from "react-icons/fa6";
+import { useParams, useNavigate, Link } from "react-router-dom";
+
+import { relMtvMetricTest } from "@/config";
+import {
+  useGetMotivationMetricTests,
+  useUpdateMotivationMetricTests,
+} from "@/api";
+import { RegistryTest, RegistryTestHeader } from "@/types/tests";
+import { useGetAllTests } from "@/api/services/registry";
+
+export default function MotivationMetricTests() {
+  const navigate = useNavigate();
+  const params = useParams();
+
+  const { keycloak, registered } = useContext(AuthContext)!;
+
+  const [availableTests, setAvailableTests] = useState<RegistryTestHeader[]>(
+    [],
+  );
+  const [selectedTests, setSelectedTests] = useState<RegistryTestHeader[]>([]);
+
+  const alert = useRef<AlertInfo>({
+    message: "",
+  });
+
+  const {
+    data: testData,
+    fetchNextPage: testFetchNextPage,
+    hasNextPage: testHasNextPage,
+  } = useGetAllTests({
+    size: 5,
+    token: keycloak?.token || "",
+    isRegistered: registered,
+  });
+
+  useEffect(() => {
+    // gather all available tests in one array
+    let tmpTests: RegistryTest[] = [];
+
+    const selTests =
+      selectedTests.map((item) => {
+        return item.id;
+      }) || [];
+
+    // iterate over backend pages and gather all items in the test array
+    if (testData?.pages) {
+      testData.pages.map((page) => {
+        tmpTests = [...tmpTests, ...page.content];
+      });
+      if (testHasNextPage) {
+        testFetchNextPage();
+      }
+    }
+    setAvailableTests(
+      tmpTests
+        .map((item) => {
+          return {
+            id: item.test.id,
+            tes: item.test.tes,
+            label: item.test.label,
+            description: item.test.description,
+          };
+        })
+        .filter((item) => !selTests.includes(item.id)),
+    );
+  }, [testData, testHasNextPage, testFetchNextPage, selectedTests]);
+
+  const mutationUpdate = useUpdateMotivationMetricTests(
+    keycloak?.token || "",
+    params.mtvId || "",
+    params.mtrId || "",
+  );
+
+  const {
+    data: selTestData,
+    fetchNextPage: selTestFetchNextPage,
+    hasNextPage: selTestHasNextPage,
+  } = useGetMotivationMetricTests(params.mtvId || "", params.mtrId || "", {
+    size: 5,
+    token: keycloak?.token || "",
+    isRegistered: registered,
+  });
+
+  useEffect(() => {
+    // gather all motivation metric tests in one array
+    let tmpSelTests: MetricTest[] = [];
+
+    // iterate over backend pages and gather all items in the mtv array
+    if (selTestData?.pages) {
+      selTestData.pages.map((page) => {
+        if (page.metric) tmpSelTests = [...tmpSelTests, ...page.metric.tests];
+      });
+      if (selTestHasNextPage) {
+        selTestFetchNextPage();
+      }
+    }
+    setSelectedTests(
+      tmpSelTests.map((item) => {
+        return {
+          id: item.db_id,
+          tes: item.id,
+          label: item.name,
+          description: item.description,
+        };
+      }),
+    );
+  }, [selTestData, selTestHasNextPage, selTestFetchNextPage]);
+
+  function handleUpdate() {
+    if (selectedTests) {
+      const metricTests = selectedTests.map((test) => {
+        return { test_id: test.id, relation: relMtvMetricTest };
+      });
+      const promise = mutationUpdate
+        .mutateAsync(metricTests)
+        .catch((err) => {
+          alert.current = {
+            message: "Error during assigning Tests to Metric",
+          };
+          throw err;
+        })
+        .then(() => {
+          alert.current = {
+            message: "Test Assignment to Metric succeeded!",
+          };
+          navigate(`/admin/motivations/${params.mtvId}#metrics`);
+        });
+      toast.promise(promise, {
+        loading: "Assinging tests to metric...",
+        success: () => `${alert.current.message}`,
+        error: () => `${alert.current.message}`,
+      });
+    }
+  }
+
+  return (
+    <div className="pb-4">
+      <Row className="cat-view-heading-block row border-bottom">
+        <Col>
+          <h2 className="text-muted cat-view-heading ">
+            Assign tests to metric
+            {params.mtvId && params.actId && (
+              <p className="lead cat-view-lead">
+                For Motivation:
+                <strong className="badge bg-light text-secondary mx-2">
+                  {params.mtvId}
+                </strong>
+                and Metric:
+                <strong className="badge bg-light text-secondary ms-2">
+                  {params.mtrId}
+                </strong>
+                <br />
+                <span className="text-sm">
+                  Each metric includes one or more tests
+                </span>
+              </p>
+            )}
+          </h2>
+        </Col>
+      </Row>
+      <Row className="mt-4  pb-4">
+        <Col className="px-4">
+          <div className="d-flex justify-content-between">
+            <div>
+              <strong className="p-1">Available Tests</strong>
+              <span className="ms-1 badge bg-primary rounded-pill fs-6">
+                {availableTests.length}
+              </span>
+            </div>
+            <div>
+              <Button
+                size="sm"
+                variant="warning"
+                onClick={() => {
+                  // setShowCreate(true);
+                }}
+              >
+                <FaPlus /> Create New Test
+              </Button>
+            </div>
+          </div>
+          <div className="alert alert-primary p-2 mt-1">
+            <small>
+              <FaPlusCircle className="me-2" /> Click an item below to assign it
+              to this Metric...
+            </small>
+          </div>
+          <div className="cat-vh-60 overflow-auto">
+            {availableTests?.map((item) => (
+              <div
+                key={item.id}
+                className="mb-4 p-2 cat-select-item"
+                onClick={() => {
+                  setSelectedTests([...selectedTests, item]);
+                }}
+              >
+                <div className="d-inline-flex align-items-center">
+                  <FaAward className="me-2" />
+                  <strong>
+                    {item.tes} - {item.label}
+                  </strong>
+                </div>
+
+                <div className="text-muted text-sm">{item.description}</div>
+              </div>
+            ))}
+          </div>
+        </Col>
+        <Col>
+          <div>
+            <strong className="p-1">Tests assigned to this metric</strong>
+            <span className="badge bg-primary rounded-pill fs-6">
+              {selectedTests.length}
+            </span>
+          </div>
+          <div className="alert alert-primary p-2 mt-1">
+            <small>
+              <FaMinusCircle className="me-2" /> Click an item below to remove
+              it from this metric...
+            </small>
+          </div>
+          <div>
+            <div className="cat-vh-60 overflow-auto">
+              {selectedTests?.map((item) => (
+                <div key={item.id} className={"mb-4 p-2 cat-select-item"}>
+                  <div className="d-inline-flex align-items-center">
+                    <div>
+                      <FaAward className="me-2" />
+                      <strong>
+                        {item.tes} - {item.label}
+                      </strong>
+                      <OverlayTrigger
+                        placement="top"
+                        overlay={<Tooltip>Delete Test</Tooltip>}
+                      >
+                        <Button
+                          size="sm"
+                          variant="light"
+                          className="ms-2"
+                          onClick={() => {
+                            setSelectedTests(
+                              selectedTests.filter(
+                                (selItem) => selItem.id != item.id,
+                              ),
+                            );
+                          }}
+                        >
+                          <FaTrashCan className="text-danger" />
+                        </Button>
+                      </OverlayTrigger>
+                    </div>
+                  </div>
+
+                  <div className="text-muted text-sm">{item.description}</div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </Col>
+      </Row>
+      <div className="d-flex justify-content-between">
+        <Link
+          className="btn btn-secondary"
+          to={`/admin/motivations/${params.mtvId}#metrics`}
+        >
+          Back
+        </Link>
+        <Button
+          variant="success"
+          onClick={() => {
+            handleUpdate();
+          }}
+        >
+          Save
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/motivations/components/MotivationMetrics.tsx
+++ b/src/pages/motivations/components/MotivationMetrics.tsx
@@ -1,11 +1,20 @@
 import { AuthContext } from "@/auth";
 import { MotivationMetric } from "@/types";
 import { useContext, useEffect, useState } from "react";
-import { Button, Col, ListGroup, ListGroupItem, Row } from "react-bootstrap";
+import {
+  Button,
+  Col,
+  ListGroup,
+  ListGroupItem,
+  OverlayTrigger,
+  Row,
+  Tooltip,
+} from "react-bootstrap";
 import notavailImg from "@/assets/thumb_notavail.png";
-import { FaPlus } from "react-icons/fa";
+import { FaCog, FaPlus } from "react-icons/fa";
 import { MotivationMetricModal } from "./MotivationMetricModal";
 import { useGetAllMotivationMetrics } from "@/api";
+import { Link } from "react-router-dom";
 
 export const MotivationMetrics = ({
   mtvId,
@@ -106,7 +115,19 @@ export const MotivationMetrics = ({
                     </div>
                   </div>
                 </Col>
-                <Col xs="auto">{/* Actions will be plaed here */}</Col>
+                <Col xs="auto">
+                  <OverlayTrigger
+                    placement="top"
+                    overlay={<Tooltip>Assign tests to this metric</Tooltip>}
+                  >
+                    <Link
+                      className="btn btn-light"
+                      to={`/admin/motivations/${mtvId}/metrics-tests/${item.metric_id}`}
+                    >
+                      <FaCog />
+                    </Link>
+                  </OverlayTrigger>
+                </Col>
               </Row>
             </ListGroupItem>
           ))}

--- a/src/types/motivation.ts
+++ b/src/types/motivation.ts
@@ -123,3 +123,25 @@ export interface MotivationPrincipleInput {
   annotation?: string;
   annotation_url?: string;
 }
+
+export interface MetricTestResponse {
+  metric: MetricHeader;
+}
+
+export interface MetricHeader {
+  id: string;
+  name: string;
+  tests: MetricTest[];
+}
+
+export interface MetricTest {
+  db_id: string;
+  id: string;
+  name: string;
+  description: string;
+}
+
+export interface MetricTestInput {
+  test_id: string;
+  relation: string;
+}

--- a/src/types/tests.ts
+++ b/src/types/tests.ts
@@ -1,0 +1,19 @@
+import { ResponsePage } from "./common";
+
+export interface RegistryTestHeader {
+  id: string;
+  tes: string;
+  label: string;
+  description: string;
+}
+
+export interface RegistryTestDefinition {
+  id: string;
+}
+
+export interface RegistryTest {
+  test: RegistryTestHeader;
+  test_definition: RegistryTestDefinition;
+}
+
+export type RegistryTestsResponse = ResponsePage<RegistryTest[]>;


### PR DESCRIPTION
### Goal
Give the ability to assign tests to metrics

### Implementation 
- [x] Add query hook to retrieve all available tests
- [x] Add query hook to retrieve all tests under a motivation metric
- [x] Add mutation hook to update tests under motivation metric
- [x] Add MotivationMetricTests view to assign tests to metric