### PR TITLE
CAT-872 Handle multiple g069 test methods

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -17,7 +17,9 @@
     "criterion_imperative": "MUST",
     "motivation_metric_type": "Binary",
     "motivation_metric_algorithm": "Simple Sum",
-    "motivation_metric_benchmark_type": "Binary-Binary "
+    "motivation_metric_benchmark_type": "Binary-Binary ",
+    "g069_param_user_info": "entitlements_in_user_info",
+    "g069_param_token_introspection": "entitlements_in_token_introspection"
   },
   "links": {
     "github": "https://github.com/fc4e-cat",

--- a/src/config.tsx
+++ b/src/config.tsx
@@ -18,6 +18,9 @@ const defaultMotivationMetricBenchmarkType =
   config.default_values?.motivation_metric_benchmark_type || "";
 const defaultMotivationMetricAlgorithm =
   config.default_values?.motivation_metric_algorithm || "";
+const defaultG069userInfo = config.default_values?.g069_param_user_info || "";
+const defaultG069tokenIntrospection =
+  config.default_values?.g069_param_token_introspection || "";
 
 const linksGithub = config.links?.github || "";
 
@@ -36,6 +39,8 @@ export {
   defaultMotivationMetricAlgorithm,
   defaultMotivationMetricType,
   defaultMotivationMetricBenchmarkType,
+  defaultG069userInfo,
+  defaultG069tokenIntrospection,
   linksGithub,
   linksDocs,
   g069Providers,

--- a/src/pages/assessments/components/CriteriaTabs.tsx
+++ b/src/pages/assessments/components/CriteriaTabs.tsx
@@ -46,6 +46,7 @@ import { TestAutoHttpsCheckForm } from "./tests/TestAutoHttpsCheckForm";
 import { useTranslation } from "react-i18next";
 import { TestAutoMd1Form } from "./tests/TestAutoMd1Form";
 import { TestAutoG069Form } from "./tests/TestAutoG069Form";
+import { defaultG069tokenIntrospection, defaultG069userInfo } from "@/config";
 
 type CriteriaTabsProps = {
   principles: AssessmentPrinciple[];
@@ -274,6 +275,35 @@ export function CriteriaTabs(props: CriteriaTabsProps) {
               <div className="border mt-4" key={test.id}>
                 <div className="cat-test-div">
                   <TestAutoG069Form
+                    g069param=""
+                    test={test as TestAutoG069}
+                    onTestChange={props.onTestChange}
+                    criterionId={criterion.id}
+                    principleId={principle.id}
+                  />
+                </div>
+              </div>,
+            );
+          } else if (test.type === "Auto-Check-AARC-G069-User-Info") {
+            testList.push(
+              <div className="border mt-4" key={test.id}>
+                <div className="cat-test-div">
+                  <TestAutoG069Form
+                    g069param={defaultG069userInfo}
+                    test={test as TestAutoG069}
+                    onTestChange={props.onTestChange}
+                    criterionId={criterion.id}
+                    principleId={principle.id}
+                  />
+                </div>
+              </div>,
+            );
+          } else if (test.type === "Auto-Check-AARC-G069-Token-Introspection") {
+            testList.push(
+              <div className="border mt-4" key={test.id}>
+                <div className="cat-test-div">
+                  <TestAutoG069Form
+                    g069param={defaultG069tokenIntrospection}
                     test={test as TestAutoG069}
                     onTestChange={props.onTestChange}
                     criterionId={criterion.id}

--- a/src/pages/motivations/components/MotivationMetric.tsx
+++ b/src/pages/motivations/components/MotivationMetric.tsx
@@ -1,5 +1,6 @@
 import { useGetMotivationMetric } from "@/api";
 import { AuthContext } from "@/auth";
+import { defaultG069tokenIntrospection, defaultG069userInfo } from "@/config";
 import { TestAutoG069Form } from "@/pages/assessments/components/tests/TestAutoG069Form";
 import { TestAutoHttpsCheckForm } from "@/pages/assessments/components/tests/TestAutoHttpsCheckForm";
 import { TestAutoMd1Form } from "@/pages/assessments/components/tests/TestAutoMd1Form";
@@ -80,6 +81,35 @@ export default function MotivationMetric({
           <div className="border mt-4" key={test.id}>
             <div className="cat-test-div">
               <TestAutoG069Form
+                g069param=""
+                test={test as TestAutoG069}
+                onTestChange={() => {}}
+                criterionId={getByCriterion ? itemId : ""}
+                principleId={""}
+              />
+            </div>
+          </div>,
+        );
+      } else if (test.type === "Auto-Check-AARC-G069-User-Info") {
+        testList.push(
+          <div className="border mt-4" key={test.id}>
+            <div className="cat-test-div">
+              <TestAutoG069Form
+                g069param={defaultG069userInfo}
+                test={test as TestAutoG069}
+                onTestChange={() => {}}
+                criterionId={getByCriterion ? itemId : ""}
+                principleId={""}
+              />
+            </div>
+          </div>,
+        );
+      } else if (test.type === "Auto-Check-AARC-G069-Token-Introspection") {
+        testList.push(
+          <div className="border mt-4" key={test.id}>
+            <div className="cat-test-div">
+              <TestAutoG069Form
+                g069param={defaultG069tokenIntrospection}
                 test={test as TestAutoG069}
                 onTestChange={() => {}}
                 criterionId={getByCriterion ? itemId : ""}

--- a/src/types/assessment.ts
+++ b/src/types/assessment.ts
@@ -202,7 +202,10 @@ export interface TestAutoG069 {
   name: string;
   description?: string;
   guidance?: Guidance;
-  type: "Auto-Check-String-Binary";
+  type:
+    | "Auto-Check-String-Binary"
+    | "Auto-Check-AARC-G069-User-Info"
+    | "Auto-Check-AARC-G069-Token-Introspection";
   text: string;
   result: number | null;
   value: string | null;


### PR DESCRIPTION
_⚠️ Attention: To be merged after merging the ansible configuration regarding the cat nodes_

### Goal
Being able to handle new test methods that are subvariants of the previous g069 automated test.
Specifically we want to handle tests that have the following new test methods:
- Auto-Check-AARC-G069-User-Info
- Auto-Check-AARC-G069-Token-Introspection
The first test will still make a request to the remote automated G069 endpoint but should only examine the boolean value in the field `additional_info.entitlements_in_user_info.is_valid` and the second one the boolean value in the field
`additional_info_entitlements_token_introspection.is_valid` and should ignore the top boolean value of the field `test_result.is_valid`

We will use the existing `TestAutoG069Form` with some extra param to handle these two cases.

### Implementation
- [x] Update the assessment test types to cater for the two new test definitions
- [x] Add an extra param to `TestAutoG069Form` named `g069param`. If this param is empty the test works as previously. If this param is field with the speficic user_info or token_introspection related value then the test looks for these values in the corresponding `additional_info` dictionary key 
- [x] Add default g069 params for user_info and token_introspection in cat config file 
- [x] Use the default g069 params as values accordingly when parsing the assessment in CriterionTabs component and loading the TestAutoG069Form by filling-in correctly the g069param prop
- [x] Update the TestAutoG069Form to handle cases accordingly to the g069param provided
