### PR TITLE
CAT-732 Add metric details view (with included tests)

### DIFF
--- a/src/api/services/motivations.ts
+++ b/src/api/services/motivations.ts
@@ -430,23 +430,27 @@ export const useGetMotivationActorCriteria = (
     enabled: isRegistered,
   });
 
-export const useGetMotivationCriMetric = ({
+export const useGetMotivationMetric = ({
   mtvId,
-  criId,
+  itemId,
   token,
+  getByCriterion,
 }: {
   mtvId: string;
-  criId: string;
+  itemId: string;
   token: string;
+  getByCriterion: boolean;
 }) =>
   useQuery({
-    queryKey: ["motivation-criterion-metric", mtvId, criId],
+    queryKey: getByCriterion
+      ? ["motivation-criterion-metric", mtvId, itemId]
+      : ["motivation-metric", mtvId, itemId],
     queryFn: async () => {
       let response = null;
-
-      response = await APIClient(token).get<CriterionMetricResponse>(
-        `/v1/registry/motivations/${mtvId}/criteria/${criId}`,
-      );
+      const url = getByCriterion
+        ? `/v1/registry/motivations/${mtvId}/criteria/${itemId}`
+        : `/v1/registry/motivations/${mtvId}/metrics/${itemId}/test`;
+      response = await APIClient(token).get<CriterionMetricResponse>(url);
       return response.data;
     },
     onError: (error: AxiosError) => {

--- a/src/assets/locales/en.json
+++ b/src/assets/locales/en.json
@@ -639,6 +639,8 @@
     "add_new_ones": "to add new ones",
     "tip_publish_asmt": "Publish Assessment Type",
     "tip_unpublish_asmt": "Unpublish Assessment Type",
-    "tip_delete_asmt": "Unpublish Assessment Type"
+    "tip_delete_asmt": "Unpublish Assessment Type",
+    "tip_view_metric_tests": "View metric details and included tests",
+    "metric_details": "Metric details"
   }
 }

--- a/src/pages/motivations/components/MotivationCriteria.tsx
+++ b/src/pages/motivations/components/MotivationCriteria.tsx
@@ -12,7 +12,7 @@ import {
   Tooltip,
 } from "react-bootstrap";
 import notavailImg from "@/assets/thumb_notavail.png";
-import { MotivationCriMetricModal } from "./MotivationCriMetricModal";
+import { MotivationMetricDetailsModal } from "./MotivationMetricDetailsModal";
 import { FaBars, FaBorderNone, FaEdit } from "react-icons/fa";
 import { Link } from "react-router-dom";
 import { MotivationMetricAssignModal } from "./MotivationMetricAssignModal";
@@ -20,7 +20,7 @@ import { useTranslation } from "react-i18next";
 
 interface MetricModalConfig {
   show: boolean;
-  criId: string;
+  itemId: string;
 }
 
 export const MotivationCriteria = ({
@@ -36,13 +36,13 @@ export const MotivationCriteria = ({
 
   const [metricModal, setMetricModal] = useState<MetricModalConfig>({
     show: false,
-    criId: "",
+    itemId: "",
   });
 
   const [metricAssignModal, setMetricAssignModal] = useState<MetricModalConfig>(
     {
       show: false,
-      criId: "",
+      itemId: "",
     },
   );
 
@@ -74,21 +74,22 @@ export const MotivationCriteria = ({
 
   return (
     <div className="px-5 mt-4">
-      <MotivationCriMetricModal
+      <MotivationMetricDetailsModal
         show={metricModal.show}
         onHide={() => {
-          setMetricModal({ criId: "", show: false });
+          setMetricModal({ itemId: "", show: false });
         }}
         mtvId={mtvId}
-        criId={metricModal.criId}
+        itemId={metricModal.itemId}
+        getByCriterion
       />
       <MotivationMetricAssignModal
         show={metricAssignModal.show}
         onHide={() => {
-          setMetricAssignModal({ criId: "", show: false });
+          setMetricAssignModal({ itemId: "", show: false });
         }}
         mtvId={mtvId}
-        criId={metricAssignModal.criId}
+        criId={metricAssignModal.itemId}
       />
       <div className="d-flex justify-content-between mb-2">
         <h5 className="text-muted cat-view-heading ">
@@ -166,7 +167,7 @@ export const MotivationCriteria = ({
                       <Button
                         className="btn btn-light btn-sm m-1"
                         onClick={() => {
-                          setMetricAssignModal({ show: true, criId: item.id });
+                          setMetricAssignModal({ show: true, itemId: item.id });
                         }}
                       >
                         <FaBorderNone />
@@ -183,7 +184,7 @@ export const MotivationCriteria = ({
                       <Button
                         className="btn btn-light btn-sm m-1"
                         onClick={() => {
-                          setMetricModal({ show: true, criId: item.id });
+                          setMetricModal({ show: true, itemId: item.id });
                         }}
                       >
                         <FaBars />

--- a/src/pages/motivations/components/MotivationMetric.tsx
+++ b/src/pages/motivations/components/MotivationMetric.tsx
@@ -1,4 +1,4 @@
-import { useGetMotivationCriMetric } from "@/api";
+import { useGetMotivationMetric } from "@/api";
 import { AuthContext } from "@/auth";
 import { TestAutoHttpsCheckForm } from "@/pages/assessments/components/tests/TestAutoHttpsCheckForm";
 import { TestAutoMd1Form } from "@/pages/assessments/components/tests/TestAutoMd1Form";
@@ -14,19 +14,22 @@ import { useContext } from "react";
 import { Col, Row } from "react-bootstrap";
 import { useTranslation } from "react-i18next";
 
-export default function MotivationCriMetric({
+export default function MotivationMetric({
   mtvId,
-  criId,
+  itemId,
+  getByCriterion,
 }: {
   mtvId: string;
-  criId: string;
+  itemId: string;
+  getByCriterion: boolean;
 }) {
   const { keycloak } = useContext(AuthContext)!;
   const { t } = useTranslation();
-  const { data: metricData } = useGetMotivationCriMetric({
+  const { data: metricData } = useGetMotivationMetric({
     mtvId: mtvId,
-    criId: criId,
+    itemId: itemId,
     token: keycloak?.token || "",
+    getByCriterion: getByCriterion,
   });
 
   const testList: JSX.Element[] = [];
@@ -44,7 +47,7 @@ export default function MotivationCriMetric({
               <TestBinaryParamForm
                 test={test as TestBinaryParam}
                 onTestChange={() => {}}
-                criterionId={criId}
+                criterionId={getByCriterion ? itemId : ""}
                 principleId={""}
               />
             </div>
@@ -64,7 +67,7 @@ export default function MotivationCriMetric({
               <TestValueFormParam
                 test={test as TestValueParam}
                 onTestChange={() => {}}
-                criterionId={criId}
+                criterionId={getByCriterion ? itemId : ""}
                 principleId={""}
               />
             </div>
@@ -77,7 +80,7 @@ export default function MotivationCriMetric({
               <TestAutoHttpsCheckForm
                 test={test as TestAutoHttpsCheck}
                 onTestChange={() => {}}
-                criterionId={criId}
+                criterionId={getByCriterion ? itemId : ""}
                 principleId={""}
               />
             </div>
@@ -94,7 +97,7 @@ export default function MotivationCriMetric({
               <TestAutoMd1Form
                 test={test as TestAutoMD1}
                 onTestChange={() => {}}
-                criterionId={criId}
+                criterionId={getByCriterion ? itemId : ""}
                 principleId={""}
               />
             </div>

--- a/src/pages/motivations/components/MotivationMetricAssignModal.tsx
+++ b/src/pages/motivations/components/MotivationMetricAssignModal.tsx
@@ -12,7 +12,7 @@ import toast from "react-hot-toast";
 import { useTranslation } from "react-i18next";
 import { SearchBox } from "@/components/SearchBox";
 
-interface MotivationCriMetricAssignProps {
+interface MotivationMetricAssignProps {
   mtvId: string;
   criId: string;
   show: boolean;
@@ -22,7 +22,7 @@ interface MotivationCriMetricAssignProps {
  * Modal component for displaying criterion metric
  */
 export function MotivationMetricAssignModal(
-  props: MotivationCriMetricAssignProps,
+  props: MotivationMetricAssignProps,
 ) {
   const { t } = useTranslation();
   const { keycloak, registered } = useContext(AuthContext)!;

--- a/src/pages/motivations/components/MotivationMetricDetailsModal.tsx
+++ b/src/pages/motivations/components/MotivationMetricDetailsModal.tsx
@@ -1,17 +1,18 @@
 import { Modal, Button } from "react-bootstrap";
-import MotivationCriMetric from "./MotivationCriMetric";
+import MotivationMetric from "./MotivationMetric";
 import { useTranslation } from "react-i18next";
 
-interface MotivationCriMetricProps {
+interface MotivationMetricProps {
   mtvId: string;
-  criId: string;
+  itemId: string;
   show: boolean;
+  getByCriterion: boolean;
   onHide: () => void;
 }
 /**
  * Modal component for displaying criterion metric
  */
-export function MotivationCriMetricModal(props: MotivationCriMetricProps) {
+export function MotivationMetricDetailsModal(props: MotivationMetricProps) {
   const { t } = useTranslation();
   return (
     <Modal
@@ -23,12 +24,18 @@ export function MotivationCriMetricModal(props: MotivationCriMetricProps) {
     >
       <Modal.Header className="bg-success text-white" closeButton>
         <Modal.Title id="contained-modal-title-vcenter">
-          {t("page_motivations.criterion_metric_tests")}
+          {props.getByCriterion
+            ? t("page_motivations.criterion_metric_tests")
+            : t("page_motivations.metric_details")}
         </Modal.Title>
       </Modal.Header>
       <Modal.Body>
-        {props.mtvId && props.criId && (
-          <MotivationCriMetric mtvId={props.mtvId} criId={props.criId} />
+        {props.mtvId && props.itemId && (
+          <MotivationMetric
+            mtvId={props.mtvId}
+            itemId={props.itemId}
+            getByCriterion={props.getByCriterion}
+          />
         )}
       </Modal.Body>
       <Modal.Footer className="d-flex justify-content-between">

--- a/src/pages/motivations/components/MotivationMetrics.tsx
+++ b/src/pages/motivations/components/MotivationMetrics.tsx
@@ -11,11 +11,17 @@ import {
   Tooltip,
 } from "react-bootstrap";
 import notavailImg from "@/assets/thumb_notavail.png";
-import { FaCog, FaPlus } from "react-icons/fa";
+import { FaBars, FaCog, FaPlus } from "react-icons/fa";
 import { MotivationMetricModal } from "./MotivationMetricModal";
 import { useGetAllMotivationMetrics } from "@/api";
 import { Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
+import { MotivationMetricDetailsModal } from "./MotivationMetricDetailsModal";
+
+interface MetricModalConfig {
+  show: boolean;
+  itemId: string;
+}
 
 export const MotivationMetrics = ({
   mtvId,
@@ -28,6 +34,11 @@ export const MotivationMetrics = ({
   const { keycloak, registered } = useContext(AuthContext)!;
   const [mtvMetrics, setMtvMetrics] = useState<MotivationMetric[]>([]);
   const [showCreateMetric, setShowCreateMetric] = useState(false);
+
+  const [metricModal, setMetricModal] = useState<MetricModalConfig>({
+    show: false,
+    itemId: "",
+  });
 
   const {
     data: mtrData,
@@ -57,6 +68,15 @@ export const MotivationMetrics = ({
 
   return (
     <div className="px-5 mt-4">
+      <MotivationMetricDetailsModal
+        show={metricModal.show}
+        onHide={() => {
+          setMetricModal({ itemId: "", show: false });
+        }}
+        mtvId={mtvId}
+        itemId={metricModal.itemId}
+        getByCriterion={false}
+      />
       <MotivationMetricModal
         show={showCreateMetric}
         mtvId={mtvId}
@@ -118,6 +138,23 @@ export const MotivationMetrics = ({
                   </div>
                 </Col>
                 <Col xs="auto">
+                  <OverlayTrigger
+                    placement="top"
+                    overlay={
+                      <Tooltip>
+                        {t("page_motivations.tip_view_metric_tests")}
+                      </Tooltip>
+                    }
+                  >
+                    <Button
+                      variant="light"
+                      onClick={() => {
+                        setMetricModal({ itemId: item.metric_id, show: true });
+                      }}
+                    >
+                      <FaBars />
+                    </Button>
+                  </OverlayTrigger>
                   <OverlayTrigger
                     placement="top"
                     overlay={


### PR DESCRIPTION
## Goal
Allow to view metric details with included tests for a specific metric. Use the same modal as with criterion -> metric details.

## Implementation
- [x] Add view metric details action button
- [x] Refactor Modal for CriterionMetricDetails to be more generic (can be used both for criterion and metric items)
- [x] Refactor backend call to be used both for specific metric based on metricId and for specific metric retrieved by criterionId
- [x] Minor clean up