### PR TITLE
CAT-788 Update metric table sort by value

### DIFF
--- a/src/api/services/registry.ts
+++ b/src/api/services/registry.ts
@@ -301,7 +301,7 @@ export const useGetRegistryMetrics = ({
   useQuery({
     queryKey: ["registry-metrics", { size, page, sortBy, sortOrder, search }],
     queryFn: async () => {
-      let url = `/v1/registry/metrics?size=${size}&page=${page}&sort=metric&order=${sortOrder}`;
+      let url = `/v1/registry/metrics?size=${size}&page=${page}&sort=metric.MTR&order=${sortOrder}`;
       search ? (url = `${url}&search=${search}`) : null;
 
       const response = await APIClient(token).get<RegistryMetricResponse>(url);

--- a/src/pages/metrics/Metrics.tsx
+++ b/src/pages/metrics/Metrics.tsx
@@ -53,7 +53,7 @@ export default function Metrics() {
     show: false,
   });
   const [opts, setOpts] = useState<MetricState>({
-    sortBy: "metric",
+    sortBy: "MTR",
     sortOrder: "ASC",
     page: 1,
     size: 10,
@@ -164,17 +164,9 @@ export default function Metrics() {
                 </span>
               </th>
 
-              <th>
-                <span
-                  onClick={() => handleSortClick("label")}
-                  className="cat-cursor-pointer"
-                >
-                  {t("fields.label")}{" "}
-                  {SortMarker("label", opts.sortBy, opts.sortOrder)}
-                </span>
-              </th>
+              <th>{t("fields.label")}</th>
 
-              <th className="w-50 p-3">
+              <th className="w-50">
                 <span>{t("fields.description")}</span>
               </th>
               <th className="w-25">


### PR DESCRIPTION
Align ui with backend changes.

Fixed sorted by by new value `metric.MTR` (the actual field is "metric_mtr" in json). In any case this allows us to sort by MTR column by default.