### PR TITLE
CAT-742 Update auto-https-check test message text styling

### DIFF
--- a/src/pages/assessments/components/tests/TestAutoHttpsCheckForm.tsx
+++ b/src/pages/assessments/components/tests/TestAutoHttpsCheckForm.tsx
@@ -163,7 +163,11 @@ export const TestAutoHttpsCheckForm = (props: AssessmentTestProps) => {
             )}
           {!runningTest && message && (
             <div>
-              <small className="text-danger">{message}</small>
+              <small
+                className={`${props.test.result !== null && props.test.result > 0 ? "text-success" : "text-danger"}`}
+              >
+                {message}
+              </small>
             </div>
           )}
         </div>


### PR DESCRIPTION
Fix https check message to be green if test succeeds and red if test fails