### PR TITLE
[CAT-869] - Implement Test Versioning UI for Tests

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -664,3 +664,20 @@ a.plain:hover {
   align-items: center;
   justify-content: space-between;
 }
+
+.opened-table-row {
+  border-bottom: none;
+}
+
+.version-row {
+  font-size: 0.9rem;
+  box-shadow: -6px 0 0 0 #ced4da;
+}
+
+.version-row td {
+  border-top: none;
+}
+
+.version-row td:first-child {
+  padding-left: 2.5rem;
+}

--- a/src/pages/tests/Tests.tsx
+++ b/src/pages/tests/Tests.tsx
@@ -1,38 +1,17 @@
 import { AuthContext } from "@/auth";
 import { useContext, useEffect, useRef, useState } from "react";
-import {
-  Alert,
-  Button,
-  OverlayTrigger,
-  Table,
-  Tooltip,
-  Form,
-} from "react-bootstrap";
-import {
-  FaArrowLeft,
-  FaArrowRight,
-  FaExclamationTriangle,
-  FaPlus,
-  FaTrash,
-  FaArrowUp,
-  FaArrowDown,
-  FaArrowsAltV,
-  FaEdit,
-  FaBars,
-  FaCodeBranch,
-} from "react-icons/fa";
-
 import { AlertInfo } from "@/types";
 import { TestModal } from "@/pages/tests/components/TestModal";
 import toast from "react-hot-toast";
 import { DeleteModal } from "@/components/DeleteModal";
 import { useTranslation } from "react-i18next";
-import { idToColor } from "@/utils/admin";
 import { useDeleteTest, useGetTests } from "@/api/services/registry";
-import { MotivationRefList } from "@/components/MotivationRefList";
 import { RegistryTest } from "@/types/tests";
-import { FaClipboardQuestion } from "react-icons/fa6";
 import { TestDetailsModal } from "./components/TestDetailsModal";
