### PR TITLE
[CAT-870] - Implement Test Preview Mode in Test Creation UI

### DIFF
--- a/src/components/PublishModal.tsx
+++ b/src/components/PublishModal.tsx
@@ -89,8 +89,11 @@ export function PublishModal(props: PublishModalProps) {
       aria-labelledby="contained-modal-title-vcenter"
       centered
     >
-      <Modal.Header className="bg-success text-white" closeButton>
-        <Modal.Title id="contained-modal-title-vcenter">
+      <Modal.Header closeButton>
+        <Modal.Title
+          className="d-flex align-items-center gap-1"
+          id="contained-modal-title-vcenter"
+        >
           {props.publish ? (
             <>
               <FaEye className="me-2" />

--- a/src/pages/assessments/components/CriteriaTabs.tsx
+++ b/src/pages/assessments/components/CriteriaTabs.tsx
@@ -1,14 +1,11 @@
 import {
-  // Alert,
   Col,
   ListGroup,
   Nav,
   OverlayTrigger,
-  // OverlayTrigger,
   Row,
   Tab,
   Tooltip,
-  // Tooltip,
 } from "react-bootstrap";
 import {
   FaCableCar,
@@ -35,7 +32,6 @@ import {
   TestAutoHttpsCheck,
   TestAutoMD1,
   TestAutoG069,
-  // MetricAlgorithm,
 } from "@/types";
 import {
   TestBinaryForm,

--- a/src/pages/assessments/components/ShareModal.tsx
+++ b/src/pages/assessments/components/ShareModal.tsx
@@ -79,8 +79,11 @@ export function ShareModal(props: ShareModalProps) {
       aria-labelledby="contained-modal-title-vcenter"
       centered
     >
-      <Modal.Header className="bg-success text-white" closeButton>
-        <Modal.Title id="contained-modal-title-vcenter">
+      <Modal.Header closeButton>
+        <Modal.Title
+          className="d-flex align-items-center gap-1"
+          id="contained-modal-title-vcenter"
+        >
           <FaShare className="me-2" />
           {t("page_assessment_list.tip_share")}
         </Modal.Title>

--- a/src/pages/criteria/components/CriterionDetailsModal.tsx
+++ b/src/pages/criteria/components/CriterionDetailsModal.tsx
@@ -29,8 +29,11 @@ export function CriterionDetailsModal(props: CriDetailsModalProps) {
       aria-labelledby="contained-modal-title-vcenter"
       centered
     >
-      <Modal.Header className="bg-success text-white" closeButton>
-        <Modal.Title id="contained-modal-title-vcenter">
+      <Modal.Header closeButton>
+        <Modal.Title
+          className="d-flex align-items-center gap-1"
+          id="contained-modal-title-vcenter"
+        >
           <FaAward className="me-2" />
           {t("page_criteria.view")}
         </Modal.Title>

--- a/src/pages/criteria/components/CriterionModal.tsx
+++ b/src/pages/criteria/components/CriterionModal.tsx
@@ -219,8 +219,11 @@ export function CriterionModal(props: CriterionModalProps) {
       aria-labelledby="contained-modal-title-vcenter"
       centered
     >
-      <Modal.Header className="bg-success text-white" closeButton>
-        <Modal.Title id="contained-modal-title-vcenter">
+      <Modal.Header closeButton>
+        <Modal.Title
+          className="d-flex align-items-center gap-1"
+          id="contained-modal-title-vcenter"
+        >
           {props.id ? (
             <>
               <FaEdit className="me-2" />

--- a/src/pages/metrics/components/MetricModal.tsx
+++ b/src/pages/metrics/components/MetricModal.tsx
@@ -24,8 +24,11 @@ export function MetricModal(props: MetricModalProps) {
       aria-labelledby="contained-modal-title-vcenter"
       centered
     >
-      <Modal.Header className="bg-success text-white" closeButton>
-        <Modal.Title id="contained-modal-title-vcenter">
+      <Modal.Header closeButton>
+        <Modal.Title
+          className="d-flex align-items-center gap-1"
+          id="contained-modal-title-vcenter"
+        >
           <FaBorderNone className="me-2" /> {t("page_metrics.tip_view")}
         </Modal.Title>
       </Modal.Header>

--- a/src/pages/motivations/components/MotivationActorModal.tsx
+++ b/src/pages/motivations/components/MotivationActorModal.tsx
@@ -88,8 +88,11 @@ export function MotivationActorModal(props: MotivationActorModalProps) {
       aria-labelledby="contained-modal-title-vcenter"
       centered
     >
-      <Modal.Header className="bg-success text-white" closeButton>
-        <Modal.Title id="contained-modal-title-vcenter">
+      <Modal.Header closeButton>
+        <Modal.Title
+          className="d-flex align-items-center gap-1"
+          id="contained-modal-title-vcenter"
+        >
           <FaUser className="me-2" />{" "}
           {t("page_motivations.modal_add_actor_title")}
         </Modal.Title>

--- a/src/pages/motivations/components/MotivationMetric.tsx
+++ b/src/pages/motivations/components/MotivationMetric.tsx
@@ -1,10 +1,12 @@
 import { useGetMotivationMetric } from "@/api";
 import { AuthContext } from "@/auth";
+import { TestAutoG069Form } from "@/pages/assessments/components/tests/TestAutoG069Form";
 import { TestAutoHttpsCheckForm } from "@/pages/assessments/components/tests/TestAutoHttpsCheckForm";
 import { TestAutoMd1Form } from "@/pages/assessments/components/tests/TestAutoMd1Form";
 import { TestBinaryParamForm } from "@/pages/assessments/components/tests/TestBinaryParam";
 import { TestValueFormParam } from "@/pages/assessments/components/tests/TestValueFormParam";
 import {
+  TestAutoG069,
   TestAutoHttpsCheck,
   TestAutoMD1,
   TestBinaryParam,
@@ -66,6 +68,19 @@ export default function MotivationMetric({
             <div className="cat-test-div">
               <TestValueFormParam
                 test={test as TestValueParam}
+                onTestChange={() => {}}
+                criterionId={getByCriterion ? itemId : ""}
+                principleId={""}
+              />
+            </div>
+          </div>,
+        );
+      } else if (test.type === "Auto-Check-String-Binary") {
+        testList.push(
+          <div className="border mt-4" key={test.id}>
+            <div className="cat-test-div">
+              <TestAutoG069Form
+                test={test as TestAutoG069}
                 onTestChange={() => {}}
                 criterionId={getByCriterion ? itemId : ""}
                 principleId={""}

--- a/src/pages/motivations/components/MotivationMetricAssignModal.tsx
+++ b/src/pages/motivations/components/MotivationMetricAssignModal.tsx
@@ -123,8 +123,11 @@ export function MotivationMetricAssignModal(
       aria-labelledby="contained-modal-title-vcenter"
       centered
     >
-      <Modal.Header className="bg-success text-white" closeButton>
-        <Modal.Title id="contained-modal-title-vcenter">
+      <Modal.Header closeButton>
+        <Modal.Title
+          className="d-flex align-items-center gap-1"
+          id="contained-modal-title-vcenter"
+        >
           {t("page_motivations.assign_metric")}
         </Modal.Title>
       </Modal.Header>

--- a/src/pages/motivations/components/MotivationMetricDetailsModal.tsx
+++ b/src/pages/motivations/components/MotivationMetricDetailsModal.tsx
@@ -22,8 +22,11 @@ export function MotivationMetricDetailsModal(props: MotivationMetricProps) {
       aria-labelledby="contained-modal-title-vcenter"
       centered
     >
-      <Modal.Header className="bg-success text-white" closeButton>
-        <Modal.Title id="contained-modal-title-vcenter">
+      <Modal.Header closeButton>
+        <Modal.Title
+          className="d-flex align-items-center gap-1"
+          id="contained-modal-title-vcenter"
+        >
           {props.getByCriterion
             ? t("page_motivations.criterion_metric_tests")
             : t("page_motivations.metric_details")}

--- a/src/pages/motivations/components/MotivationMetricModal.tsx
+++ b/src/pages/motivations/components/MotivationMetricModal.tsx
@@ -283,8 +283,11 @@ export function MotivationMetricModal(props: MetricModalProps) {
       aria-labelledby="contained-modal-title-vcenter"
       centered
     >
-      <Modal.Header className="bg-success text-white" closeButton>
-        <Modal.Title id="contained-modal-title-vcenter">
+      <Modal.Header closeButton>
+        <Modal.Title
+          className="d-flex align-items-center gap-1"
+          id="contained-modal-title-vcenter"
+        >
           {props.mtrId ? (
             <>
               <FaEdit className="me-2" /> {t("page_motivations.edit_metric")}:{" "}

--- a/src/pages/motivations/components/MotivationModal.tsx
+++ b/src/pages/motivations/components/MotivationModal.tsx
@@ -176,8 +176,11 @@ export function MotivationModal(props: MotivationModalProps) {
       aria-labelledby="contained-modal-title-vcenter"
       centered
     >
-      <Modal.Header className="bg-success text-white" closeButton>
-        <Modal.Title id="contained-modal-title-vcenter">
+      <Modal.Header closeButton>
+        <Modal.Title
+          className="d-flex align-items-center gap-1"
+          id="contained-modal-title-vcenter"
+        >
           <FaFile className="me-2" />{" "}
           {props.motivation === null ? t("create_new") : t("edit")}{" "}
           {t("motivation")}

--- a/src/pages/motivations/components/MotivationPrinciplesModal.tsx
+++ b/src/pages/motivations/components/MotivationPrinciplesModal.tsx
@@ -71,8 +71,11 @@ export default function MotivationPrinciplesModal(
       aria-labelledby="contained-modal-title-vcenter"
       centered
     >
-      <Modal.Header className="bg-success text-white" closeButton>
-        <Modal.Title id="contained-modal-title-vcenter">
+      <Modal.Header closeButton>
+        <Modal.Title
+          className="d-flex align-items-center gap-1"
+          id="contained-modal-title-vcenter"
+        >
           <FaTags className="me-2" />{" "}
           {t("page_motivations.modal_principles_title")}
         </Modal.Title>

--- a/src/pages/principles/components/PrincipleDetailsModal.tsx
+++ b/src/pages/principles/components/PrincipleDetailsModal.tsx
@@ -31,8 +31,11 @@ export function PrincipleDetailsModal(props: PrincipleModalDetailsProps) {
       aria-labelledby="contained-modal-title-vcenter"
       centered
     >
-      <Modal.Header className="bg-success text-white" closeButton>
-        <Modal.Title id="contained-modal-title-vcenter">
+      <Modal.Header closeButton>
+        <Modal.Title
+          className="d-flex align-items-center gap-1"
+          id="contained-modal-title-vcenter"
+        >
           <FaTags className="me-2" />
           {t("page_principles.view")}
         </Modal.Title>

--- a/src/pages/principles/components/PrincipleModal.tsx
+++ b/src/pages/principles/components/PrincipleModal.tsx
@@ -169,21 +169,22 @@ export function PrincipleModal(props: PrincipleModalProps) {
       aria-labelledby="contained-modal-title-vcenter"
       centered
     >
-      <Modal.Header className="bg-success text-white" closeButton>
-        <Modal.Title id="contained-modal-title-vcenter">
-          <Modal.Title id="contained-modal-title-vcenter">
-            {props.id ? (
-              <>
-                <FaEdit className="me-2" />
-                {t("page_principles.edit")}
-              </>
-            ) : (
-              <>
-                <FaFile className="me-2" />
-                {t("page_principles.create_new")}
-              </>
-            )}
-          </Modal.Title>
+      <Modal.Header closeButton>
+        <Modal.Title
+          className="d-flex align-items-center gap-1"
+          id="contained-modal-title-vcenter"
+        >
+          {props.id ? (
+            <>
+              <FaEdit className="me-2" />
+              {t("page_principles.edit")}
+            </>
+          ) : (
+            <>
+              <FaFile className="me-2" />
+              {t("page_principles.create_new")}
+            </>
+          )}
         </Modal.Title>
       </Modal.Header>
       <Modal.Body>

--- a/src/pages/tests/Tests.tsx
+++ b/src/pages/tests/Tests.tsx
@@ -12,6 +12,7 @@ import TestsHeader from "./components/TestsHeader";
 import TestSearch from "./components/TestSearch";
 import TestTable from "./components/TestTable";
 import TestPagination from "./components/TestPagination";
+import CreateTestModal from "./components/CreateTestModal";
 
 type TestsState = {
   sortOrder: string;
@@ -223,9 +224,27 @@ function Tests() {
         }}
         handleDelete={handleDeleteConfirmed}
       />
+      <CreateTestModal
+        id={testModalCfg.id}
+        show={
+          testModalCfg.show &&
+          !(testModalCfg.isEditing || testModalCfg.isVersioning)
+        }
+        onHide={() => {
+          setTestModalCfg({
+            id: "",
+            show: false,
+            isVersioning: false,
+            isEditing: false,
+          });
+        }}
+      />
       <TestModal
         id={testModalCfg.id}
-        show={testModalCfg.show}
+        show={
+          testModalCfg.show &&
+          (testModalCfg?.isEditing || testModalCfg?.isVersioning || false)
+        }
         isEditing={testModalCfg?.isEditing}
         isVersioning={testModalCfg?.isVersioning}
         onHide={() => {

--- a/src/pages/tests/components/CreateTestModal.tsx
+++ b/src/pages/tests/components/CreateTestModal.tsx
@@ -1,0 +1,545 @@
+import {
+  useCreateTest,
+  useGetAllTestMethods,
+  useGetTest,
+} from "@/api/services/registry";
+import { AuthContext } from "@/auth";
+import { AlertInfo, RegistryResource } from "@/types";
+import { TestDefinitionInput, TestHeaderInput, TestParam } from "@/types/tests";
+import { useContext, useEffect, useRef, useState } from "react";
+import {
+  Modal,
+  Button,
+  Form,
+  InputGroup,
+  Row,
+  Col,
+  OverlayTrigger,
+  Tooltip,
+} from "react-bootstrap";
+import toast from "react-hot-toast";
+import { useTranslation } from "react-i18next";
+import { FaFile, FaInfoCircle, FaTrash } from "react-icons/fa";
+import TestPreviewModal from "./TestPreviewModal";
+
+interface TestModalProps {
+  id: string;
+  show: boolean;
+  onHide: () => void;
+}
+
+function CreateTestModal(props: TestModalProps) {
+  const alert = useRef<AlertInfo>({
+    message: "",
+  });
+  const { t } = useTranslation();
+  const { keycloak, registered } = useContext(AuthContext)!;
+
+  const [testMethods, setTestMethods] = useState<RegistryResource[]>([]);
+  const [showErrors, setShowErrors] = useState(false);
+  const [testHeader, setTestHeader] = useState<TestHeaderInput>({
+    label: "",
+    tes: "",
+    description: "",
+  });
+
+  const [testDefinition, setTestDefinition] = useState<TestDefinitionInput>({
+    test_method_id: "",
+    label: "",
+    param_type: "onscreen",
+    test_params: "",
+    test_question: "",
+    tool_tip: "",
+  });
+  const [params, setParams] = useState<TestParam[]>([]);
+
+  const addNewParam = (evidence: boolean) => {
+    const id = params.length > 0 ? params[params.length - 1].id + 1 : 1;
+    setParams([
+      ...params,
+      { id: id, name: evidence ? "evidence" : "", text: "", tooltip: "" },
+    ]);
+  };
+
+  const { data } = useGetTest({
+    id: props.id,
+    token: keycloak?.token || "",
+    isRegistered: registered,
+  });
+
+  useEffect(() => {
+    if (props.id && data) {
+      // split params
+      const paramNames = data.test_definition.test_params.split("|");
+      const paramTexts = data.test_definition.test_question.split("|");
+      const paramTips = data.test_definition.tool_tip.split("|");
+      const params: TestParam[] = [];
+      if (
+        paramNames.length == paramTexts.length &&
+        paramNames.length == paramTips.length
+      ) {
+        for (let i = 0; i < paramNames.length; i++) {
+          params.push({
+            id: i,
+            name: paramNames[i],
+            text: paramTexts[i],
+            tooltip: paramTips[i],
+          });
+        }
+      }
+      setTestHeader(data.test);
+      setTestDefinition(data.test_definition);
+      setParams(params);
+    }
+  }, [data, props.id]);
+
+  const updateParamTestDef = () => {
+    // find first the evidence
+    let names = "";
+    let text = "";
+    let tips = "";
+    const evidence = params.find((item) => item.name === "evidence");
+    const subParams = params.filter((item) => item.name !== "evidence");
+
+    // iterate over params (minus evidence) and update test def
+    subParams.map((item) => {
+      names === "" ? (names = item.name) : (names = names + "|" + item.name);
+      text === "" ? (text = item.text) : (text = text + "|" + item.text);
+      tips === "" ? (tips = item.tooltip) : (tips = tips + "|" + item.tooltip);
+    });
+
+    if (evidence !== undefined) {
+      names === ""
+        ? (names = evidence.name)
+        : (names = names + "|" + evidence.name);
+      text === ""
+        ? (text = evidence.text)
+        : (text = text + "|" + evidence.text);
+      tips === ""
+        ? (tips = evidence.tooltip)
+        : (tips = tips + "|" + evidence.tooltip);
+    }
+
+    setTestDefinition({
+      ...testDefinition,
+      test_question: text,
+      test_params: names,
+      tool_tip: tips,
+    });
+  };
+
+  const updateParam = (id: number, field: keyof TestParam, value: string) => {
+    setParams((prevParams) =>
+      prevParams.map((param) =>
+        param.id === id ? { ...param, [field]: value } : param,
+      ),
+    );
+  };
+
+  const removeParam = (id: number) => {
+    setParams(params.filter((item) => item.id !== id));
+  };
+
+  const {
+    data: tmData,
+    fetchNextPage: tmFetchNextPage,
+    hasNextPage: tmHasNextPage,
+  } = useGetAllTestMethods({
+    size: 5,
+    token: keycloak?.token || "",
+    isRegistered: registered,
+  });
+
+  useEffect(() => {
+    setShowErrors(false);
+    if (props.id === "") {
+      setTestHeader({
+        label: "",
+        tes: "",
+        description: "",
+      });
+      setTestDefinition({
+        test_method_id: "",
+        label: "",
+        param_type: "onscreen",
+        test_params: "",
+        test_question: "",
+        tool_tip: "",
+      });
+      setParams([]);
+    }
+  }, [props.show, props.id]);
+
+  useEffect(() => {
+    // gather all test methods
+    let tmpTm: RegistryResource[] = [];
+
+    // iterate over backend pages and gather all items in the metric types array
+    if (tmData?.pages) {
+      tmData.pages.map((page) => {
+        tmpTm = [...tmpTm, ...page.content];
+      });
+      if (tmHasNextPage) {
+        tmFetchNextPage();
+      }
+    }
+
+    setTestMethods(tmpTm);
+  }, [tmData, tmHasNextPage, tmFetchNextPage]);
+
+  function handleValidate() {
+    setShowErrors(true);
+    return testHeader.tes !== "" && testHeader.label !== "";
+  }
+
+  const mutateCreate = useCreateTest(
+    keycloak?.token || "",
+    testHeader,
+    testDefinition,
+  );
+
+  function handleCreate() {
+    updateParamTestDef();
+    const promise = mutateCreate
+      .mutateAsync()
+      .catch((err) => {
+        alert.current = {
+          message: "Error: " + err.response.data.message,
+        };
+        throw err;
+      })
+      .then(() => {
+        props.onHide();
+        alert.current = {
+          message: t("page_tests.toast_create_success"),
+        };
+      });
+    toast.promise(promise, {
+      loading: t("page_tests.toast_create_progress"),
+      success: () => `${alert.current.message}`,
+      error: () => `${alert.current.message}`,
+    });
+  }
+
+  return (
+    <>
+      <Modal
+        show={props.show}
+        onHide={props.onHide}
+        size="xl"
+        aria-labelledby="contained-modal-title-vcenter"
+        centered
+        scrollable
+      >
+        <Modal.Header closeButton>
+          <Modal.Title
+            className="d-flex align-items-center gap-1"
+            id="contained-modal-title-vcenter"
+          >
+            <FaFile className="me-2" />
+            {t("page_tests.create_new")}
+          </Modal.Title>
+        </Modal.Header>
+        <Modal.Body
+          style={{
+            display: "flex",
+            gap: "1rem",
+            justifyContent: "space-around",
+          }}
+        >
+          <div style={{ width: "50%" }}>
+            <Row>
+              <InputGroup className="mt-2">
+                <OverlayTrigger
+                  key="top"
+                  placement="top"
+                  overlay={
+                    <Tooltip id={`tooltip-top`}>
+                      {t("page_tests.tip_tes")}
+                    </Tooltip>
+                  }
+                >
+                  <InputGroup.Text id="label-test-tes">
+                    <FaInfoCircle className="me-2" />{" "}
+                    {t("fields.tes").toUpperCase()} (*):
+                  </InputGroup.Text>
+                </OverlayTrigger>
+                <Form.Control
+                  id="input-test-tes"
+                  value={testHeader.tes}
+                  onChange={(e) => {
+                    setTestHeader({
+                      ...testHeader,
+                      tes: e.target.value,
+                    });
+                  }}
+                  aria-describedby="label-metric-mtr"
+                />
+              </InputGroup>
+              {showErrors && testHeader.tes === "" && (
+                <span className="text-danger">{t("required")}</span>
+              )}
+              <Col>
+                <InputGroup className="mt-2">
+                  <OverlayTrigger
+                    key="top"
+                    placement="top"
+                    overlay={
+                      <Tooltip id={`tooltip-top`}>
+                        {t("page_tests.tip_label")}
+                      </Tooltip>
+                    }
+                  >
+                    <InputGroup.Text id="label-test-label">
+                      <FaInfoCircle className="me-2" /> {t("fields.label")} (*):
+                    </InputGroup.Text>
+                  </OverlayTrigger>
+                  <Form.Control
+                    id="input-test-label"
+                    aria-describedby="label-test-label"
+                    value={testHeader.label}
+                    onChange={(e) => {
+                      setTestHeader({
+                        ...testHeader,
+                        label: e.target.value,
+                      });
+                    }}
+                  />
+                </InputGroup>
+                {showErrors && testHeader.label === "" && (
+                  <span className="text-danger">{t("required")}</span>
+                )}
+              </Col>
+            </Row>
+            <Row className="mt-2">
+              <Col className="mt-1">
+                <OverlayTrigger
+                  key="top"
+                  placement="top"
+                  overlay={
+                    <Tooltip id={`tooltip-top`}>
+                      {t("page_tests.tip_test_description")}
+                    </Tooltip>
+                  }
+                >
+                  <span id="label-test-description">
+                    <FaInfoCircle className="ms-1 me-2" />{" "}
+                    {t("fields.description")} (*):
+                  </span>
+                </OverlayTrigger>
+                <Form.Control
+                  className="mt-1"
+                  as="textarea"
+                  rows={2}
+                  value={testHeader.description}
+                  onChange={(e) => {
+                    setTestHeader({
+                      ...testHeader,
+                      description: e.target.value,
+                    });
+                  }}
+                />
+                {showErrors && testHeader.description === "" && (
+                  <span className="text-danger">{t("required")}</span>
+                )}
+              </Col>
+            </Row>
+            <Row>
+              <Col>
+                <InputGroup className="mt-2">
+                  <OverlayTrigger
+                    key="top"
+                    placement="top"
+                    overlay={
+                      <Tooltip id={`tooltip-top`}>
+                        {t("page_tests.tip_test_method")}
+                      </Tooltip>
+                    }
+                  >
+                    <InputGroup.Text id="label-test-method">
+                      <FaInfoCircle className="me-2" />{" "}
+                      {t("page_tests.test_method")} (*):
+                    </InputGroup.Text>
+                  </OverlayTrigger>
+                  <Form.Select
+                    id="input-test-method"
+                    aria-describedby="label-test-method"
+                    placeholder={t("page_tests.select_test_method")}
+                    value={
+                      testDefinition.test_method_id
+                        ? testDefinition.test_method_id
+                        : ""
+                    }
+                    onChange={(e) => {
+                      setTestDefinition({
+                        ...testDefinition,
+                        test_method_id: e.target.value,
+                      });
+                    }}
+                  >
+                    <>
+                      <option value="" disabled>
+                        {t("page_tests.select_test_method")}
+                      </option>
+                      {testMethods.map((item) => (
+                        <option key={item.id} value={item.id}>
+                          {item.label}
+                        </option>
+                      ))}
+                    </>
+                  </Form.Select>
+                </InputGroup>
+                {showErrors && testDefinition.test_method_id === "" && (
+                  <span className="text-danger">{t("required")}</span>
+                )}
+                {testDefinition.test_method_id != "" && (
+                  <div className="bg-light text-secondary border rounded mt-2 p-3">
+                    <small>
+                      <em>
+                        {
+                          testMethods.find(
+                            (item) => item.id == testDefinition.test_method_id,
+                          )?.description
+                        }
+                      </em>
+                    </small>
+                  </div>
+                )}
+              </Col>
+            </Row>
+            <Row className="mt-2">
+              <div className="border-top p-2">
+                <strong>{t("page_tests.parameters")}:</strong>
+                <Button
+                  size="sm"
+                  variant="success"
+                  className="ms-2"
+                  onClick={() => {
+                    addNewParam(false);
+                    // updateParamTestDef();
+                  }}
+                >
+                  {t("page_tests.parameters_add")}
+                </Button>
+                <Button
+                  size="sm"
+                  variant="success"
+                  className="ms-2"
+                  onClick={() => {
+                    addNewParam(true);
+                  }}
+                  disabled={
+                    params.find((item) => item.name === "evidence") !==
+                    undefined
+                  }
+                >
+                  {t("page_tests.parameters_add_evidence")}
+                </Button>
+                <table>
+                  <thead>
+                    {params.length > 0 && (
+                      <tr>
+                        <th>{t("fields.name")}</th>
+                        <th>{t("fields.text")}</th>
+                        <th>{t("fields.tooltip")}</th>
+                        <th></th>
+                      </tr>
+                    )}
+                  </thead>
+                  <tbody>
+                    {params.map((param) => {
+                      return (
+                        <tr key={`${param.id}`}>
+                          <td>
+                            <Form.Control
+                              id={`param-${param.id}-name`}
+                              value={param.name}
+                              onChange={(e) => {
+                                updateParam(param.id, "name", e.target.value);
+                              }}
+                              disabled={param.name === "evidence"}
+                            />
+                          </td>
+                          <td>
+                            <Form.Control
+                              id={`param-${param.id}-text`}
+                              value={param.text}
+                              onChange={(e) => {
+                                updateParam(param.id, "text", e.target.value);
+                              }}
+                            />
+                          </td>
+                          <td>
+                            <Form.Control
+                              id={`param-${param.id}-tooltip`}
+                              value={param.tooltip}
+                              onChange={(e) => {
+                                updateParam(
+                                  param.id,
+                                  "tooltip",
+                                  e.target.value,
+                                );
+                              }}
+                            />
+                          </td>
+                          <td>
+                            <Button
+                              size="sm"
+                              variant="danger"
+                              onClick={() => {
+                                removeParam(param.id);
+                              }}
+                            >
+                              <FaTrash />
+                            </Button>
+                          </td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              </div>
+            </Row>
+          </div>
+
+          <div
+            style={{
+              width: "1px",
+              height: "auto",
+              backgroundColor: "#ccc",
+              margin: "0 1rem",
+            }}
+          ></div>
+          <div style={{ width: "50%" }}>
+            <TestPreviewModal
+              testHeader={testHeader}
+              testDefinition={testDefinition}
+              params={params}
+              testMethodName={
+                testMethods.find((m) => m.id === testDefinition.test_method_id)
+                  ?.label
+              }
+            />
+          </div>
+        </Modal.Body>
+        <Modal.Footer className="d-flex justify-content-between">
+          <Button className="btn-secondary" onClick={props.onHide}>
+            {t("buttons.cancel")}
+          </Button>
+          <Button
+            className="btn-success"
+            onClick={() => {
+              if (handleValidate() === true) {
+                handleCreate();
+              }
+            }}
+          >
+            {t("buttons.create")}
+          </Button>
+        </Modal.Footer>
+      </Modal>
+    </>
+  );
+}
+
+export default CreateTestModal;

--- a/src/pages/tests/components/TestDetailsModal.tsx
+++ b/src/pages/tests/components/TestDetailsModal.tsx
@@ -41,8 +41,11 @@ export function TestDetailsModal(props: TestModalDetailsProps) {
       aria-labelledby="contained-modal-title-vcenter"
       centered
     >
-      <Modal.Header className="bg-success text-white" closeButton>
-        <Modal.Title id="contained-modal-title-vcenter">
+      <Modal.Header closeButton>
+        <Modal.Title
+          className="d-flex align-items-center gap-1"
+          id="contained-modal-title-vcenter"
+        >
           <FaClipboardQuestion className="me-2" />
           {t("page_tests.view")}
         </Modal.Title>

--- a/src/pages/tests/components/TestModal.tsx
+++ b/src/pages/tests/components/TestModal.tsx
@@ -1,5 +1,4 @@
 import {
-  useCreateTest,
   useGetAllTestMethods,
   useGetTest,
   useUpdateTest,
@@ -21,13 +20,7 @@ import {
 } from "react-bootstrap";
 import toast from "react-hot-toast";
 import { useTranslation } from "react-i18next";
-import {
-  FaEdit,
-  FaFile,
-  FaInfoCircle,
-  FaTrash,
-  FaCodeBranch,
-} from "react-icons/fa";
+import { FaEdit, FaInfoCircle, FaTrash, FaCodeBranch } from "react-icons/fa";
 
 interface TestModalProps {
   id: string;
@@ -36,9 +29,7 @@ interface TestModalProps {
   isVersioning?: boolean;
   onHide: () => void;
 }
-/**
- * Modal component for creating a test
- */
+
 export function TestModal(props: TestModalProps) {
   const alert = useRef<AlertInfo>({
     message: "",
@@ -203,12 +194,6 @@ export function TestModal(props: TestModalProps) {
     return testHeader.tes !== "" && testHeader.label !== "";
   }
 
-  const mutateCreate = useCreateTest(
-    keycloak?.token || "",
-    testHeader,
-    testDefinition,
-  );
-
   const mutateUpdate = useUpdateTest(
     keycloak?.token || "",
     props.id,
@@ -247,30 +232,6 @@ export function TestModal(props: TestModalProps) {
     });
   }
 
-  // handle backend call to add a new test
-  function handleCreate() {
-    updateParamTestDef();
-    const promise = mutateCreate
-      .mutateAsync()
-      .catch((err) => {
-        alert.current = {
-          message: "Error: " + err.response.data.message,
-        };
-        throw err;
-      })
-      .then(() => {
-        props.onHide();
-        alert.current = {
-          message: t("page_tests.toast_create_success"),
-        };
-      });
-    toast.promise(promise, {
-      loading: t("page_tests.toast_create_progress"),
-      success: () => `${alert.current.message}`,
-      error: () => `${alert.current.message}`,
-    });
-  }
-
   function handleCreateNewVersion() {
     updateParamTestDef();
     const promise = mutateCreateVersion
@@ -302,22 +263,20 @@ export function TestModal(props: TestModalProps) {
       aria-labelledby="contained-modal-title-vcenter"
       centered
     >
-      <Modal.Header className="bg-success text-white" closeButton>
-        <Modal.Title id="contained-modal-title-vcenter">
+      <Modal.Header closeButton>
+        <Modal.Title
+          className="d-flex align-items-center gap-1"
+          id="contained-modal-title-vcenter"
+        >
           {props.id && !props.isVersioning ? (
             <>
               <FaEdit className="me-2" />
               {t("page_tests.update")}
             </>
-          ) : props.id && props.isVersioning ? (
+          ) : (
             <>
               <FaCodeBranch className="me-2" />
               {t("page_tests.create_new_version")}
-            </>
-          ) : (
-            <>
-              <FaFile className="me-2" />
-              {t("page_tests.create_new")}
             </>
           )}
         </Modal.Title>
@@ -590,7 +549,7 @@ export function TestModal(props: TestModalProps) {
           >
             {t("buttons.create_version")}
           </Button>
-        ) : props.id ? (
+        ) : (
           <Button
             className="btn-success"
             onClick={() => {
@@ -600,17 +559,6 @@ export function TestModal(props: TestModalProps) {
             }}
           >
             {t("buttons.update")}
-          </Button>
-        ) : (
-          <Button
-            className="btn-success"
-            onClick={() => {
-              if (handleValidate() === true) {
-                handleCreate();
-              }
-            }}
-          >
-            {t("buttons.create")}
           </Button>
         )}
       </Modal.Footer>

--- a/src/pages/tests/components/TestPreviewModal.tsx
+++ b/src/pages/tests/components/TestPreviewModal.tsx
@@ -1,0 +1,401 @@
+import React from "react";
+import { Button, Form, InputGroup } from "react-bootstrap";
+import { useTranslation } from "react-i18next";
+import { TestDefinitionInput, TestHeaderInput, TestParam } from "@/types/tests";
+import { TestToolTip } from "@/pages/assessments/components";
+
+interface TestPreviewProps {
+  testHeader: TestHeaderInput;
+  testDefinition?: TestDefinitionInput;
+  params: TestParam[];
+  testMethodName?: string;
+}
+
+const TestPreviewModal: React.FC<TestPreviewProps> = ({
+  testHeader,
+  testDefinition,
+  params,
+  testMethodName,
+}) => {
+  const { t } = useTranslation();
+
+  // Helper function to render evidence fields consistently
+  const renderEvidenceField = (param: TestParam, index: number) => {
+    return (
+      <div key={index} className="border p-2 rounded mb-2 bg-light">
+        <div className="d-flex align-items-center">
+          <strong className="me-2">
+            {param.text || t("Evidence")}{" "}
+            {param?.tooltip && (
+              <span className="mb-1">
+                <TestToolTip
+                  tipId={"text-" + param.id}
+                  tipText={param.tooltip}
+                />
+              </span>
+            )}
+          </strong>
+        </div>
+        <InputGroup className="mt-3" size="sm" aria-disabled="true">
+          <InputGroup.Text id="label-add-url" aria-disabled="true">
+            {t("url")}:
+          </InputGroup.Text>
+          <Form.Control
+            id="input-add-url"
+            aria-describedby="label-add-url"
+            placeholder={t("page_assessment_edit.evidence_url")}
+            disabled
+          />
+        </InputGroup>
+
+        <InputGroup className="mt-2" size="sm" aria-disabled="true">
+          <InputGroup.Text id="label-add-description" aria-disabled="true">
+            {t("fields.description")}:
+          </InputGroup.Text>
+          <Form.Control
+            id="input-add-description"
+            aria-describedby="label-add-description"
+            placeholder={t("page_assessment_edit.evidence_description")}
+            disabled
+          />
+        </InputGroup>
+      </div>
+    );
+  };
+
+  // Determine the test type based on the test_method_id
+  const getTestType = (): string => {
+    if (!testDefinition?.test_method_id) return "binary"; // Default type
+
+    // Map test_method_id to test type based on the method name
+    const methodName = testMethodName?.toLowerCase() || "";
+    if (methodName.includes("auto-check-url")) return "Auto-Check-Url-Binary";
+    if (methodName.includes("auto-check-string"))
+      return "Auto-Check-String-Binary";
+    if (methodName.includes("auto-check-xml-md1")) {
+      if (methodName.includes("md1a")) return "Auto-Check-Xml-MD1a";
+      if (methodName.includes("md1b1")) return "Auto-Check-Xml-MD1b1";
+      return "Auto-Check-Xml-MD1b2";
+    }
+    if (methodName.includes("value")) return "value";
+    if (methodName.includes("string")) {
+      return "Number-Manual";
+    }
+    if (methodName.includes("number")) return "Number-Manual";
+    if (methodName.includes("ratio")) return "Ratio-Manual";
+    if (methodName.includes("percent")) return "Percent-Manual";
+    if (methodName.includes("trl")) return "TRL-Manual";
+    if (methodName.includes("years")) return "Years-Manual";
+
+    const hasEvidence = params.some((p) => p.name === "evidence");
+    if (hasEvidence) return "Binary-Manual-Evidence";
+
+    return "binary";
+  };
+
+  const renderParams = () => {
+    const testType = getTestType();
+
+    if (
+      [
+        "value",
+        "Number-Manual",
+        "Number-Auto",
+        "Ratio-Manual",
+        "Percent-Manual",
+        "TRL-Manual",
+        "Years-Manual",
+      ].includes(testType)
+    ) {
+      return (
+        <div className="mb-2">
+          {params.map((param, index) => {
+            if (param.name === "evidence") {
+              return renderEvidenceField(param, index);
+            } else {
+              return (
+                <div key={index} className="border p-2 rounded mb-2 bg-light">
+                  <div>
+                    <strong className="me-2">
+                      {param.text || t("{Question}")}{" "}
+                      {param?.tooltip && (
+                        <span style={{ height: "35px", alignSelf: "start" }}>
+                          <TestToolTip
+                            tipId={"text-" + param.id}
+                            tipText={param.tooltip}
+                          />
+                        </span>
+                      )}
+                    </strong>
+                  </div>
+                  <div className="mt-2">
+                    {testType === "TRL-Manual" ? (
+                      <Form.Select
+                        disabled
+                        aria-label="TRL Selection"
+                        className="form-control-sm"
+                      >
+                        <option>{t("Select TRL level")}</option>
+                      </Form.Select>
+                    ) : testType === "Ratio-Manual" ? (
+                      <div className="d-flex align-items-center">
+                        <Form.Control
+                          type="text"
+                          disabled
+                          placeholder="0"
+                          size="sm"
+                          className="me-2"
+                        />
+                      </div>
+                    ) : testType === "Percent-Manual" ? (
+                      <div className="d-flex align-items-center">
+                        <Form.Control
+                          type="text"
+                          disabled
+                          placeholder="0"
+                          size="sm"
+                          className="me-2"
+                        />
+                        <span>%</span>
+                      </div>
+                    ) : testType === "Years-Manual" ? (
+                      <div className="d-flex align-items-center">
+                        <Form.Control
+                          type="text"
+                          disabled
+                          placeholder="0"
+                          size="sm"
+                          className="me-2"
+                        />
+                        <span>{t("years")}</span>
+                      </div>
+                    ) : (
+                      <Form.Control
+                        type="text"
+                        disabled
+                        placeholder="0"
+                        size="sm"
+                      />
+                    )}
+                  </div>
+                </div>
+              );
+            }
+          })}
+        </div>
+      );
+    } else if (
+      [
+        "Auto-Check-Url-Binary",
+        "Auto-Check-String-Binary",
+        "Auto-Check-Xml-MD1a",
+        "Auto-Check-Xml-MD1b1",
+        "Auto-Check-Xml-MD1b2",
+      ].includes(testType)
+    ) {
+      return (
+        <div className="mb-2">
+          {params.map((param, index) => {
+            if (param.name === "evidence") {
+              return renderEvidenceField(param, index);
+            } else {
+              return (
+                <div key={index} className="border p-2 rounded mb-2 bg-light">
+                  <div>
+                    <strong className="me-2">
+                      {param.text || t("{Question}")}{" "}
+                      {param?.tooltip &&
+                        !(
+                          testType === "Auto-Check-Url-Binary" ||
+                          testType === "Auto-Check-String-Binary"
+                        ) && (
+                          <TestToolTip
+                            tipId={"text-" + param.id}
+                            tipText={param.tooltip}
+                          />
+                        )}
+                    </strong>
+                  </div>
+                  {testType === "Auto-Check-Url-Binary" ? (
+                    <>
+                      <InputGroup className="mt-1">
+                        <InputGroup.Text id={`label-${param.id}`}>
+                          <TestToolTip
+                            tipId={`params-${index}-${param.id}`}
+                            tipText={param?.tooltip || ""}
+                          />
+                          <span className="ms-2">{param.name}</span>:
+                        </InputGroup.Text>
+                        <Form.Control
+                          placeholder={t("https://example.com")}
+                          aria-label={t("Enter URL")}
+                          disabled
+                        />
+                        <Button
+                          variant="success"
+                          disabled
+                          className="d-flex align-items-center"
+                        >
+                          <span className="me-1">▶</span>
+                          {t("page_assessment_edit.run_check")}
+                        </Button>
+                      </InputGroup>
+                      <div className="mt-2">
+                        <small className="text-muted">
+                          {t("page_assessment_edit.status_message_placeholder")}
+                        </small>
+                      </div>
+                    </>
+                  ) : testType === "Auto-Check-String-Binary" ? (
+                    <>
+                      <InputGroup className="mt-1">
+                        <InputGroup.Text id={`label-${param.id}`}>
+                          <TestToolTip
+                            tipId={`params-${index}-${param.id}`}
+                            tipText={param?.tooltip || ""}
+                          />
+                          <span className="ms-2">{param.name}</span>:
+                        </InputGroup.Text>
+                        <Form.Select>
+                          <option value="">Select a value</option>
+                          <option value="provider1">Provider 1</option>
+                          <option value="provider2">Provider 2</option>
+                          <option value="provider3">Provider 3</option>
+                        </Form.Select>
+                        <Button
+                          variant="success"
+                          disabled
+                          className="d-flex align-items-center"
+                        >
+                          <span className="me-1">▶</span>
+                          {t("page_assessment_edit.run_check")}
+                        </Button>
+                      </InputGroup>
+                      <div className="mt-2">
+                        <div className="text-muted mb-2">
+                          {t("page_assessment_edit.status_message_placeholder")}
+                        </div>
+                        <div className="mt-2">
+                          <div>
+                            {t("Validation")}
+                            {": "}
+                            <span className="badge bg-secondary">
+                              {t("Pending")}
+                            </span>
+                          </div>
+                          <div className="mt-2">
+                            <ul className="mb-0">
+                              <li>
+                                <small>
+                                  {t("Check item 1")}
+                                  {": "}
+                                  <span className="badge bg-secondary">
+                                    {t("Pending")}
+                                  </span>
+                                </small>
+                              </li>
+                              <li>
+                                <small>
+                                  {t("Check item 2")}
+                                  {": "}
+                                  <span className="badge bg-secondary">
+                                    {t("Pending")}
+                                  </span>
+                                </small>
+                              </li>
+                            </ul>
+                          </div>
+                        </div>
+                      </div>
+                    </>
+                  ) : (
+                    <InputGroup className="mt-2" size="sm">
+                      <Form.Control
+                        placeholder={
+                          testType.includes("URL")
+                            ? t("Enter URL")
+                            : t("Enter value")
+                        }
+                        disabled
+                      />
+                      <InputGroup.Text>
+                        <span className="text-muted">{t("Run")}</span>
+                      </InputGroup.Text>
+                    </InputGroup>
+                  )}
+                </div>
+              );
+            }
+          })}
+        </div>
+      );
+    } else {
+      return params.map((param, index) => (
+        <div key={index} className="mb-2">
+          {param.name === "evidence" ? (
+            renderEvidenceField(param, index)
+          ) : (
+            <div className="border p-2 rounded mb-2 bg-light">
+              <div className="d-flex align-items-center">
+                <strong>
+                  {param.text || t("{Question}")}{" "}
+                  {param?.tooltip && (
+                    <span className="">
+                      <TestToolTip
+                        tipId={"text-" + param.id}
+                        tipText={param.tooltip}
+                      />
+                    </span>
+                  )}
+                </strong>
+              </div>
+              <div className="d-flex gap-3 mt-2">
+                <Form.Check disabled label={t("Yes")} type="radio" />
+                <Form.Check disabled label={t("No")} type="radio" />
+              </div>
+            </div>
+          )}
+        </div>
+      ));
+    }
+  };
+
+  return (
+    <div className="mt-1" style={{ borderRadius: 0, border: "none" }}>
+      <div className="text-black">
+        <h4 className="mb-2">Test Preview</h4>
+      </div>
+      <div>
+        <div className="p-2">
+          <div className="d-flex align-items-start mb-3">
+            <div>
+              <h5>
+                {testHeader.tes || t("{TES Name placeholder}")} -{" "}
+                {testHeader.label || t("{Test Label placeholder}")}
+              </h5>
+              <p className="text-muted mb-2">
+                {testHeader.description || t("{Test Description placeholder}")}
+              </p>
+              {testMethodName && (
+                <span className="badge bg-secondary me-1">
+                  {testMethodName}
+                </span>
+              )}
+            </div>
+          </div>
+          <div className="mb-2">
+            <div>
+              {params.length > 0 ? (
+                renderParams()
+              ) : (
+                <p className="text-muted">{t("No parameters defined yet")}</p>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default TestPreviewModal;


### PR DESCRIPTION
This PR implements a real-time test preview feature in the test creation UI, allowing test creators to visualize how their tests will appear to end users while building them.

- Created a TestPreviewModal component that shows a live preview with the test creation form
- Styled the preview to match the real assessment view
- Added tooltips in the preview that match what users will see in actual tests
- Updated modals header style