### PR TITLE
[CAT-866] -  Implement "Create New Version" for Test

### DIFF
--- a/src/api/services/registry.ts
+++ b/src/api/services/registry.ts
@@ -289,6 +289,35 @@ export function useDeleteTest(token: string) {
   });
 }
 
+export function useCreateTestVersion({
+  token,
+  id,
+  testHeader,
+  testDefinition,
+}: {
+  token: string;
+  id: string;
+  testHeader: TestHeaderInput;
+  testDefinition: TestDefinitionInput;
+}) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: () => {
+      return APIClient(token).post(`/v1/registry/tests/${id}/version`, {
+        test: testHeader,
+        test_definition: testDefinition,
+      });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries(["registry-tests"]);
+      queryClient.invalidateQueries(["all-tests"]);
+    },
+    onError: (error: AxiosError) => {
+      return handleBackendError(error);
+    },
+  });
+}
+
 export const useGetRegistryMetrics = ({
   size,
   page,

--- a/src/assets/locales/en.json
+++ b/src/assets/locales/en.json
@@ -79,6 +79,7 @@
     "update_details": "Update Details",
     "create": "Create",
     "create_new": "Create New",
+    "create_version": "Create New Version",
     "delete": "Delete",
     "confirm_delete": "Confirm Delete",
     "about": "About",
@@ -685,6 +686,7 @@
     "tip_view": "View test details",
     "tip_delete": "Delete test",
     "tip_edit": "Edit test",
+    "tip_create_version": "Create a new version of this test",
     "tip_label": "Label (Name) of the test item",
     "modal_delete_title": "Delete test",
     "modal_delete_message": "Are you sure you want to delete the following test?",
@@ -697,6 +699,7 @@
     "parameters_add": "Add new",
     "parameters_add_evidence": "Add Evidence",
     "create_new": "Create New Test",
+    "create_new_version": "Create New Test Version",
     "edit": "Edit Test",
     "view": "View Test Details",
     "toast_delete_success": "Test succesfully deleted!",
@@ -704,7 +707,9 @@
     "toast_create_success": "Test Created!",
     "toast_create_progress": "Creating Test...",
     "toast_update_success": "Test Updated!",
-    "toast_update_progress": "Updating Test..."
+    "toast_update_progress": "Updating Test...",
+    "toast_create_version_success": "New test version successfully created!",
+    "toast_create_version_progress": "Creating new test version..."
   },
   "page_metrics": {
     "title": "Metrics",

--- a/src/pages/tests/Tests.tsx
+++ b/src/pages/tests/Tests.tsx
@@ -19,6 +19,7 @@ import {
   FaArrowsAltV,
   FaEdit,
   FaBars,
+  FaCodeBranch,
 } from "react-icons/fa";
 
 import { AlertInfo } from "@/types";
@@ -44,6 +45,7 @@ type TestsState = {
 type TestModalConfig = {
   id: string;
   show: boolean;
+  isVersioning?: boolean;
 };
 
 type TestModalDetailsConfig = {
@@ -70,6 +72,11 @@ export default function Tests() {
   );
   const tooltipDelete = (
     <Tooltip id="tip-delete">{t("page_tests.tip_delete")}</Tooltip>
+  );
+  const tooltipCreateVersion = (
+    <Tooltip id="tip-create-version">
+      {t("page_tests.tip_create_version")}
+    </Tooltip>
   );
   const { keycloak, registered } = useContext(AuthContext)!;
 
@@ -130,6 +137,7 @@ export default function Tests() {
   const [testModalCfg, setTestModalCfg] = useState<TestModalConfig>({
     id: "",
     show: false,
+    isVersioning: false,
   });
 
   const [testDetailsModalCfg, setTestDetailsModalCfg] =
@@ -137,6 +145,10 @@ export default function Tests() {
       id: "",
       show: false,
     });
+
+  const handleCreateVersion = (testId: string) => {
+    setTestModalCfg({ id: testId, show: true, isVersioning: true });
+  };
 
   // handler for changing page size
   const handleChangePageSize = (evt: { target: { value: string } }) => {
@@ -182,6 +194,7 @@ export default function Tests() {
     }
     return <FaArrowsAltV className="text-secondary opacity-50" />;
   };
+
   return (
     <div>
       <DeleteModal
@@ -198,8 +211,9 @@ export default function Tests() {
       <TestModal
         id={testModalCfg.id}
         show={testModalCfg.show}
+        isVersioning={testModalCfg?.isVersioning}
         onHide={() => {
-          setTestModalCfg({ id: "", show: false });
+          setTestModalCfg({ id: "", show: false, isVersioning: false });
         }}
       />
       <TestDetailsModal
@@ -356,6 +370,19 @@ export default function Tests() {
                             }}
                           >
                             <FaEdit />
+                          </Button>
+                        </OverlayTrigger>
+                        <OverlayTrigger
+                          placement="top"
+                          overlay={tooltipCreateVersion}
+                        >
+                          <Button
+                            className="btn btn-light btn-sm m-1"
+                            onClick={() => {
+                              handleCreateVersion(item.test.id);
+                            }}
+                          >
+                            <FaCodeBranch />
                           </Button>
                         </OverlayTrigger>
                         <OverlayTrigger placement="top" overlay={tooltipDelete}>

--- a/src/pages/validations/ValidationDetails.tsx
+++ b/src/pages/validations/ValidationDetails.tsx
@@ -283,7 +283,7 @@ function ValidationDetails(props: ValidationProps) {
               <div className="row py-3 mt-4">
                 {validation?.status === "REVIEW" && (
                   <h4>
-                    {t("field.status")}
+                    {t("fields.status")}
                     <small className="px-3">
                       <span className="badge bg-primary">
                         <FaGlasses /> {t("review")}
@@ -294,7 +294,7 @@ function ValidationDetails(props: ValidationProps) {
                 {validation?.status === ValidationStatus.REJECTED && (
                   <>
                     <h4>
-                      {t("field.status")}
+                      {t("fields.status")}
                       <small className="px-3">
                         <span className="badge bg-danger">
                           <FaTimes /> {t("rejected")}
@@ -324,7 +324,7 @@ function ValidationDetails(props: ValidationProps) {
                 {validation?.status === ValidationStatus.APPROVED && (
                   <>
                     <h4>
-                      {t("field.status")}
+                      {t("fields.status")}
                       <small className="px-3">
                         <span className="badge bg-success">
                           <FaCheck /> {t("approved")}


### PR DESCRIPTION
This PR implements a new versioning process for Tests, allowing users to create new iterations of existing Tests while preserving the original TES identifier.

- Modified the Tests component to handle creating a new test version via the same modal used for editing
- Updated TestModal component to accept an isVersioning prop
- Added tooltips and appropriate translations for the new version creation functionality