### PR TITLE
CAT-813 Trim user_id in admin assessments table

### DIFF
--- a/src/pages/admin/AdminAssessments.tsx
+++ b/src/pages/admin/AdminAssessments.tsx
@@ -32,6 +32,7 @@ import { DeleteModal } from "@/components/DeleteModal";
 import { toast } from "react-hot-toast";
 import { useTranslation } from "react-i18next";
 import { PublishModal } from "@/components";
+import { trimField } from "@/utils/admin";
 
 type Pagination = {
   page: number;
@@ -304,7 +305,16 @@ function AdminAssessments() {
                       </td>
                       <td className="align-middle">
                         <div>
-                          <small>{item.user_id}</small>
+                          <OverlayTrigger
+                            placement="top"
+                            overlay={
+                              <Tooltip id={"tip-user-" + item.user_id}>
+                                {item.user_id}
+                              </Tooltip>
+                            }
+                          >
+                            <small>{trimField(item.user_id, 15)}</small>
+                          </OverlayTrigger>
                         </div>
                       </td>
                       <td className="align-middle text-center">


### PR DESCRIPTION
Trim user_id field when its long (over 15chars) and have a tooltip that displays the full id