+import TestsHeader from "./components/TestsHeader";
+import TestSearch from "./components/TestSearch";
+import TestTable from "./components/TestTable";
+import TestPagination from "./components/TestPagination";
 
 type TestsState = {
   sortOrder: string;
@@ -45,6 +24,7 @@ type TestsState = {
 type TestModalConfig = {
   id: string;
   show: boolean;
+  isEditing?: boolean;
   isVersioning?: boolean;
 };
 
@@ -61,30 +41,14 @@ interface DeleteModalConfig {
   itemName: string;
 }
 
-// the main component that lists the tests in a table
-export default function Tests() {
+function Tests() {
   const { t } = useTranslation();
-  const tooltipView = (
-    <Tooltip id="tip-view">{t("page_tests.tip_view")}</Tooltip>
-  );
-  const tooltipEdit = (
-    <Tooltip id="tip-edit">{t("page_tests.tip_edit")}</Tooltip>
-  );
-  const tooltipDelete = (
-    <Tooltip id="tip-delete">{t("page_tests.tip_delete")}</Tooltip>
-  );
-  const tooltipCreateVersion = (
-    <Tooltip id="tip-create-version">
-      {t("page_tests.tip_create_version")}
-    </Tooltip>
-  );
   const { keycloak, registered } = useContext(AuthContext)!;
 
   const alert = useRef<AlertInfo>({
     message: "",
   });
 
-  // Delete Modal
   const [deleteModalConfig, setDeleteModalConfig] = useState<DeleteModalConfig>(
     {
       show: false,
@@ -94,6 +58,41 @@ export default function Tests() {
       itemName: "",
     },
   );
+
+  const [opts, setOpts] = useState<TestsState>({
+    sortBy: "lastTouch",
+    sortOrder: "DESC",
+    page: 1,
+    size: 10,
+    search: "",
+  });
+
+  const [testModalCfg, setTestModalCfg] = useState<TestModalConfig>({
+    id: "",
+    show: false,
+    isEditing: false,
+    isVersioning: false,
+  });
+
+  const [testDetailsModalCfg, setTestDetailsModalCfg] =
+    useState<TestModalDetailsConfig>({
+      id: "",
+      show: false,
+    });
+
+  const [expandedTests, setExpandedTests] = useState<{
+    [key: string]: boolean;
+  }>({});
+
+  const { isLoading, data, refetch } = useGetTests({
+    size: opts.size,
+    page: opts.page,
+    sortBy: opts.sortBy,
+    sortOrder: opts.sortOrder,
+    search: opts.search,
+    token: keycloak?.token || "",
+    isRegistered: registered,
+  });
 
   const mutationDelete = useDeleteTest(keycloak?.token || "");
 
@@ -126,77 +125,93 @@ export default function Tests() {
     }
   };
 
-  const [opts, setOpts] = useState<TestsState>({
-    sortBy: "lastTouch",
-    sortOrder: "DESC",
-    page: 1,
-    size: 10,
-    search: "",
-  });
-
-  const [testModalCfg, setTestModalCfg] = useState<TestModalConfig>({
-    id: "",
-    show: false,
-    isVersioning: false,
-  });
-
-  const [testDetailsModalCfg, setTestDetailsModalCfg] =
-    useState<TestModalDetailsConfig>({
-      id: "",
-      show: false,
-    });
-
-  const handleCreateVersion = (testId: string) => {
-    setTestModalCfg({ id: testId, show: true, isVersioning: true });
-  };
-
-  // handler for changing page size
-  const handleChangePageSize = (evt: { target: { value: string } }) => {
-    setOpts({ ...opts, page: 1, size: parseInt(evt.target.value) });
-  };
-
-  // handler for clicking to sort
-  const handleSortClick = (field: string) => {
+  const handleSortChange = (field: string) => {
     if (field === opts.sortBy) {
-      if (opts.sortOrder === "ASC") {
-        setOpts({ ...opts, sortOrder: "DESC" });
-      } else {
-        setOpts({ ...opts, sortOrder: "ASC" });
-      }
+      setOpts({
+        ...opts,
+        sortOrder: opts.sortOrder === "ASC" ? "DESC" : "ASC",
+      });
     } else {
-      setOpts({ ...opts, sortOrder: "ASC", sortBy: field });
+      setOpts({
+        ...opts,
+        sortOrder: "ASC",
+        sortBy: field,
+      });
     }
   };
-
-  // data get list of tests
-  const { isLoading, data, refetch } = useGetTests({
-    size: opts.size,
-    page: opts.page,
-    sortBy: opts.sortBy,
-    sortOrder: opts.sortOrder,
-    search: opts.search,
-    token: keycloak?.token || "",
-    isRegistered: registered,
-  });
 
   // refetch users when parameters change
   useEffect(() => {
     refetch();
   }, [opts, refetch]);
 
-  // get the test data to create the table
   const tests: RegistryTest[] = data ? data?.content : [];
-  // create an up/down arrow to designate sorting in a column
-  const SortMarker = (field: string, sortField: string, sortOrder: string) => {
-    if (field === sortField) {
-      if (sortOrder === "DESC") return <FaArrowUp />;
-      else if (sortOrder === "ASC") return <FaArrowDown />;
-    }
-    return <FaArrowsAltV className="text-secondary opacity-50" />;
-  };
 
   return (
-    <div>
+    <>
+      <TestsHeader
+        onCreateTest={() => setTestModalCfg({ id: "", show: true })}
+      />
+      <TestSearch
+        searchValue={opts.search}
+        onSearchChange={(searchText) =>
+          setOpts({ ...opts, search: searchText, page: 1 })
+        }
+        onClearSearch={() => setOpts({ ...opts, search: "", page: 1 })}
+      />
+      <TestTable
+        tests={tests}
+        isLoading={isLoading}
+        sortBy={opts.sortBy}
+        sortOrder={opts.sortOrder}
+        expandedTests={expandedTests}
+        onSortChange={handleSortChange}
+        onToggleExpand={(testId) =>
+          setExpandedTests((prev) => ({
+            ...prev,
+            [testId]: !prev[testId],
+          }))
+        }
+        onViewTest={(testId) =>
+          setTestDetailsModalCfg({
+            id: testId,
+            show: true,
+          })
+        }
+        onEditTest={(testId) =>
+          setTestModalCfg({
+            id: testId,
+            show: true,
+            isEditing: true,
+          })
+        }
+        onCreateVersion={(testId) =>
+          setTestModalCfg({
+            id: testId,
+            show: true,
+            isVersioning: true,
+          })
+        }
+        onDeleteTest={(testId, name) =>
+          setDeleteModalConfig({
+            ...deleteModalConfig,
+            show: true,
+            itemId: testId,
+            itemName: name,
+          })
+        }
+      />
+      <TestPagination
+        page={opts.page}
+        size={opts.size}
+        totalPages={data?.total_pages}
+        totalElements={data?.total_elements}
+        numberOfPage={data?.number_of_page}
+        sizeOfPage={data?.size_of_page}
+        onPageSizeChange={(size) => setOpts({ ...opts, page: 1, size })}
+        onPageChange={(page) => setOpts({ ...opts, page })}
+      />
+      <div className="p-4"></div>
       <DeleteModal
         show={deleteModalConfig.show}
         title={deleteModalConfig.title}
@@ -211,9 +226,15 @@ export default function Tests() {
       <TestModal
         id={testModalCfg.id}
         show={testModalCfg.show}
+        isEditing={testModalCfg?.isEditing}
         isVersioning={testModalCfg?.isVersioning}
         onHide={() => {
-          setTestModalCfg({ id: "", show: false, isVersioning: false });
+          setTestModalCfg({
+            id: "",
+            show: false,
+            isVersioning: false,
+            isEditing: false,
+          });
         }}
       />
       <TestDetailsModal
@@ -223,251 +244,8 @@ export default function Tests() {
           setTestDetailsModalCfg({ id: "", show: false });
         }}
       />
-      <div className="cat-view-heading-block row border-bottom">
-        <div className="col">
-          <h2 className="text-muted cat-view-heading ">
-            {t("page_tests.title")}
-            <p className="lead cat-view-lead">{t("page_tests.subtitle")}</p>
-          </h2>
-        </div>
-        <div className="col-md-auto cat-heading-right">
-          <Button
-            variant="warning"
-            onClick={() => {
-              setTestModalCfg({ id: "", show: true });
-            }}
-          >
-            <FaPlus /> {t("buttons.create_new")}
-          </Button>
-        </div>
-      </div>
-      <div>
-        <Form className="mb-3">
-          <div className="row cat-view-search-block border-bottom">
-            <div className="col col-lg-3"></div>
-            <div className="col md-auto col-lg-9">
-              <div className="d-flex justify-content-center">
-                <Form.Control
-                  placeholder={t("fields.search")}
-                  onChange={(e) => {
-                    setOpts({ ...opts, search: e.target.value, page: 1 });
-                  }}
-                  value={opts.search}
-                />
-                <Button
-                  onClick={() => {
-                    setOpts({ ...opts, search: "", page: 1 });
-                  }}
-                  className="ms-4"
-                >
-                  {t("buttons.clear")}
-                </Button>
-              </div>
-            </div>
-          </div>
-        </Form>
-      </div>
-      <div>
-        <Table hover>
-          <thead>
-            <tr className="table-light">
-              <th>
-                <span
-                  onClick={() => handleSortClick("TES")}
-                  className="cat-cursor-pointer"
-                >
-                  {t("fields.tes").toUpperCase()}{" "}
-                  {SortMarker("TES", opts.sortBy, opts.sortOrder)}
-                </span>
-              </th>
-              <th>
-                <span
-                  onClick={() => handleSortClick("labelTest")}
-                  className="cat-cursor-pointer"
-                >
-                  {t("fields.label")}{" "}
-                  {SortMarker("labelTest", opts.sortBy, opts.sortOrder)}
-                </span>
-              </th>
-              <th className="w-50">
-                <span>{t("fields.description")}</span>
-              </th>
-              <th>
-                <span
-                  onClick={() => handleSortClick("lastTouch")}
-                  className="cat-cursor-pointer text-nowrap"
-                >
-                  {t("fields.modified")}{" "}
-                  {SortMarker("lastTouch", opts.sortBy, opts.sortOrder)}
-                </span>
-              </th>
-              <th>
-                <span>{t("motivations")}</span>
-              </th>
-              <th></th>
-            </tr>
-          </thead>
-          {tests.length > 0 ? (
-            <tbody>
-              {tests.map((item) => {
-                return (
-                  <tr key={item.test.id}>
-                    <td className="align-middle">
-                      <div className="d-flex  justify-content-start">
-                        <div>
-                          <FaClipboardQuestion
-                            size={"2.5rem"}
-                            style={{ color: idToColor(item.test.id) }}
-                          />
-                        </div>
-                        <div className="ms-2 d-flex flex-column justify-content-between">
-                          <div>{item.test.tes}</div>
-                          <div>
-                            <span
-                              style={{ fontSize: "0.64rem" }}
-                              className="text-muted"
-                            >
-                              {item.test.id}
-                            </span>
-                          </div>
-                        </div>
-                      </div>
-                    </td>
-                    <td className="align-middle">{item.test.label}</td>
-
-                    <td className="align-middle">{item.test.description}</td>
-                    <td className="align-middle">
-                      <small>{item.test.last_touch?.split("T")[0]}</small>
-                    </td>
-                    <td>
-                      <MotivationRefList
-                        motivations={item.used_by_motivations || []}
-                      />
-                    </td>
-                    <td>
-                      <div className="d-flex flex-nowrap">
-                        <OverlayTrigger placement="top" overlay={tooltipView}>
-                          <Button
-                            className="btn btn-light btn-sm m-1"
-                            onClick={() => {
-                              setTestDetailsModalCfg({
-                                id: item.test.id,
-                                show: true,
-                              });
-                            }}
-                          >
-                            <FaBars />
-                          </Button>
-                        </OverlayTrigger>
-                        <OverlayTrigger placement="top" overlay={tooltipEdit}>
-                          <Button
-                            className="btn btn-light btn-sm m-1"
-                            onClick={() => {
-                              setTestModalCfg({
-                                id: item.test.id,
-                                show: true,
-                              });
-                            }}
-                          >
-                            <FaEdit />
-                          </Button>
-                        </OverlayTrigger>
-                        <OverlayTrigger
-                          placement="top"
-                          overlay={tooltipCreateVersion}
-                        >
-                          <Button
-                            className="btn btn-light btn-sm m-1"
-                            onClick={() => {
-                              handleCreateVersion(item.test.id);
-                            }}
-                          >
-                            <FaCodeBranch />
-                          </Button>
-                        </OverlayTrigger>
-                        <OverlayTrigger placement="top" overlay={tooltipDelete}>
-                          <Button
-                            className="btn btn-light btn-sm m-1"
-                            onClick={() => {
-                              setDeleteModalConfig({
-                                ...deleteModalConfig,
-                                show: true,
-                                itemId: item.test.id,
-                                itemName: `${item.test.label} - ${item.test.tes}`,
-                              });
-                            }}
-                          >
-                            <FaTrash />
-                          </Button>
-                        </OverlayTrigger>
-                      </div>
-                    </td>
-                  </tr>
-                );
-              })}
-            </tbody>
-          ) : null}
-        </Table>
-        {!isLoading && tests.length === 0 && (
-          <Alert variant="warning" className="text-center mx-auto">
-            <h3>
-              <FaExclamationTriangle />
-            </h3>
-            <h5>{t("no_data")}</h5>
-          </Alert>
-        )}
-        <div className="d-flex justify-content-end">
-          <div>
-            <span className="mx-1">{t("rows_per_page")} </span>
-            <select
-              name="per-page"
-              value={opts.size.toString() || "20"}
-              id="per-page"
-              onChange={handleChangePageSize}
-            >
-              <option value="5">5</option>
-              <option value="10">10</option>
-              <option value="15">15</option>
-              <option value="20">20</option>
-            </select>
-          </div>
-
-          {data && data.number_of_page && data.total_pages && (
-            <div className="ms-4">
-              <span>
-                {(data.number_of_page - 1) * opts.size + 1} -{" "}
-                {(data.number_of_page - 1) * opts.size + data.size_of_page} of{" "}
-                {data.total_elements}
-              </span>
-              <span
-                onClick={() => {
-                  setOpts({ ...opts, page: opts.page - 1 });
-                }}
-                className={`ms-4 btn py-0 btn-light btn-small ${
-                  opts.page === 1 ? "disabled text-muted" : null
-                }`}
-              >
-                <FaArrowLeft />
-              </span>
-              <span
-                onClick={() => {
-                  setOpts({ ...opts, page: opts.page + 1 });
-                }}
-                className={`btn py-0 btn-light btn-small" ${
-                  data?.total_pages > data?.number_of_page
-                    ? null
-                    : "disabled text-muted"
-                }`}
-              >
-                <FaArrowRight />
-              </span>
-            </div>
-          )}
-        </div>
-      </div>
-      <div className="row py-3 p-4">
-        <div className="col"></div>
-      </div>
-    </div>
+    </>
   );
 }
+
+export default Tests;

--- a/src/pages/tests/components/TestModal.tsx
+++ b/src/pages/tests/components/TestModal.tsx
@@ -32,6 +32,7 @@ import {
 interface TestModalProps {
   id: string;
   show: boolean;
+  isEditing?: boolean;
   isVersioning?: boolean;
   onHide: () => void;
 }
@@ -350,7 +351,7 @@ export function TestModal(props: TestModalProps) {
                     });
                   }}
                   aria-describedby="label-metric-mtr"
-                  disabled={props.isVersioning}
+                  disabled={props?.isEditing || props?.isVersioning}
                 />
               </InputGroup>
               {showErrors && testHeader.tes === "" && (

--- a/src/pages/tests/components/TestPagination.tsx
+++ b/src/pages/tests/components/TestPagination.tsx
@@ -1,0 +1,77 @@
+import React from "react";
+import { FaArrowLeft, FaArrowRight } from "react-icons/fa";
+import { useTranslation } from "react-i18next";
+
+interface PaginationProps {
+  page: number;
+  size: number;
+  totalPages?: number;
+  totalElements?: number;
+  numberOfPage?: number;
+  sizeOfPage?: number;
+  onPageSizeChange: (size: number) => void;
+  onPageChange: (page: number) => void;
+}
+
+const TestPagination: React.FC<PaginationProps> = ({
+  page,
+  size,
+  totalPages,
+  totalElements,
+  numberOfPage,
+  sizeOfPage,
+  onPageSizeChange,
+  onPageChange,
+}) => {
+  const { t } = useTranslation();
+
+  const handleChangePageSize = (evt: React.ChangeEvent<HTMLSelectElement>) => {
+    onPageSizeChange(parseInt(evt.target.value));
+  };
+
+  return (
+    <div className="d-flex justify-content-end">
+      <div>
+        <span className="mx-1">{t("rows_per_page")} </span>
+        <select
+          name="per-page"
+          value={size.toString()}
+          id="per-page"
+          onChange={handleChangePageSize}
+        >
+          <option value="5">5</option>
+          <option value="10">10</option>
+          <option value="15">15</option>
+          <option value="20">20</option>
+        </select>
+      </div>
+
+      {numberOfPage && totalPages && (
+        <div className="ms-4">
+          <span>
+            {(numberOfPage - 1) * size + 1} -{" "}
+            {(numberOfPage - 1) * size + (sizeOfPage || 0)} of {totalElements}
+          </span>
+          <span
+            onClick={() => onPageChange(page - 1)}
+            className={`ms-4 btn py-0 btn-light btn-small ${
+              page === 1 ? "disabled text-muted" : null
+            }`}
+          >
+            <FaArrowLeft />
+          </span>
+          <span
+            onClick={() => onPageChange(page + 1)}
+            className={`btn py-0 btn-light btn-small ${
+              totalPages > numberOfPage ? null : "disabled text-muted"
+            }`}
+          >
+            <FaArrowRight />
+          </span>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default TestPagination;

--- a/src/pages/tests/components/TestRow.tsx
+++ b/src/pages/tests/components/TestRow.tsx
@@ -1,0 +1,183 @@
+import React from "react";
+import { Button, OverlayTrigger, Tooltip } from "react-bootstrap";
+import {
+  FaBars,
+  FaChevronDown,
+  FaChevronUp,
+  FaCodeBranch,
+  FaEdit,
+  FaTrash,
+} from "react-icons/fa";
+import { FaClipboardQuestion } from "react-icons/fa6";
+import { useTranslation } from "react-i18next";
+import { RegistryTest } from "@/types/tests";
+import { idToColor } from "@/utils/admin";
+import { MotivationRefList } from "@/components/MotivationRefList";
+
+interface TestRowProps {
+  test: RegistryTest;
+  isExpanded: boolean;
+  toggleExpand: (testId: string) => void;
+  onView: (testId: string) => void;
+  onEdit: (testId: string) => void;
+  onCreateVersion: (testId: string) => void;
+  onDelete: (testId: string, name: string) => void;
+}
+
+const TestRow: React.FC<TestRowProps> = ({
+  test,
+  isExpanded,
+  toggleExpand,
+  onView,
+  onEdit,
+  onCreateVersion,
+  onDelete,
+}) => {
+  const { t } = useTranslation();
+  const hasVersions = test.test_versions && test.test_versions.length > 0;
+
+  const tooltipView = (
+    <Tooltip id="tip-view">{t("page_tests.tip_view")}</Tooltip>
+  );
+  const tooltipEdit = (
+    <Tooltip id="tip-edit">{t("page_tests.tip_edit")}</Tooltip>
+  );
+  const tooltipDelete = (
+    <Tooltip id="tip-delete">{t("page_tests.tip_delete")}</Tooltip>
+  );
+
+  const tooltipCreateVersion = (
+    <Tooltip id="tip-create-version">
+      {t("page_tests.tip_create_version")}
+    </Tooltip>
+  );
+
+  const hasMotivations = (test: RegistryTest): boolean => {
+    console.log("test", test);
+    return Boolean(
+      test?.used_by_motivations && test.used_by_motivations?.length > 0,
+    );
+  };
+
+  return (
+    <tr key={test.test.id} className={isExpanded ? "opened-table-row" : ""}>
+      <td
+        className={
+          isExpanded ? "align-middle opened-table-row" : "align-middle"
+        }
+      >
+        <div className="d-flex justify-content-start">
+          {hasVersions && (
+            <div
+              className="me-2 d-flex align-items-center"
+              style={{ cursor: "pointer", width: "1rem" }}
+              onClick={() => toggleExpand(test.test.id)}
+            >
+              {isExpanded ? <FaChevronDown /> : <FaChevronUp />}
+            </div>
+          )}
+          <div>
+            <FaClipboardQuestion
+              size={"2.5rem"}
+              style={{ color: idToColor(test.test.id) }}
+            />
+          </div>
+          <div className="ms-2 d-flex flex-column justify-content-between">
+            <div>
+              {test.test.tes}{" "}
+              {hasVersions && test.is_latest_version !== false && (
+                <span className="ms-2 badge bg-success">
+                  latest
+                  {test.test.version ? ` v${test.test.version}` : ""}
+                </span>
+              )}
+            </div>
+
+            <div>
+              <span style={{ fontSize: "0.64rem" }} className="text-muted">
+                {test.test.id}
+              </span>
+            </div>
+          </div>
+        </div>
+      </td>
+      <td
+        className={
+          hasVersions && isExpanded
+            ? "align-middle opened-table-row"
+            : "align-middle"
+        }
+      >
+        {test.test.label}
+      </td>
+      <td
+        className={
+          hasVersions && isExpanded
+            ? "align-middle opened-table-row"
+            : "align-middle"
+        }
+      >
+        {test.test.description}
+      </td>
+      <td
+        className={
+          hasVersions && isExpanded
+            ? "align-middle opened-table-row"
+            : "align-middle"
+        }
+      >
+        <small>{test.test.last_touch?.split("T")[0]}</small>
+      </td>
+      <td className={hasVersions && isExpanded ? "opened-table-row" : ""}>
+        <MotivationRefList motivations={test.used_by_motivations || []} />
+      </td>
+      <td className={hasVersions && isExpanded ? "opened-table-row" : ""}>
+        <div className="d-flex flex-nowrap">
+          <OverlayTrigger placement="top" overlay={tooltipView}>
+            <Button
+              className="btn btn-light btn-sm m-1"
+              onClick={() => onView(test.test.id)}
+            >
+              <FaBars />
+            </Button>
+          </OverlayTrigger>
+          <OverlayTrigger placement="top" overlay={tooltipEdit}>
+            <Button
+              className="btn btn-light btn-sm m-1"
+              onClick={() => onEdit(test.test.id)}
+            >
+              <FaEdit />
+            </Button>
+          </OverlayTrigger>
+
+          <OverlayTrigger placement="top" overlay={tooltipCreateVersion}>
+            <Button
+              className="btn btn-light btn-sm m-1"
+              onClick={() => onCreateVersion(test.test.id)}
+            >
+              <FaCodeBranch />
+            </Button>
+          </OverlayTrigger>
+
+          {!hasMotivations(test) && (
+            <OverlayTrigger placement="top" overlay={tooltipDelete}>
+              <Button
+                className="btn btn-light btn-sm m-1"
+                onClick={() =>
+                  onDelete(
+                    test.test.id,
+                    `${test.test.label} - ${test.test.tes}`,
+                  )
+                }
+              >
+                <FaTrash />
+              </Button>
+            </OverlayTrigger>
+          )}
+        </div>
+      </td>
+    </tr>
+  );
+};
+
+export default TestRow;

--- a/src/pages/tests/components/TestSearch.tsx
+++ b/src/pages/tests/components/TestSearch.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+import { Button, Form } from "react-bootstrap";
+import { useTranslation } from "react-i18next";
+
+interface TestSearchProps {
+  searchValue: string;
+  onSearchChange: (searchText: string) => void;
+  onClearSearch: () => void;
+}
+
+const TestSearch: React.FC<TestSearchProps> = ({
+  searchValue,
+  onSearchChange,
+  onClearSearch,
+}) => {
+  const { t } = useTranslation();
+
+  return (
+    <Form className="mb-3">
+      <div className="row cat-view-search-block border-bottom">
+        <div className="col col-lg-3"></div>
+        <div className="col md-auto col-lg-9">
+          <div className="d-flex justify-content-center">
+            <Form.Control
+              placeholder={t("fields.search")}
+              onChange={(e) => onSearchChange(e.target.value)}
+              value={searchValue}
+            />
+            <Button onClick={onClearSearch} className="ms-4">
+              {t("buttons.clear")}
+            </Button>
+          </div>
+        </div>
+      </div>
+    </Form>
+  );
+};
+
+export default TestSearch;

--- a/src/pages/tests/components/TestTable.tsx
+++ b/src/pages/tests/components/TestTable.tsx
@@ -1,0 +1,138 @@
+import React, { Fragment } from "react";
+import { Alert, Table } from "react-bootstrap";
+import {
+  FaArrowDown,
+  FaArrowUp,
+  FaArrowsAltV,
+  FaExclamationTriangle,
+} from "react-icons/fa";
+import { useTranslation } from "react-i18next";
+import { RegistryTest } from "@/types/tests";
+import TestRow from "./TestRow";
+import TestVersionRow from "./TestVersionRow";
+
+interface TestTableProps {
+  tests: RegistryTest[];
+  isLoading: boolean;
+  sortBy: string;
+  sortOrder: string;
+  expandedTests: { [key: string]: boolean };
+  onSortChange: (field: string) => void;
+  onToggleExpand: (testId: string) => void;
+  onViewTest: (testId: string) => void;
+  onEditTest: (testId: string) => void;
+  onCreateVersion: (testId: string) => void;
+  onDeleteTest: (testId: string, name: string) => void;
+}
+
+const TestTable: React.FC<TestTableProps> = ({
+  tests,
+  isLoading,
+  sortBy,
+  sortOrder,
+  expandedTests,
+  onSortChange,
+  onToggleExpand,
+  onViewTest,
+  onEditTest,
+  onCreateVersion,
+  onDeleteTest,
+}) => {
+  const { t } = useTranslation();
+
+  const SortMarker = (field: string, sortField: string, sortOrder: string) => {
+    if (field === sortField) {
+      if (sortOrder === "DESC") return <FaArrowUp />;
+      else if (sortOrder === "ASC") return <FaArrowDown />;
+    }
+    return <FaArrowsAltV className="text-secondary opacity-50" />;
+  };
+
+  if (!isLoading && tests.length === 0) {
+    return (
+      <Alert variant="warning" className="text-center mx-auto">
+        <h3>
+          <FaExclamationTriangle />
+        </h3>
+        <h5>{t("no_data")}</h5>
+      </Alert>
+    );
+  }
+
+  return (
+    <Table hover>
+      <thead>
+        <tr className="table-light">
+          <th style={{ width: "220px" }}>
+            <span
+              onClick={() => onSortChange("TES")}
+              className="cat-cursor-pointer"
+            >
+              {t("fields.tes").toUpperCase()}{" "}
+              {SortMarker("TES", sortBy, sortOrder)}
+            </span>
+          </th>
+          <th>
+            <span
+              onClick={() => onSortChange("labelTest")}
+              className="cat-cursor-pointer"
+            >
+              {t("fields.label")} {SortMarker("labelTest", sortBy, sortOrder)}
+            </span>
+          </th>
+          <th className="w-50">
+            <span>{t("fields.description")}</span>
+          </th>
+          <th>
+            <span
+              onClick={() => onSortChange("lastTouch")}
+              className="cat-cursor-pointer text-nowrap"
+            >
+              {t("fields.modified")}{" "}
+              {SortMarker("lastTouch", sortBy, sortOrder)}
+            </span>
+          </th>
+          <th>
+            <span>{t("motivations")}</span>
+          </th>
+          <th></th>
+        </tr>
+      </thead>
+      {tests.length > 0 && (
+        <tbody>
+          {tests.map((item) => {
+            const isExpanded = expandedTests[item.test.id] || false;
+            const hasVersions =
+              item.test_versions && item.test_versions.length > 0;
+
+            return (
+              <Fragment key={`fragment-${item.test.id}`}>
+                <TestRow
+                  test={item}
+                  isExpanded={isExpanded}
+                  toggleExpand={onToggleExpand}
+                  onView={onViewTest}
+                  onEdit={onEditTest}
+                  onCreateVersion={onCreateVersion}
+                  onDelete={onDeleteTest}
+                />
+                {isExpanded &&
+                  hasVersions &&
+                  item.test_versions?.map((version) => (
+                    <TestVersionRow
+                      key={`version-${version.test.id}`}
+                      version={version}
+                      onView={onViewTest}
+                      onEdit={onEditTest}
+                    />
+                  ))}
+              </Fragment>
+            );
+          })}
+        </tbody>
+      )}
+    </Table>
+  );
+};
+
+export default TestTable;

--- a/src/pages/tests/components/TestVersionRow.tsx
+++ b/src/pages/tests/components/TestVersionRow.tsx
@@ -1,0 +1,87 @@
+import React from "react";
+import { Button, OverlayTrigger, Tooltip } from "react-bootstrap";
+import { FaBars, FaEdit } from "react-icons/fa";
+import { FaClipboardQuestion } from "react-icons/fa6";
+import { useTranslation } from "react-i18next";
+import { RegistryTest } from "@/types/tests";
+import { idToColor } from "@/utils/admin";
+import { MotivationRefList } from "@/components/MotivationRefList";
+
+interface TestVersionRowProps {
+  version: RegistryTest;
+  onView: (testId: string) => void;
+  onEdit: (testId: string) => void;
+}
+
+const TestVersionRow: React.FC<TestVersionRowProps> = ({
+  version,
+  onView,
+  onEdit,
+}) => {
+  const { t } = useTranslation();
+
+  const tooltipView = (
+    <Tooltip id="tip-view">{t("page_tests.tip_view")}</Tooltip>
+  );
+  const tooltipEdit = (
+    <Tooltip id="tip-edit">{t("page_tests.tip_edit")}</Tooltip>
+  );
+
+  return (
+    <tr className="version-row version-child-column">
+      <td className="align-middle">
+        <div className="d-flex flex-column gap-2 ps-4">
+          <div className="d-flex align-items-center gap-1">
+            <FaClipboardQuestion
+              size={"2.2rem"}
+              style={{
+                color: idToColor(version.test.id),
+                opacity: 0.7,
+              }}
+            />
+            <span className="badge bg-secondary">
+              {version.test.version
+                ? `v${version.test.version}`
+                : "old version"}
+            </span>
+          </div>
+          <span style={{ fontSize: "0.64rem" }} className="text-muted">
+            {version.test.id}
+          </span>
+        </div>
+      </td>
+      <td className="align-middle">{version.test.label}</td>
+      <td className="align-middle">{version.test.description}</td>
+      <td className="align-middle">
+        <small>{version.test.last_touch?.split("T")[0]}</small>
+      </td>
+      <td>
+        {version?.used_by_motivations ? (
+          <MotivationRefList motivations={version.used_by_motivations || []} />
+        ) : null}
+      </td>
+      <td>
+        <div className="d-flex flex-nowrap">
+          <OverlayTrigger placement="top" overlay={tooltipView}>
+            <Button
+              className="btn btn-light btn-sm m-1"
+              onClick={() => onView(version.test.id)}
+            >
+              <FaBars />
+            </Button>
+          </OverlayTrigger>
+          <OverlayTrigger placement="top" overlay={tooltipEdit}>
+            <Button
+              className="btn btn-light btn-sm m-1"
+              onClick={() => onEdit(version.test.id)}
+            >
+              <FaEdit />
+            </Button>
+          </OverlayTrigger>
+        </div>
+      </td>
+    </tr>
+  );
+};
+
+export default TestVersionRow;

--- a/src/pages/tests/components/TestsHeader.tsx
+++ b/src/pages/tests/components/TestsHeader.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+import { Button } from "react-bootstrap";
+import { FaPlus } from "react-icons/fa";
+import { useTranslation } from "react-i18next";
+
+interface TestsHeaderProps {
+  onCreateTest: () => void;
+}
+
+const TestsHeader: React.FC<TestsHeaderProps> = ({ onCreateTest }) => {
+  const { t } = useTranslation();
+
+  return (
+    <div className="cat-view-heading-block row border-bottom">
+      <div className="col">
+        <h2 className="text-muted cat-view-heading">
+          {t("page_tests.title")}
+          <p className="lead cat-view-lead">{t("page_tests.subtitle")}</p>
+        </h2>
+      </div>
+      <div className="col-md-auto cat-heading-right">
+        <Button variant="warning" onClick={onCreateTest}>
+          <FaPlus /> {t("buttons.create_new")}
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export default TestsHeader;

--- a/src/types/tests.ts
+++ b/src/types/tests.ts
@@ -7,6 +7,7 @@ export interface RegistryTestHeader {
   label: string;
   description: string;
   last_touch?: string;
+  version?: number;
 }
 
 export interface RegistryTestDefinition {
@@ -23,6 +24,8 @@ export interface RegistryTest {
   test: RegistryTestHeader;
   test_definition: RegistryTestDefinition;
   used_by_motivations?: MotivationReference[];
+  test_versions?: RegistryTest[];
+  is_latest_version?: boolean;
 }
 
 export type RegistryTestsResponse = ResponsePage<RegistryTest[]>;


### PR DESCRIPTION
This PR implements a versioning display feature for Tests in the management table, allowing an admin to view and compare different versions of tests directly in the UI.

- Added expandable rows with chevron indicators for tests with multiple versions
- Implemented nested row display that shows version history as indented child rows
- Added disabled state for delete button when tests are used in motivations
- Refactored Tests component into smaller, more readable components