### PR TITLE
Cypress fixes

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -7,8 +7,6 @@ export default defineConfig({
       bundler: "vite",
     },
   },
-
-  hosts: { localhost: "127.0.0.1" },
   env: {
     auth_base_url: "http://localhost:58080/",
     auth_realm: "quarkus",

--- a/cypress/e2e/admin.cy.ts
+++ b/cypress/e2e/admin.cy.ts
@@ -1,36 +1,31 @@
 /// <reference types="cypress"/>
 describe("admin", () => {
   beforeEach(() => {
-    cy.kcLogout();
-    cy.kcLogin("admin").as("admin");
-    cy.visit("/profile");
+    cy.kcLogout().then(() => {
+      cy.kcLogin("admin")
+        .as("adminTokens")
+        .then(() => {
+          cy.visit("/admin/validations");
+        });
+    });
   });
-
   it("accept a validation request", () => {
     cy.intercept(
       "GET",
-      "http://localhost:8080/v1/admin/validations?size=10&page=1&sortby=asc",
+      "http://127.0.0.1:8080/v1/admin/validations?size=20&page=1",
       {
         fixture: "validations/validations.json",
       },
     ).as("getValidations");
-    cy.intercept("GET", "http://localhost:8080/v1/admin/validations/1", {
+    cy.intercept("GET", "http://127.0.0.1:8080/v1/admin/validations/1", {
       fixture: "validations/validation.json",
     });
-    // Navigate to validations list for admins
-    cy.get("#admin_nav").click();
-    cy.get("#admin_validation").contains("Validations").click();
-    cy.wait(["@getValidations"]);
-    cy.url().should("include", "/validations");
-
-    // Click the approve icon for the validation.
     cy.get("table").contains("Oxford Fertility");
-    cy.get(".cat-action-approve-link").click();
-    // Click the approve button on the validation's page.
+    cy.get('[href="/admin/validations/1/approve#alert-spot"]').click();
     cy.get(".btn-success").click();
     cy.intercept(
       "PUT",
-      "http://localhost:8080/v1/admin/validations/1/update-status",
+      "http://127.0.0.1:8080/v1/admin/validations/1/update-status",
       {
         fixture: "validations/validation_approved.json",
       },
@@ -41,43 +36,30 @@ describe("admin", () => {
         fixture: "validations/validations_approved.json",
       },
     ).as("validationsApproved");
-    cy.contains("Validation successfully approved.");
-    cy.wait(["@validationsApproved"]);
-    cy.contains("APPROVED");
+    cy.contains("Validation Request Approved.");
   });
 
   it("declines a validation request", () => {
     cy.intercept(
+      "GET",
+      "http://127.0.0.1:8080/v1/admin/validations?size=20&page=1",
       {
-        method: "GET",
-        url: "http://localhost:8080/v1/admin/validations?size=10&page=1&sortby=asc",
-      },
-      (req) => {
-        if (req.alias === "rejectedValidations") {
-          req.reply({ fixture: "validations/validations_rejected.json" });
-        } else {
-          req.reply({ fixture: "validations/validations.json" });
-        }
+        fixture: "validations/validations.json",
       },
     ).as("getValidations");
-    // Navigate to validations list for admins
-    cy.get("#admin_nav").click();
-    cy.get("#admin_validation").contains("Validations").click();
-    cy.wait(["@getValidations"]);
-    cy.url().should("include", "/validations");
-
+    cy.intercept("GET", "http://127.0.0.1:8080/v1/admin/validations/1", {
+      fixture: "validations/validation.json",
+    });
     // Click the approve icon for the validation.
     cy.get("table").contains("Oxford Fertility");
-    cy.get(".cat-action-reject-link").click();
-    // Click the approve button on the validation's page.
+    cy.get('[href="/admin/validations/1/reject/#alert-spot"]').click();
+    cy.get("#input-share-user").type("Rejected");
     cy.get(".btn-danger").click();
     cy.intercept(
       "PUT",
-      "http://localhost:8080/v1/admin/validations/1/update-status",
+      "http://127.0.0.1:8080/v1/admin/validations/1/update-status",
       { fixture: "validations/validations_rejected.json" },
     );
-
-    cy.contains("Validation successfully rejected.");
-    cy.url().should("include", "/validations");
+    cy.contains("Validation Request Rejected.");
   });
 });

--- a/cypress/e2e/assess.cy.ts
+++ b/cypress/e2e/assess.cy.ts
@@ -1,9 +1,13 @@
 /// <reference types="cypress"/>
 describe("/assess", () => {
   beforeEach(() => {
-    cy.kcLogout();
-    cy.kcLogin("identified").as("identifiedTokens");
-    cy.visit("/assess");
+    cy.kcLogout().then(() => {
+      cy.kcLogin("identified")
+        .as("identifiedTokens")
+        .then(() => {
+          cy.visit("/assess");
+        });
+    });
   });
 
   it("should have actor cards that are flippable", () => {
@@ -20,15 +24,10 @@ describe("/assess", () => {
     cy.url().should("include", "public-assessments");
   });
   it("should have working links", () => {
-    cy.get("#view_assessments_button").should(
-      "have.attr",
-      "href",
-      "/assessments",
-    );
-    cy.get("#assessment_form_button").should(
-      "have.attr",
-      "href",
-      "/assessments/create",
-    );
+    cy.get(
+      "#actorCard_PID_Scheme_Component > .bg-transparent > .text-decoration-none",
+    )
+      .should("have.attr", "href")
+      .and("match", /^\/public-assessments/);
   });
 });

--- a/cypress/e2e/assessment.cy.ts
+++ b/cypress/e2e/assessment.cy.ts
@@ -1,4 +1,4 @@
-describe.only("/assessments/create", () => {
+describe("/assessments/create", () => {
   before(() => {
     cy.setupValidation("identified");
   });
@@ -77,7 +77,7 @@ describe.only("/assessments/create", () => {
     );
   });
 
-  it.only("create an assessment", () => {
+  it("create an assessment", () => {
     const subjectId = "identified_test_subject_id";
     const subjectName = "identified_test_subject_name";
     const subjectType = "identified_test_subject_type";
@@ -108,36 +108,35 @@ describe.only("/assessments/create", () => {
 
 describe("/assessments", () => {
   beforeEach(() => {
-    cy.kcLogout();
-    cy.kcLogin("identified").as("identifiedTokens");
-    cy.visit("/assessments");
+    cy.kcLogout().then(() => {
+      cy.kcLogin("identified")
+        .as("identifiedTokens")
+        .then(() => {
+          cy.visit("/assessments");
+        });
+    });
   });
 
   it("should be able to filter on subject type and name", () => {
-    cy.contains("Filter").click();
-
     // Test subject type filtering
-    cy.get("#floatingSelectSubjectType").select("identified_test_subject_type");
-    cy.get("#floatingSelectSubjectType")
+    cy.get("#subject-type-select").select("identified_test_subject_type");
+    cy.get("#subject-type-select")
       .find(":selected")
       .should("have.text", "identified_test_subject_type");
-    cy.get("#apply_filter_button").click();
     cy.get("table").find("tbody").find("tr").should("exist");
-
     cy.get("#clear_filter_button").click();
-    cy.get("#floatingSelectSubjectType")
+    cy.get("#subject-type-select")
       .find(":selected")
       .should("have.text", "Select Subject Type");
 
     // Test subject name filtering
-    cy.get("#floatingSelectSubjectName").select("identified_test_subject_name");
-    cy.get("#floatingSelectSubjectName")
+    cy.get("#subject-name-select").select("identified_test_subject_name");
+    cy.get("#subject-name-select")
       .find(":selected")
       .should("have.text", "identified_test_subject_name");
-    cy.get("#apply_filter_button").click();
     cy.get("table").find("tbody").find("tr").should("exist");
     cy.get("#clear_filter_button").click();
-    cy.get("#floatingSelectSubjectName")
+    cy.get("#subject-name-select")
       .find(":selected")
       .should("have.text", "Select Subject Name");
   });
@@ -148,20 +147,25 @@ describe("/assessments", () => {
       .parent("tr")
       .find('[id^="edit-button-"]')
       .click();
-    cy.get("#actorRadio").contains("PID Manager at Oxford Fertility");
+    cy.get("#actorRadio").contains(
+      "PID Scheme (Component) at Oxford Fertility - EOSC PID Policy",
+    );
     cy.get("#assessment-wizard-tab-step-3").click();
     cy.get("form:visible").within(() => {
       cy.get("#test-check-no").click();
     });
-    cy.get("#left-tabs-tabpane-C5").contains("FAIL");
     cy.contains("Close").click();
-    // select via Ranking header to prevent breaking tests when columns change.
-    cy.contains("thead th", "Ranking").then((rankingHeader) => {
-      const rankingColumnIndex = rankingHeader.index();
-
-      cy.get(
-        `tbody > :nth-child(1) > :nth-child(${rankingColumnIndex + 1})`,
-      ).should("contain", "7");
+    cy.get("table")
+      .contains("td", "1")
+      .parent("tr")
+      .find('[id^="edit-button-"]')
+      .click();
+    cy.get("#actorRadio").contains(
+      "PID Scheme (Component) at Oxford Fertility - EOSC PID Policy",
+    );
+    cy.get("#assessment-wizard-tab-step-3").click();
+    cy.get("form:visible").within(() => {
+      cy.get("#test-check-yes").should("be.checked");
     });
   });
 
@@ -171,21 +175,26 @@ describe("/assessments", () => {
       .parent("tr")
       .find('[id^="edit-button-"]')
       .click();
-    cy.get("#actorRadio").contains("PID Manager at Oxford Fertility");
+    cy.get("#actorRadio").contains(
+      "PID Scheme (Component) at Oxford Fertility - EOSC PID Policy",
+    );
     cy.get("#assessment-wizard-tab-step-3").click();
     cy.get("form:visible").within(() => {
       cy.get("#test-check-no").click();
     });
-    cy.get("#left-tabs-tabpane-C5").contains("FAIL");
     cy.get("#submit_assessment_button").click();
-    // select via Ranking header to prevent breaking tests when columns change.
-    cy.contains("thead th", "Ranking").then((rankingHeader) => {
-      const rankingColumnIndex = rankingHeader.index();
-      cy.get(
-        `tbody > :nth-child(1) > :nth-child(${rankingColumnIndex + 1})`,
-      ).should("contain", "6");
+    cy.get("table")
+      .contains("td", "1")
+      .parent("tr")
+      .find('[id^="edit-button-"]')
+      .click();
+    cy.get("#actorRadio").contains(
+      "PID Scheme (Component) at Oxford Fertility - EOSC PID Policy",
+    );
+    cy.get("#assessment-wizard-tab-step-3").click();
+    cy.get("form:visible").within(() => {
+      cy.get("#test-check-no").should("be.checked");
     });
-    cy.contains("Assessment succesfully updated.").should("be.visible");
   });
 
   it("deletes an assessment", () => {

--- a/cypress/e2e/assessment.cy.ts
+++ b/cypress/e2e/assessment.cy.ts
@@ -1,12 +1,16 @@
-describe("/assessments/create", () => {
+describe.only("/assessments/create", () => {
   before(() => {
     cy.setupValidation("identified");
   });
 
   beforeEach(() => {
-    cy.kcLogout();
-    cy.kcLogin("identified").as("identifiedTokens");
-    cy.visit("/assessments/create");
+    cy.kcLogout().then(() => {
+      cy.kcLogin("identified")
+        .as("identifiedTokens")
+        .then(() => {
+          cy.visit("/assessments/create");
+        });
+    });
   });
 
   it("greets with create assessment", () => {
@@ -23,7 +27,9 @@ describe("/assessments/create", () => {
     cy.url().should("contain", "/assess");
   });
   it("has the correct actor option", () => {
-    cy.get("#actorRadio").contains("PID Manager at Oxford Fertility");
+    cy.get("#actorRadio").contains(
+      "PID Scheme (Component) at Oxford Fertility - EOSC PID Policy",
+    );
   });
 
   it("Can go to step 2 and go back", () => {
@@ -46,7 +52,7 @@ describe("/assessments/create", () => {
     cy.get("#radio-0").click();
     cy.get("#create_assessment_button").should("not.have.attr", "disabled");
     cy.get("#next-button").click();
-    cy.get('#accordion_general button[aria-expanded="true"]').should("exist");
+    cy.get("#accordion_general button").should("exist");
     cy.get("#accordion_submitter").click();
     cy.get('#accordion_submitter button[aria-expanded="true"]').should("exist");
     cy.get("#input-submitter-fname").should(
@@ -71,17 +77,16 @@ describe("/assessments/create", () => {
     );
   });
 
-  it("create an assessment", () => {
-    const T7 =
-      "Can you provide evidence that the relation between PIDs and entities, as maintained by the PID manager, conforms to the Authority requirements.";
-    const T35 =
-      "Given the percentage f of resolved PIDs that result in a viable entity, compared to a community expectation p. Please provide values for f and p.";
+  it.only("create an assessment", () => {
     const subjectId = "identified_test_subject_id";
     const subjectName = "identified_test_subject_name";
     const subjectType = "identified_test_subject_type";
     cy.get("#radio-0").click();
     cy.get("#create_assessment_button").should("not.have.attr", "disabled");
     cy.get("#assessment-wizard-tab-step-2").click();
+    cy.get(
+      "#accordion_general > .accordion-header > .accordion-button",
+    ).click();
     cy.get("#input-info-name").type("identified_test_assessment");
     cy.get("#accordion_subject").click();
     cy.get("#input-info-subject-id").type(subjectId);
@@ -91,88 +96,10 @@ describe("/assessments/create", () => {
     cy.get("form:visible").within(() => {
       cy.get("#test-check-yes").click();
     });
-    cy.get("#left-tabs-tabpane-C5").contains("PASS").should("exist");
-    cy.get("#left-tabs-tab-C6").click();
+    cy.get("#left-tabs-tab-P10C28").click();
     cy.get("form:visible").within(() => {
       cy.get("#test-check-yes").click();
     });
-    cy.get("#left-tabs-tabpane-C6").contains("PASS").should("exist");
-    cy.get("#left-tabs-tab-C7").click();
-
-    cy.get("form:visible")
-      .contains(T7)
-      .closest("form")
-      .within(() => {
-        cy.get("#test-check-yes").click();
-      });
-
-    cy.get("form:visible")
-      .contains(T35)
-      .closest("form")
-      .within(() => {
-        cy.get("#input-value-control").type("70");
-        cy.get("#input-value-community").type("70");
-      });
-    cy.get("#left-tabs-tabpane-C7").contains("PASS").should("exist");
-
-    cy.get("#left-tabs-tab-C11").click();
-    cy.get("form:visible").within(() => {
-      cy.get("#test-check-yes").click();
-    });
-    cy.get("#left-tabs-tabpane-C11").contains("PASS").should("exist");
-
-    cy.get("#left-tabs-tab-C14").click();
-    cy.get("form:visible").within(() => {
-      cy.get("#input-value-control").type("70");
-      cy.get("#input-value-community").type("70");
-    });
-    cy.get("#left-tabs-tabpane-C14").contains("PASS").should("exist");
-
-    cy.get("#left-tabs-tab-C34").click();
-    cy.get("form:visible").within(() => {
-      cy.get("#input-value-control").type("70");
-      cy.get("#input-value-community").type("70");
-    });
-    cy.get("#left-tabs-tabpane-C34").contains("PASS").should("exist");
-
-    cy.get("#left-tabs-tab-C16").click();
-    cy.get("form:visible").within(() => {
-      cy.get("#input-value-control").type("70");
-      cy.get("#input-value-community").type("70");
-    });
-    cy.get("#left-tabs-tabpane-C16").contains("PASS").should("exist");
-
-    cy.get("#left-tabs-tab-C19").click();
-    cy.get("form:visible").within(() => {
-      cy.get("#test-check-yes").click();
-    });
-    cy.get("#left-tabs-tabpane-C19").contains("PASS").should("exist");
-
-    cy.get("#left-tabs-tab-C22").click();
-    cy.get("form:visible").within(() => {
-      cy.get("#test-check-yes").click();
-    });
-    cy.get("#left-tabs-tabpane-C22").contains("PASS").should("exist");
-
-    cy.get("#left-tabs-tab-C29").click();
-    cy.get("form:visible").within(() => {
-      cy.get("#test-check-yes").click();
-    });
-    cy.get("#left-tabs-tabpane-C29").contains("PASS").should("exist");
-
-    cy.get("#left-tabs-tab-C28").click();
-    cy.get("form:visible").within(() => {
-      cy.get("#test-check-yes").click();
-    });
-    cy.get("#left-tabs-tabpane-C28").contains("PASS").should("exist");
-
-    cy.get("#left-tabs-tab-C35").click();
-    cy.get("form:visible").within(() => {
-      cy.get("#input-value-control").type("70");
-      cy.get("#input-value-community").type("70");
-    });
-    cy.get("#left-tabs-tabpane-C35").contains("PASS").should("exist");
-
     cy.get("#create_assessment_button").click();
     cy.url().should("contain", "/assessments");
     cy.contains("Assessment succesfully created.").should("be.visible");

--- a/cypress/e2e/profile.cy.ts
+++ b/cypress/e2e/profile.cy.ts
@@ -12,15 +12,15 @@ describe("/profile", () => {
 
   it("checks an identified user profile information", () => {
     // Check if profile information is correct.
-    cy.intercept("GET", "http://localhost:8080/v1/users/profile", {
+    cy.intercept("GET", "http://127.0.0.1:8080/v1/users/profile", {
       fixture: "profile_empty.json",
     });
-    cy.get("#user-id").should("contain", "identified_ui_voperson_id");
+    cy.get("#user-id").should("contain", "identified...");
     cy.get("#identified").should("contain", "Identified");
   });
 
   it("does not allow validations without updating details", () => {
-    cy.intercept("GET", "http://localhost:8080/v1/users/profile", {
+    cy.intercept("GET", "http://127.0.0.1:8080/v1/users/profile", {
       fixture: "profile_empty.json",
     });
 
@@ -31,9 +31,6 @@ describe("/profile", () => {
   });
 
   it("does not show assessments/subjects without validation", () => {
-    cy.intercept("GET", "http://localhost:8080/v1/users/profile", {
-      fixture: "profile_updated.json",
-    });
     cy.get("#assessments_section").should("have.class", "disabled");
     cy.get("#subjects_section").should("have.class", "disabled");
   });

--- a/cypress/e2e/subject.cy.ts
+++ b/cypress/e2e/subject.cy.ts
@@ -8,14 +8,14 @@ describe("/subjects", () => {
     cy.visit("/subjects");
     cy.intercept(
       "GET",
-      "http://localhost:8080/v1/subjects?size=10&page=1&sortby=asc",
+      "http://127.0.0.1:8080/v1/subjects?size=20&page=1&sortby=undefined",
       {
         fixture: "subjects/subjects",
       },
     ).as("getSubjects");
   });
   it("deletes a subject", () => {
-    cy.intercept("GET", "http://localhost:8080/v1/subjects/9", {
+    cy.intercept("GET", "http://127.0.0.1:8080/v1/subjects/9", {
       fixture: "subjects/subject",
     }).as("getSubject");
     cy.get("table")
@@ -34,7 +34,7 @@ describe("/subjects", () => {
     cy.contains("Subject succesfully deleted.").should("be.visible");
   });
   it("edits a subject", () => {
-    cy.intercept("GET", "http://localhost:8080/v1/subjects/9", {
+    cy.intercept("GET", "http://127.0.0.1:8080/v1/subjects/9", {
       fixture: "subjects/subject",
     }).as("getSubject");
     cy.get("table")
@@ -73,7 +73,7 @@ describe("/subjects?create", () => {
   });
 
   it("creates a subject", () => {
-    cy.intercept("POST", "http://localhost:8080/v1/subjects", {
+    cy.intercept("POST", "http://127.0.0.1:8080/v1/subjects", {
       fixture: "subjects/subject",
     }).as("postSubject");
     cy.get("#input-info-subject-id").type("subject_test_id");
@@ -86,19 +86,19 @@ describe("/subjects?create", () => {
   it("requires a subject id", () => {
     cy.get(".btn-success").click();
     cy.get(".modal-content").should("be.visible");
-    cy.contains("Error during subject creation.").should("be.visible");
+    cy.contains("Error during subject creation!").should("be.visible");
   });
   it("requires a subject name", () => {
     cy.get("#input-info-subject-id").type("subject_test_id{enter}");
     cy.get(".btn-success").click();
     cy.get(".modal-content").should("be.visible");
-    cy.contains("Error during subject creation.").should("be.visible");
+    cy.contains("Error during subject creation!").should("be.visible");
   });
   it("requires a subject type", () => {
     cy.get("#input-info-subject-id").type("subject_test_id");
     cy.get("#input-info-subject-name").type("subject_test_name{enter}");
     cy.get(".btn-success").click();
     cy.get(".modal-content").should("be.visible");
-    cy.contains("Error during subject creation.").should("be.visible");
+    cy.contains("Error during subject creation!").should("be.visible");
   });
 });

--- a/cypress/e2e/validation.cy.ts
+++ b/cypress/e2e/validation.cy.ts
@@ -8,16 +8,16 @@ describe("/validations/request", () => {
   });
 
   it("creates a validation", () => {
-    cy.intercept("POST", "http://localhost:8080/v1/validations", {
+    cy.intercept("POST", "http://127.0.0.1:8080/v1/validations", {
       fixture: "validations/validation_review.json",
     }).as("getValidations");
     cy.get(".select__input").click().type("Oxford");
     cy.contains(".select__option", "University of Oxford").click();
-    cy.get("#actor_id").select(1);
+    cy.get("#registry_actor_id").select(1);
     cy.get("#organisation_role").type("Team Manager");
-    cy.get("#actor_id")
-      .should("have.value", "1")
-      .contains("PID Standards Body");
+    cy.get("#registry_actor_id")
+      .should("have.value", "pid_graph:0E00C332")
+      .contains("PID Scheme (Component)");
     cy.get("#create_validation").click();
     cy.wait(["@getValidations"]);
     cy.url().should("contain", "/validations");
@@ -27,17 +27,17 @@ describe("/validations/request", () => {
   });
 
   it("creates a validation with a custom organisation", () => {
-    cy.intercept("POST", "http://localhost:8080/v1/validations", {
+    cy.intercept("POST", "http://127.0.0.1:8080/v1/validations", {
       fixture: "validations/validation_review.json",
     }).as("getValidations");
     cy.get("#organisation_source").select("Custom");
     cy.get("#organisation_name").type("Test Organisation");
     cy.get("#organisation_website").type("www.example.com");
-    cy.get("#actor_id").select(1);
+    cy.get("#registry_actor_id").select(1);
     cy.get("#organisation_role").type("Team Manager");
-    cy.get("#actor_id")
-      .should("have.value", "1")
-      .contains("PID Standards Body");
+    cy.get("#registry_actor_id")
+      .should("have.value", "pid_graph:0E00C332")
+      .contains("PID Scheme (Component)");
     cy.get("#create_validation").click();
     cy.wait(["@getValidations"]);
     cy.url().should("contain", "/validations");

--- a/cypress/fixtures/subjects/subjects.json
+++ b/cypress/fixtures/subjects/subjects.json
@@ -31,25 +31,25 @@
     {
       "name": "test",
       "type": "2",
-      "id": 9,
+      "id": 2,
       "subject_id": "test"
     },
     {
       "name": "test",
       "type": "3",
-      "id": 8,
+      "id": 3,
       "subject_id": "test"
     },
     {
       "name": "test",
       "type": "4",
-      "id": 7,
+      "id": 4,
       "subject_id": "test"
     },
     {
       "name": "test",
       "type": "5",
-      "id": 1,
+      "id": 5,
       "subject_id": "test"
     }
   ],

--- a/cypress/fixtures/validations/validation.json
+++ b/cypress/fixtures/validations/validation.json
@@ -4,5 +4,5 @@
   "organisation_source": "ROR",
   "organisation_name": "Oxford Fertility",
   "organisation_website": "http://www.oxfordfertility.co.uk/",
-  "actor_id": 5
+  "registry_actor_id": "pid_graph:0E00C332"
 }

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -51,7 +51,7 @@ Cypress.Commands.add("approveValidation", (authToken) => {
 
   cy.request({
     method: "PUT",
-    url: `http://localhost:8080/v1/admin/validations/1/update-status`,
+    url: `http://localhost:8080/v1/admin/validations/3/update-status`,
     body: approveRequestBody,
     headers: {
       Accept: "application/json",

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "@typescript-eslint/eslint-plugin": "^6.7.0",
         "@typescript-eslint/parser": "^6.7.0",
         "@vitejs/plugin-react": "^4.0.3",
-        "cypress": "^13.3.1",
+        "cypress": "^13.17.0",
         "eslint": "^8.49.0",
         "eslint-plugin-react": "^7.33.2",
         "eslint-plugin-react-hooks": "^4.6.0",
@@ -519,10 +519,11 @@
       }
     },
     "node_modules/@cypress/request": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@cypress/request/-/request-3.0.1.tgz",
-      "integrity": "sha512-TWivJlJi8ZDx2wGOw1dbLuHJKUYX7bWySw377nlnGOW3hP9/MUKIsEdXT/YngWxVdgNCHRBmFlBipE+5/2ZZlQ==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@cypress/request/-/request-3.0.7.tgz",
+      "integrity": "sha512-LzxlLEMbBOPYB85uXrDqvD4MgcenjRBLIns3zyhx7vTPj/0u2eQhzXvPiGcaJrV38Q9dbkExWp6cOHPJ+EtFYg==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "aws-sign2": "~0.7.0",
         "aws4": "^1.8.0",
@@ -530,35 +531,21 @@
         "combined-stream": "~1.0.6",
         "extend": "~3.0.2",
         "forever-agent": "~0.6.1",
-        "form-data": "~2.3.2",
-        "http-signature": "~1.3.6",
+        "form-data": "~4.0.0",
+        "http-signature": "~1.4.0",
         "is-typedarray": "~1.0.0",
         "isstream": "~0.1.2",
         "json-stringify-safe": "~5.0.1",
         "mime-types": "~2.1.19",
         "performance-now": "^2.1.0",
-        "qs": "6.10.4",
+        "qs": "6.13.1",
         "safe-buffer": "^5.1.2",
-        "tough-cookie": "^4.1.3",
+        "tough-cookie": "^5.0.0",
         "tunnel-agent": "^0.6.0",
         "uuid": "^8.3.2"
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/@cypress/request/node_modules/form-data": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-      "dev": true,
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 0.12"
       }
     },
     "node_modules/@cypress/xvfb": {
@@ -2274,6 +2261,7 @@
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
       "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "safer-buffer": "~2.1.0"
       }
@@ -2283,6 +2271,7 @@
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.8"
       }
@@ -2341,15 +2330,17 @@
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
       "integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": "*"
       }
     },
     "node_modules/aws4": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.12.0.tgz",
-      "integrity": "sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg==",
-      "dev": true
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.13.2.tgz",
+      "integrity": "sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/axios": {
       "version": "1.7.7",
@@ -2414,6 +2405,7 @@
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
       "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
         "tweetnacl": "^0.14.3"
       }
@@ -2615,6 +2607,37 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.1.tgz",
+      "integrity": "sha512-BhYE+WDaywFg2TBWYNXAE+8B1ATnThNBqXHP5nQu0jWJdVvY2hvkpyB3qOmtmDePiS5/BDQ8wASEWGMWRG148g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.3.tgz",
+      "integrity": "sha512-YTd+6wGlNlPxSuri7Y6X8tY2dmm12UMH66RpKMhiX6rsk5wXXnYgbUcOt8kiS31/AjfoTOvCsE+w8nZQLQnzHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -2695,7 +2718,8 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
-      "dev": true
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/ccount": {
       "version": "2.0.1",
@@ -2765,9 +2789,9 @@
       }
     },
     "node_modules/ci-info": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
-      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.1.0.tgz",
+      "integrity": "sha512-HutrvTNsF48wnxkzERIXOe5/mlcfFcbfCmwcg6CJnizbSue78AbDt+1cgl26zwn61WFxhcPykPfZrbqjGmBb4A==",
       "dev": true,
       "funding": [
         {
@@ -2775,6 +2799,7 @@
           "url": "https://github.com/sponsors/sibiraj-s"
         }
       ],
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -3001,7 +3026,8 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cosmiconfig": {
       "version": "7.1.0",
@@ -3104,23 +3130,25 @@
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
     "node_modules/cypress": {
-      "version": "13.6.3",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.6.3.tgz",
-      "integrity": "sha512-d/pZvgwjAyZsoyJ3FOsJT5lDsqnxQ/clMqnNc++rkHjbkkiF2h9s0JsZSyyH4QXhVFW3zPFg82jD25roFLOdZA==",
+      "version": "13.17.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.17.0.tgz",
+      "integrity": "sha512-5xWkaPurwkIljojFidhw8lFScyxhtiFHl/i/3zov+1Z5CmY4t9tjIdvSXfu82Y3w7wt0uR9KkucbhkVvJZLQSA==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "MIT",
       "dependencies": {
-        "@cypress/request": "^3.0.0",
+        "@cypress/request": "^3.0.6",
         "@cypress/xvfb": "^1.2.4",
         "@types/sinonjs__fake-timers": "8.1.1",
         "@types/sizzle": "^2.3.2",
         "arch": "^2.2.0",
         "blob-util": "^2.0.2",
         "bluebird": "^3.7.2",
-        "buffer": "^5.6.0",
+        "buffer": "^5.7.1",
         "cachedir": "^2.3.0",
         "chalk": "^4.1.0",
         "check-more-types": "^2.24.0",
+        "ci-info": "^4.0.0",
         "cli-cursor": "^3.1.0",
         "cli-table3": "~0.6.1",
         "commander": "^6.2.1",
@@ -3135,7 +3163,6 @@
         "figures": "^3.2.0",
         "fs-extra": "^9.1.0",
         "getos": "^3.2.1",
-        "is-ci": "^3.0.0",
         "is-installed-globally": "~0.4.0",
         "lazy-ass": "^1.6.0",
         "listr2": "^3.8.3",
@@ -3149,7 +3176,8 @@
         "request-progress": "^3.0.0",
         "semver": "^7.5.3",
         "supports-color": "^8.1.1",
-        "tmp": "~0.2.1",
+        "tmp": "~0.2.3",
+        "tree-kill": "1.2.2",
         "untildify": "^4.0.0",
         "yauzl": "^2.10.0"
       },
@@ -3360,6 +3388,7 @@
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "assert-plus": "^1.0.0"
       },
@@ -3595,11 +3624,27 @@
         "csstype": "^3.0.2"
       }
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/ecc-jsbn": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
       "integrity": "sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
@@ -3699,6 +3744,26 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-iterator-helpers": {
       "version": "1.0.15",
       "resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.0.15.tgz",
@@ -3719,6 +3784,19 @@
         "internal-slot": "^1.0.5",
         "iterator.prototype": "^1.1.2",
         "safe-array-concat": "^1.0.1"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/es-set-tostringtag": {
@@ -4270,7 +4348,8 @@
       "dev": true,
       "engines": [
         "node >=0.6.0"
-      ]
+      ],
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -4468,6 +4547,7 @@
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
       "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": "*"
       }
@@ -4520,9 +4600,13 @@
       }
     },
     "node_modules/function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/function.prototype.name": {
       "version": "1.1.6",
@@ -4561,18 +4645,42 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.1.tgz",
-      "integrity": "sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.7.tgz",
+      "integrity": "sha512-VW6Pxhsrk0KAOqs3WEd0klDiF/+V7gQOpAvY1jVU/LHmaD/kQO4523aiJuikX/QAKYiW6x8Jh+RJej1almdtCA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3",
-        "has-proto": "^1.0.1",
-        "has-symbols": "^1.0.3"
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.0",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/get-stream": {
@@ -4616,6 +4724,7 @@
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "assert-plus": "^1.0.0"
       }
@@ -4766,12 +4875,13 @@
       }
     },
     "node_modules/gopd": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
-      "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
       "dev": true,
-      "dependencies": {
-        "get-intrinsic": "^1.1.3"
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -4849,10 +4959,11 @@
       }
     },
     "node_modules/has-symbols": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -4873,6 +4984,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/hast-util-to-jsx-runtime": {
@@ -4993,14 +5117,15 @@
       }
     },
     "node_modules/http-signature": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.3.6.tgz",
-      "integrity": "sha512-3adrsD6zqo4GsTqtO7FyrejHNv+NgiIfAfv68+jVlFmSr9OGy7zrxONceFRLKvnnZA5jbxQBX1u9PpB6Wi32Gw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.4.0.tgz",
+      "integrity": "sha512-G5akfn7eKbpDN+8nPS/cb57YeA1jLTVxjpCj7tmm3QKPdyDy7T+qSC40e9ptydSWvkwjSXw1VbkpyEm39ukeAg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "assert-plus": "^1.0.0",
         "jsprim": "^2.0.2",
-        "sshpk": "^1.14.1"
+        "sshpk": "^1.18.0"
       },
       "engines": {
         "node": ">=0.10"
@@ -5261,18 +5386,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-ci": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-3.0.1.tgz",
-      "integrity": "sha512-ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ==",
-      "dev": true,
-      "dependencies": {
-        "ci-info": "^3.2.0"
-      },
-      "bin": {
-        "is-ci": "bin.js"
       }
     },
     "node_modules/is-core-module": {
@@ -5585,7 +5698,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-unicode-supported": {
       "version": "0.1.0",
@@ -5691,7 +5805,8 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/iterator.prototype": {
       "version": "1.1.2",
@@ -5740,7 +5855,8 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/jsesc": {
       "version": "2.5.2",
@@ -5768,7 +5884,8 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
       "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
-      "dev": true
+      "dev": true,
+      "license": "(AFL-2.1 OR BSD-3-Clause)"
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -5784,7 +5901,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -5818,6 +5936,7 @@
       "engines": [
         "node >=0.6.0"
       ],
+      "license": "MIT",
       "dependencies": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
@@ -6153,6 +6272,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/mathml-tag-names": {
@@ -6998,10 +7127,14 @@
       }
     },
     "node_modules/object-inspect": {
-      "version": "1.12.3",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
-      "integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==",
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.3.tgz",
+      "integrity": "sha512-kDCGIbxkDSXE3euJZZXzc6to7fCrKHNI/hSRQnRuQ+BWjFNzZwiFF8fj/6o2t2G9/jTj8PSIYTfCLelLZEeRpA==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -7309,7 +7442,8 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.0.0",
@@ -7498,12 +7632,6 @@
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
-    "node_modules/psl": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
-      "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==",
-      "dev": true
-    },
     "node_modules/pump": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
@@ -7523,12 +7651,13 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.10.4",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.4.tgz",
-      "integrity": "sha512-OQiU+C+Ds5qiH91qh/mg0w+8nwQuLjM4F4M/PbmhDOoYehPh+Fb0bDjtR1sOvy7YKxvj28Y/M0PhP5uVX0kB+g==",
+      "version": "6.13.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.1.tgz",
+      "integrity": "sha512-EJPeIn0CYrGu+hli1xilKAPXODtJ12T0sP63Ijx2/khC2JtuaN3JyNIpvmnkmaEtha9ocbG4A4cMcr+TvqvwQg==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.0.4"
+        "side-channel": "^1.0.6"
       },
       "engines": {
         "node": ">=0.6"
@@ -7536,12 +7665,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/querystringify": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
-      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
-      "dev": true
     },
     "node_modules/queue": {
       "version": "6.0.2",
@@ -7998,12 +8121,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/requires-port": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
-      "dev": true
-    },
     "node_modules/resolve": {
       "version": "1.22.4",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.4.tgz",
@@ -8299,7 +8416,8 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/scheduler": {
       "version": "0.23.0",
@@ -8379,14 +8497,76 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
-      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.0",
-        "get-intrinsic": "^1.0.2",
-        "object-inspect": "^1.9.0"
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -8524,6 +8704,7 @@
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.18.0.tgz",
       "integrity": "sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "asn1": "~0.2.3",
         "assert-plus": "^1.0.0",
@@ -9051,16 +9232,34 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/tmp": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
-      "integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
+    "node_modules/tldts": {
+      "version": "6.1.71",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.71.tgz",
+      "integrity": "sha512-LQIHmHnuzfZgZWAf2HzL83TIIrD8NhhI0DVxqo9/FdOd4ilec+NTNZOlDZf7EwrTNoutccbsHjvWHYXLAtvxjw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "rimraf": "^3.0.0"
+        "tldts-core": "^6.1.71"
       },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.71",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.71.tgz",
+      "integrity": "sha512-LRbChn2YRpic1KxY+ldL1pGXN/oVvKfCVufwfVzEQdFYNo39uF7AJa/WXdo+gYO7PTvdfkCPCed6Hkvz/kR7jg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tmp": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.3.tgz",
+      "integrity": "sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
-        "node": ">=8.17.0"
+        "node": ">=14.14"
       }
     },
     "node_modules/to-fast-properties": {
@@ -9088,27 +9287,16 @@
       "integrity": "sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ=="
     },
     "node_modules/tough-cookie": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.3.tgz",
-      "integrity": "sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.0.tgz",
+      "integrity": "sha512-rvZUv+7MoBYTiDmFPBrhL7Ujx9Sk+q9wwm22x8c8T5IJaR+Wsyc7TNxbVxo84kZoRJZZMazowFLqpankBEQrGg==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
-        "psl": "^1.1.33",
-        "punycode": "^2.1.1",
-        "universalify": "^0.2.0",
-        "url-parse": "^1.5.3"
+        "tldts": "^6.1.32"
       },
       "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/tough-cookie/node_modules/universalify": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
-      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
-      "dev": true,
-      "engines": {
-        "node": ">= 4.0.0"
+        "node": ">=16"
       }
     },
     "node_modules/tr46": {
@@ -9116,6 +9304,16 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "license": "MIT"
+    },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tree-kill": "cli.js"
+      }
     },
     "node_modules/trim-lines": {
       "version": "3.0.1",
@@ -9168,6 +9366,7 @@
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "safe-buffer": "^5.0.1"
       },
@@ -9179,7 +9378,8 @@
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
-      "dev": true
+      "dev": true,
+      "license": "Unlicense"
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -9496,16 +9696,6 @@
         "punycode": "^2.1.0"
       }
     },
-    "node_modules/url-parse": {
-      "version": "1.5.10",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
-      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
-      "dev": true,
-      "dependencies": {
-        "querystringify": "^2.1.1",
-        "requires-port": "^1.0.0"
-      }
-    },
     "node_modules/use-isomorphic-layout-effect": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.2.tgz",
@@ -9537,6 +9727,7 @@
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -9558,6 +9749,7 @@
       "engines": [
         "node >=0.6.0"
       ],
+      "license": "MIT",
       "dependencies": {
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@typescript-eslint/eslint-plugin": "^6.7.0",
     "@typescript-eslint/parser": "^6.7.0",
     "@vitejs/plugin-react": "^4.0.3",
-    "cypress": "^13.3.1",
+    "cypress": "^13.17.0",
     "eslint": "^8.49.0",
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^4.6.0",

--- a/src/config.json
+++ b/src/config.json
@@ -1,6 +1,6 @@
 {
   "api": {
-    "base_url": "http://localhost:8080",
+    "base_url": "http://127.0.0.1:8080",
     "version": "v1"
   },
   "embedded_views": {

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -78,16 +78,19 @@ function Profile() {
                 </span>
               )}
               <span className="font-weight-bold">
-                {userProfile?.name} {userProfile?.surname}
+                <span id="name">{userProfile?.name}</span>
+                <span id="surname"> {userProfile?.surname}</span>
               </span>
-              <span className="text-black-50">{userProfile?.email}</span>
+              <span className="text-black-50" id="email">
+                {userProfile?.email}
+              </span>
               {userProfile?.orcid_id && (
                 <div id="orcid">
                   <strong>{t("orcid")}:</strong> {userProfile?.orcid_id}
                 </div>
               )}
               {userProfile?.id && (
-                <span className="text-black-50">
+                <span className="text-black-50" id="user-id">
                   <strong>ID:</strong> {trimField(userProfile.id, 10)}
                   <OverlayTrigger
                     placement="top"

--- a/src/pages/assessments/AssessmentsList.tsx
+++ b/src/pages/assessments/AssessmentsList.tsx
@@ -314,6 +314,7 @@ function AssessmentsList({ listPublic = false }: AssessmentListProps) {
                 </OverlayTrigger>
 
                 <Form.Select
+                  id="subject-type-select"
                   aria-label={t("page_assessment_list.filter_subject_type")}
                   onChange={(e) => {
                     setFilters({ ...filters, subject_type: e.target.value });
@@ -345,6 +346,7 @@ function AssessmentsList({ listPublic = false }: AssessmentListProps) {
                 </OverlayTrigger>
 
                 <Form.Select
+                  id="subject-name-select"
                   aria-label={t("page_assessment_list.filter_subject_name")}
                   onChange={(e) => {
                     setFilters({ ...filters, subject_name: e.target.value });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,6 +6,7 @@ import path from "path";
 export default defineConfig({
   plugins: [react()],
   server: {
+    host: "127.0.0.1",
     port: 3000,
   },
   preview: {


### PR DESCRIPTION
## Cypress spec /assess and /assessment page
### Description
This PR Updates all cypress tests and some fixtures. It also fixes the localhost/127.0.0.1 issue I was having on mac. The fix to the config for the localhost issue might introduce issues on linux like we had last time. If they do feel free to revert them to a state working for linux. The best option might be to replace it with an env variable, so that it can be altered depending on the dev's setup.

### Changes made
- Updated all tests back to a working state.
- Updated fixtures where needed.
- Added back some ids that were missing.
- Fixed configuration issue with localhost/127.0.0.1 for my local setup. 

 ### How to test
 #### With Cypress UI
- Setup and run both the fc4e-cat-ui and fc4e-cat-api locally.
- run `npx cypress open` in the fc4e-cat-ui project.
- Select E2E testing.
- Select a browser and click 'start testing'.
- This should open the chosen browser and allow you to run the test by clicking on any of the specs.

#### On the CLI
- Setup and run both the fc4e-cat-ui and fc4e-cat-api locally.
- `npx cypress run` 