### PR TITLE
CAT-874 View public assessments from all motivations

### DIFF
--- a/src/api/services/assessments.ts
+++ b/src/api/services/assessments.ts
@@ -99,7 +99,9 @@ export const useGetAssessments = ({
     queryKey: ["assessments"],
     queryFn: async () => {
       let url = isPublic
-        ? `/v2/assessments/by-motivation/${motivationId}/by-actor/${actorId}?size=${size}&page=${page}`
+        ? motivationId == ""
+          ? `/v2/assessments/by-actor/${actorId}?size=${size}&page=${page}`
+          : `/v2/assessments/by-motivation/${motivationId}/by-actor/${actorId}?size=${size}&page=${page}`
         : `/v2/assessments?size=${size}&page=${page}`;
 
       subject_name ? (url = `${url}&subject_name=${subject_name}`) : null;

--- a/src/assets/locales/en.json
+++ b/src/assets/locales/en.json
@@ -297,6 +297,7 @@
     "tip_delete": "Delete Assessment"
   },
   "page_assessments": {
+    "public_view": "View public assessments",
     "view": "View your assessments",
     "subtitle": "Read about different actors in the ecosystem before starting."
   },

--- a/src/pages/assessments/Assessments.tsx
+++ b/src/pages/assessments/Assessments.tsx
@@ -54,7 +54,7 @@ function Assessments() {
           title: actorItem.label,
           description: actorItem.description,
           image: cardImg,
-          linkText: t("page_assessments.view"),
+          linkText: t("page_assessments.public_view"),
           link: `/public-assessments?actor-id=${
             actorItem.id
           }&motivation-id=${"pid_graph:3E109BBA"}&actor-name=${actorItem.label}`,

--- a/src/pages/assessments/AssessmentsList.tsx
+++ b/src/pages/assessments/AssessmentsList.tsx
@@ -154,7 +154,7 @@ function AssessmentsList({ listPublic = false }: AssessmentListProps) {
     subject_type: filters.subject_type,
     isPublic: listPublic,
     actorId: actorIdParam || "",
-    motivationId: motivationIdParam || "",
+    motivationId: "",
   });
 
   // refetch users when parameters change


### PR DESCRIPTION
### Goal
Use newly available api endpoint to list all public assessments: `/v2/assessments/by-actor/{actor-id}`
This will replace the previews endpoint: `/v2/assessments/by-motivation/{motivation-id}/by-actor/{actor-id}`

### Implementation
- [x] Update `useGetAssessments` backend query hook to be able to target the new endpoint when motivationId parameter is empty
- [x] Make motivationId parameter empty when using the hook in public mode in `AssessmentsList` component
- [x] Update i18n entries to use a new label "View public assessments" for the links on the public assessment page