### PR TITLE
[CAT-880] - Add Versioning Support for Metrics

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -778,7 +778,7 @@ a.plain:hover {
 }
 
 .version-row td:first-child {
-  padding-left: 2.8rem;
+  padding-left: 3rem;
   background: linear-gradient(to right, #eee 8%, transparent 8%);
 }
 

--- a/src/api/services/motivations.ts
+++ b/src/api/services/motivations.ts
@@ -717,3 +717,44 @@ export function useUpdateMotivationMetricTests(
     },
   });
 }
+
+export function useCreateMetricVersion(
+  token: string,
+  mtvId: string,
+  mtrId: string,
+  {
+    label,
+    description,
+    type_algorithm_id,
+    type_metric_id,
+    type_benchmark_id,
+    url,
+    value_benchmark,
+  }: MetricInput,
+) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: () => {
+      return APIClient(token).post(
+        `/v1/registry/motivations/${mtvId}/metric/${mtrId}/version-metric`,
+        {
+          label: label,
+          description: description,
+          type_algorithm_id: type_algorithm_id,
+          type_metric_id: type_metric_id,
+          type_benchmark_id: type_benchmark_id,
+          url: url,
+          value_benchmark: value_benchmark,
+        },
+      );
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries(["motivation-metrics"]);
+      queryClient.invalidateQueries(["all-metrics"]);
+      queryClient.invalidateQueries(["motivation-metric-full", mtvId, mtrId]);
+    },
+    onError: (error: AxiosError) => {
+      return handleBackendError(error);
+    },
+  });
+}

--- a/src/assets/locales/en.json
+++ b/src/assets/locales/en.json
@@ -663,7 +663,6 @@
     "list_principles_subtitle": "Principles related with criteria under motivation",
     "create_principle": "Create Principle",
     "modal_principles_title": "Manage Principles",
-
     "modal_asmt_delete_title": "Delete Assessment Type",
     "modal_asmt_delete_message": "Are you sure you want to delete the following Assessment type ?",
     "asmt_types": "Assessment Types",
@@ -682,7 +681,8 @@
     "tip_view_metric_tests": "View metric details and included tests",
     "metric_details": "Metric details",
     "modal_metric_delete_title": "Delete Metric",
-    "modal_metric_delete_message": "Are you sure you want to delete the following Metric ?"
+    "modal_metric_delete_message": "Are you sure you want to delete the following Metric ?",
+    "create_new_metric_version": "Create New Metric Version"
   },
   "page_tests": {
     "title": "Tests",

--- a/src/pages/metrics/Metrics.tsx
+++ b/src/pages/metrics/Metrics.tsx
@@ -1,5 +1,5 @@
 import { AuthContext } from "@/auth";
-import { useContext, useEffect, useState } from "react";
+import { Fragment, useContext, useEffect, useState } from "react";
 import {
   Alert,
   Button,
@@ -17,6 +17,8 @@ import {
   FaArrowDown,
   FaArrowsAltV,
   FaBorderNone,
+  FaChevronDown,
+  FaChevronRight,
 } from "react-icons/fa";
 
 import { RegistryMetric } from "@/types";
@@ -25,6 +27,7 @@ import { idToColor } from "@/utils/admin";
 import { useGetRegistryMetrics } from "@/api/services/registry";
 import { MetricModal } from "./components/MetricModal";
 import { MotivationRefList } from "@/components/MotivationRefList";
+import TestVersionRow from "../tests/components/TestVersionRow";
 
 type MetricState = {
   sortOrder: string;
@@ -41,6 +44,10 @@ type MetricModalConfig = {
 
 // the main component that lists the metrics in a table
 export default function Metrics() {
+  const [expandedTests, setExpandedTests] = useState<{
+    [key: string]: boolean;
+  }>({});
+
   const { t } = useTranslation();
   const tooltipView = (
     <Tooltip id="tip-view">{t("page_metrics.tip_view")}</Tooltip>
@@ -105,17 +112,7 @@ export default function Metrics() {
     return <FaArrowsAltV className="text-secondary opacity-50" />;
   };
   return (
-    <div>
-      <MetricModal
-        metric={modalConfig.metric}
-        show={modalConfig.show}
-        onHide={() => {
-          setModalConfig({
-            metric: null,
-            show: false,
-          });
-        }}
-      />
+    <>
       <div className="cat-view-heading-block row border-bottom">
         <div className="col">
           <h2 className="text-muted cat-view-heading ">
@@ -183,58 +180,160 @@ export default function Metrics() {
           {metrics.length > 0 ? (
             <tbody>
               {metrics.map((item) => {
+                const isExpanded = expandedTests[item?.metric_id] || false;
+                const hasVersions =
+                  item?.metric_versions && item.metric_versions?.length > 0;
+
                 return (
-                  <tr key={item.metric_id + item.motivation_id}>
-                    <td className="align-middle">
-                      <div className="d-flex  justify-content-start">
-                        <div>
-                          <FaBorderNone
-                            size={"2.5rem"}
-                            style={{ color: idToColor(item.metric_id) }}
-                          />
-                        </div>
-                        <div className="ms-2 d-flex flex-column justify-content-between">
-                          <div>{item.metric_mtr}</div>
-                          <div>
-                            <span
-                              style={{ fontSize: "0.64rem" }}
-                              className="text-muted"
+                  <Fragment key={item.metric_id}>
+                    <tr
+                      className={isExpanded ? "opened-table-row" : ""}
+                      key={item.metric_id + item.motivation_id}
+                    >
+                      <td
+                        className={
+                          isExpanded
+                            ? "align-middle opened-table-row"
+                            : "align-middle"
+                        }
+                      >
+                        <div className="d-flex justify-content-start">
+                          {hasVersions && (
+                            <div
+                              className="me-2 d-flex align-items-center"
+                              style={{ cursor: "pointer", width: "1rem" }}
+                              onClick={() => {
+                                setExpandedTests((prev) => {
+                                  console.log("item222", item);
+
+                                  return {
+                                    ...prev,
+                                    [item.metric_id]: !prev[item.metric_id],
+                                  };
+                                });
+                              }}
                             >
-                              {item.metric_id}
-                            </span>
+                              {isExpanded ? (
+                                <FaChevronDown />
+                              ) : (
+                                <FaChevronRight />
+                              )}
+                            </div>
+                          )}
+                          <div>
+                            <FaBorderNone
+                              size={"2.5rem"}
+                              style={{ color: idToColor(item.metric_id) }}
+                            />
+                          </div>
+
+                          <div className="ms-2 d-flex flex-column justify-content-between">
+                            {item.metric_mtr}{" "}
+                            {hasVersions && (
+                              <span
+                                className="badge bg-success mt-1"
+                                style={{ width: "fit-content" }}
+                              >
+                                latest
+                                {item?.metric_version
+                                  ? ` v${item.metric_version}`
+                                  : ""}
+                              </span>
+                            )}
+                            <div>
+                              <span
+                                style={{ fontSize: "0.64rem" }}
+                                className="text-muted"
+                              >
+                                {item.metric_id}
+                              </span>
+                            </div>
                           </div>
                         </div>
-                      </div>
-                    </td>
+                      </td>
 
-                    <td className="align-middle">{item.metric_label}</td>
-                    <td className="align-middle">{item.metric_description}</td>
-                    <td className="align-middle">
-                      <span>{item.type_algorithm_label}</span>
-                    </td>
-                    <td>
-                      <MotivationRefList
-                        motivations={item.used_by_motivations || []}
-                      />
-                    </td>
-                    <td>
-                      <div className="d-flex flex-nowrap">
-                        <OverlayTrigger placement="top" overlay={tooltipView}>
-                          <Button
-                            className="btn btn-light btn-sm m-1"
-                            onClick={() => {
-                              setModalConfig({
-                                metric: item,
-                                show: true,
-                              });
-                            }}
-                          >
-                            <FaBars />
-                          </Button>
-                        </OverlayTrigger>
-                      </div>
-                    </td>
-                  </tr>
+                      <td
+                        className={
+                          isExpanded
+                            ? "align-middle opened-table-row"
+                            : "align-middle"
+                        }
+                      >
+                        {item.metric_label}
+                      </td>
+                      <td
+                        className={
+                          isExpanded
+                            ? "align-middle opened-table-row"
+                            : "align-middle"
+                        }
+                      >
+                        {item.metric_description}
+                      </td>
+                      <td
+                        className={
+                          isExpanded
+                            ? "align-middle opened-table-row"
+                            : "align-middle"
+                        }
+                      >
+                        <span>{item.type_algorithm_label}</span>
+                      </td>
+                      <td
+                        className={
+                          isExpanded
+                            ? "align-middle opened-table-row"
+                            : "align-middle"
+                        }
+                      >
+                        <MotivationRefList
+                          motivations={item.used_by_motivations || []}
+                        />
+                      </td>
+                      <td
+                        className={
+                          isExpanded
+                            ? "align-middle opened-table-row"
+                            : "align-middle"
+                        }
+                      >
+                        <div className="d-flex flex-nowrap">
+                          <OverlayTrigger placement="top" overlay={tooltipView}>
+                            <Button
+                              className="btn btn-light btn-sm m-1"
+                              onClick={() => {
+                                setModalConfig({
+                                  metric: item,
+                                  show: true,
+                                });
+                              }}
+                            >
+                              <FaBars />
+                            </Button>
+                          </OverlayTrigger>
+                        </div>
+                      </td>
+                    </tr>
+                    {isExpanded &&
+                      hasVersions &&
+                      item?.metric_versions?.map((version) => (
+                        <TestVersionRow
+                          key={`version-${version.metric_id}`}
+                          id={version.metric_id}
+                          version={version.metric_version}
+                          label={version.metric_label}
+                          description={version.metric_description}
+                          type_algorithm_label={version?.type_algorithm_label}
+                          used_by_motivations={version?.used_by_motivations}
+                          onView={() => {
+                            setModalConfig({
+                              metric: version,
+                              show: true,
+                            });
+                          }}
+                        />
+                      ))}
+                  </Fragment>
                 );
               })}
             </tbody>
@@ -300,6 +399,16 @@ export default function Metrics() {
       <div className="row py-3 p-4">
         <div className="col"></div>
       </div>
-    </div>
+      <MetricModal
+        metric={modalConfig.metric}
+        show={modalConfig.show}
+        onHide={() => {
+          setModalConfig({
+            metric: null,
+            show: false,
+          });
+        }}
+      />
+    </>
   );
 }

--- a/src/pages/motivations/components/MotivationMetric.tsx
+++ b/src/pages/motivations/components/MotivationMetric.tsx
@@ -21,13 +21,22 @@ export default function MotivationMetric({
   mtvId,
   itemId,
   getByCriterion,
+  metricMetadata,
 }: {
   mtvId: string;
   itemId: string;
   getByCriterion: boolean;
+  metricMetadata?: {
+    id: string;
+    name: string;
+    label_algorithm_type: string;
+    label_type_metric: string;
+    benchmark_value: string;
+  };
 }) {
   const { keycloak } = useContext(AuthContext)!;
   const { t } = useTranslation();
+  console.log("itemId", itemId);
   const { data: metricData } = useGetMotivationMetric({
     mtvId: mtvId,
     itemId: itemId,
@@ -151,6 +160,16 @@ export default function MotivationMetric({
       }
     });
 
+  const metricDetails = metricData?.metric
+    ? {
+        id: metricData.metric.id,
+        name: metricData.metric.name,
+        label_type_metric: metricData.metric.label_type_metric,
+        label_algorithm_type: metricData.metric.label_algorithm_type,
+        benchmark_value: metricData.metric.benchmark_value,
+      }
+    : metricMetadata;
+
   return (
     <div className="pb-4">
       <div className="p-2 rounded border">
@@ -158,25 +177,25 @@ export default function MotivationMetric({
           <Col>
             <div>
               <strong className="me-2">{t("fields.id")}:</strong>
-              <span>{metricData?.metric?.id}</span>
+              <span>{metricDetails?.id || ""}</span>
             </div>
             <div>
               <strong className="me-2">{t("fields.name")}:</strong>
-              <span>{metricData?.metric?.name}</span>
+              <span>{metricDetails?.name || ""}</span>
             </div>
           </Col>
           <Col>
             <div>
               <strong className="me-2">{t("fields.type")}:</strong>
-              <span>{metricData?.metric?.label_type_metric}</span>
+              <span>{metricDetails?.label_type_metric || ""}</span>
             </div>
             <div>
               <strong className="me-2">{t("fields.algorithm")}:</strong>
-              <span>{metricData?.metric?.label_algorithm_type}</span>
+              <span>{metricDetails?.label_algorithm_type || ""}</span>
             </div>
             <div>
               <strong className="me-2">{t("fields.benchmark")}:</strong>
-              <span>{metricData?.metric?.benchmark_value}</span>
+              <span>{metricDetails?.benchmark_value || ""}</span>
             </div>
           </Col>
         </Row>

--- a/src/pages/motivations/components/MotivationMetricDetailsModal.tsx
+++ b/src/pages/motivations/components/MotivationMetricDetailsModal.tsx
@@ -8,6 +8,13 @@ interface MotivationMetricProps {
   show: boolean;
   getByCriterion: boolean;
   onHide: () => void;
+  onMetricMetadata?: () => {
+    id: string;
+    name: string;
+    label_algorithm_type: string;
+    label_type_metric: string;
+    benchmark_value: string;
+  };
 }
 /**
  * Modal component for displaying criterion metric
@@ -38,6 +45,7 @@ export function MotivationMetricDetailsModal(props: MotivationMetricProps) {
             mtvId={props.mtvId}
             itemId={props.itemId}
             getByCriterion={props.getByCriterion}
+            metricMetadata={props?.onMetricMetadata && props.onMetricMetadata()}
           />
         )}
       </Modal.Body>

--- a/src/pages/motivations/components/MotivationMetrics.tsx
+++ b/src/pages/motivations/components/MotivationMetrics.tsx
@@ -1,6 +1,13 @@
 import { AuthContext } from "@/auth";
-import { AlertInfo, MotivationMetric } from "@/types";
-import { useContext, useEffect, useMemo, useRef, useState } from "react";
+import { AlertInfo, RegistryMetric } from "@/types";
+import {
+  Fragment,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import {
   Button,
   Col,
@@ -11,7 +18,16 @@ import {
   Tooltip,
 } from "react-bootstrap";
 import notavailImg from "@/assets/thumb_notavail.png";
-import { FaBars, FaCog, FaEdit, FaPlus, FaTrash } from "react-icons/fa";
+import {
+  FaBars,
+  FaCodeBranch,
+  FaCog,
+  FaEdit,
+  FaPlus,
+  FaTrash,
+  FaChevronDown,
+  FaChevronRight,
+} from "react-icons/fa";
 import { MotivationMetricModal } from "./MotivationMetricModal";
 import { useDeleteMotivationMetric, useGetAllMotivationMetrics } from "@/api";
 import { Link } from "react-router-dom";
@@ -24,6 +40,7 @@ import { SearchBox } from "@/components/SearchBox";
 interface MetricModalConfig {
   show: boolean;
   itemId: string;
+  isVersioning?: boolean;
 }
 
 interface DeleteMetricModalConfig {
@@ -43,19 +60,22 @@ export const MotivationMetrics = ({
 }) => {
   const { t } = useTranslation();
   const { keycloak, registered } = useContext(AuthContext)!;
-  const [mtvMetrics, setMtvMetrics] = useState<MotivationMetric[]>([]);
+  const [mtvMetrics, setMtvMetrics] = useState<RegistryMetric[]>([]);
+  const [expandedMetrics, setExpandedMetrics] = useState<{
+    [key: string]: boolean;
+  }>({});
+  const [metricModal, setMetricModal] = useState<MetricModalConfig>({
+    show: false,
+    itemId: "",
+  });
   const [modalCreateEdit, setModalCreateEdit] = useState<MetricModalConfig>({
     show: false,
     itemId: "",
+    isVersioning: false,
   });
 
   const alert = useRef<AlertInfo>({
     message: "",
-  });
-
-  const [metricModal, setMetricModal] = useState<MetricModalConfig>({
-    show: false,
-    itemId: "",
   });
 
   const {
@@ -111,19 +131,21 @@ export const MotivationMetrics = ({
   };
 
   useEffect(() => {
-    // gather all mtv metrics in one array
-    let tmpMtr: MotivationMetric[] = [];
+    let result: RegistryMetric[] = [];
 
     // iterate over backend pages and gather all items in the motivation metrics array
     if (mtrData?.pages) {
-      mtrData.pages.map((page) => {
-        tmpMtr = [...tmpMtr, ...page.content];
+      mtrData.pages.forEach((page) => {
+        const contentDetails = page.content as RegistryMetric[];
+        result = [...result, ...contentDetails];
       });
+
       if (mtrHasNextPage) {
         mtrFetchNextPage();
       }
     }
-    setMtvMetrics(tmpMtr);
+
+    setMtvMetrics(result);
   }, [mtrData, mtrHasNextPage, mtrFetchNextPage]);
 
   const [searchInput, setSearchInput] = useState("");
@@ -135,16 +157,68 @@ export const MotivationMetrics = ({
     setSearchInput("");
   };
 
-  const filteredMetrics = useMemo(() => {
-    return mtvMetrics.filter((item) => {
-      const query = searchInput.toLowerCase();
-      return (
-        item.metric_id.toLowerCase().includes(query) ||
-        item.metric_label.toLowerCase().includes(query) ||
-        item.metric_description.toLowerCase().includes(query)
-      );
-    });
-  }, [searchInput, mtvMetrics]);
+  const filteredMetrics = useMemo(
+    () =>
+      mtvMetrics?.filter((item) => {
+        const query = searchInput.toLowerCase();
+
+        const result =
+          item.metric_id.toLowerCase().includes(query) ||
+          item.metric_label.toLowerCase().includes(query) ||
+          item.metric_description.toLowerCase().includes(query);
+
+        if (result) return true;
+
+        // Also check for sub-versions if any exist
+        if (item.metric_versions && item.metric_versions?.length > 0) {
+          return item.metric_versions.some(
+            (version) =>
+              version.metric_id.toLowerCase().includes(query) ||
+              version.metric_label.toLowerCase().includes(query) ||
+              version.metric_description.toLowerCase().includes(query),
+          );
+        }
+
+        return false;
+      }),
+    [searchInput, mtvMetrics],
+  );
+
+  const handleMetricMetadata = () => {
+    // Find the metric that matches the current modal itemId
+    const currentMetric = mtvMetrics.find(
+      (item) => item.metric_id === metricModal.itemId,
+    );
+
+    // If metric not found at top level, search in versions
+    if (!currentMetric) {
+      for (const metric of mtvMetrics) {
+        if (metric.metric_versions) {
+          const versionMetric = metric.metric_versions.find(
+            (version) => version.metric_id === metricModal.itemId,
+          );
+          if (versionMetric) {
+            return {
+              id: versionMetric.metric_id || "",
+              name: versionMetric.metric_label || "",
+              label_algorithm_type: versionMetric.type_algorithm_label || "",
+              label_type_metric: versionMetric.type_metric_label || "",
+              benchmark_value: versionMetric.value_benchmark || "",
+            };
+          }
+        }
+      }
+    }
+
+    // Return found metric data or empty values if not found
+    return {
+      id: currentMetric?.metric_id || "",
+      name: currentMetric?.metric_label || "",
+      label_algorithm_type: currentMetric?.type_algorithm_label || "",
+      label_type_metric: currentMetric?.type_metric_label || "",
+      benchmark_value: currentMetric?.value_benchmark || "",
+    };
+  };
 
   return (
     <div className="px-5 mt-4">
@@ -170,14 +244,16 @@ export const MotivationMetrics = ({
         mtvId={mtvId}
         itemId={metricModal.itemId}
         getByCriterion={false}
+        onMetricMetadata={handleMetricMetadata}
       />
       <MotivationMetricModal
         show={modalCreateEdit.show}
         mtvId={mtvId}
         mtrId={modalCreateEdit.itemId}
         onHide={() => {
-          setModalCreateEdit({ itemId: "", show: false });
+          setModalCreateEdit({ itemId: "", show: false, isVersioning: false });
         }}
+        isVersioning={modalCreateEdit.isVersioning}
       />
       <div className="d-flex justify-content-between mb-2">
         <h5 className="text-muted cat-view-heading ">
@@ -198,7 +274,11 @@ export const MotivationMetrics = ({
             <Button
               variant="warning"
               onClick={() => {
-                setModalCreateEdit({ itemId: "", show: true });
+                setModalCreateEdit({
+                  itemId: "",
+                  show: true,
+                  isVersioning: false,
+                });
               }}
               disabled={published}
             >
@@ -217,103 +297,277 @@ export const MotivationMetrics = ({
       </div>
       <div>
         <ListGroup>
-          {filteredMetrics.map((item) => (
-            <ListGroupItem key={item.metric_id}>
-              <Row>
-                <Col>
-                  <div className="flex items-center ng-star-inserted">
-                    <div className="margin-right-8 flex justify-center items-center ng-star-inserted radio-card-icon">
-                      <img
-                        src={notavailImg}
-                        className="text-center m-1 rounded-full"
-                        width="60%"
-                      />
-                    </div>
-                    <div>
-                      <div className="flex text-sm text-gray-900 font-weight-500 items-center cursor-pointer">
-                        {item.metric_label}
+          {filteredMetrics.map((item) => {
+            const isExpanded = expandedMetrics[item.metric_id] || false;
+            const hasVersions =
+              item?.metric_versions && item.metric_versions?.length > 0;
+
+            return (
+              <Fragment key={item.metric_id}>
+                <ListGroupItem>
+                  <Row>
+                    <Col>
+                      <div className="flex items-center ng-star-inserted">
+                        <div className="d-flex align-items-center">
+                          {hasVersions && (
+                            <div
+                              className="me-2"
+                              style={{ cursor: "pointer", width: "1rem" }}
+                              onClick={() => {
+                                setExpandedMetrics((prev) => ({
+                                  ...prev,
+                                  [item.metric_id]: !prev[item.metric_id],
+                                }));
+                              }}
+                            >
+                              {isExpanded ? (
+                                <FaChevronDown />
+                              ) : (
+                                <FaChevronRight />
+                              )}
+                            </div>
+                          )}
+                          <div className="margin-right-8 flex justify-center items-center ng-star-inserted radio-card-icon">
+                            <img
+                              src={notavailImg}
+                              className="text-center m-1 rounded-full"
+                              width="60%"
+                            />
+                          </div>
+                        </div>
+                        <div>
+                          <div className="d-flex gap-2 text-sm text-gray-900 font-weight-500 items-center cursor-pointer">
+                            {item.metric_label}
+                            {hasVersions && (
+                              <span
+                                className="badge bg-success"
+                                style={{
+                                  width: "fit-content",
+                                  fontSize: "0.7rem",
+                                }}
+                              >
+                                latest
+                                {item.metric_version
+                                  ? ` v${item.metric_version}`
+                                  : ""}
+                              </span>
+                            )}
+                          </div>
+                          <div className="text-xs text-gray-600 ng-star-inserted">
+                            {item.metric_description}
+                          </div>
+                          <div>
+                            <span
+                              style={{ fontSize: "0.64rem" }}
+                              className="text-muted"
+                            >
+                              {item.metric_id}
+                            </span>
+                          </div>
+                        </div>
                       </div>
-                      <div className="text-xs text-gray-600 ng-star-inserted">
-                        {item.metric_description}
-                      </div>
-                    </div>
-                  </div>
-                </Col>
-                <Col xs="auto">
-                  <OverlayTrigger
-                    placement="top"
-                    overlay={
-                      <Tooltip>{t("page_motivations.tip_edit_metric")}</Tooltip>
-                    }
-                  >
-                    <Button
-                      variant="light"
-                      onClick={() => {
-                        setModalCreateEdit({
-                          itemId: item.metric_id,
-                          show: true,
-                        });
-                      }}
-                    >
-                      <FaEdit />
-                    </Button>
-                  </OverlayTrigger>
-                  <OverlayTrigger
-                    placement="top"
-                    overlay={
-                      <Tooltip>
-                        {t("page_motivations.tip_view_metric_tests")}
-                      </Tooltip>
-                    }
-                  >
-                    <Button
-                      variant="light"
-                      onClick={() => {
-                        setMetricModal({ itemId: item.metric_id, show: true });
-                      }}
-                    >
-                      <FaBars />
-                    </Button>
-                  </OverlayTrigger>
-                  <OverlayTrigger
-                    placement="top"
-                    overlay={
-                      <Tooltip>{t("page_motivations.assign_tests")}</Tooltip>
-                    }
-                  >
-                    <Link
-                      className="btn btn-light"
-                      to={`/admin/motivations/${mtvId}/metrics-tests/${item.metric_id}`}
-                    >
-                      <FaCog />
-                    </Link>
-                  </OverlayTrigger>
-                  <OverlayTrigger
-                    placement="top"
-                    overlay={
-                      <Tooltip id="tip-delete">
-                        {t("page_motivations.tip_delete_metric")}
-                      </Tooltip>
-                    }
-                  >
-                    <Button
-                      className="btn btn-light btn-sm m-1"
-                      onClick={() => {
-                        setDeleteMetricModalConfig({
-                          ...deleteMetricModalConfig,
-                          show: true,
-                          itemId: item.metric_id,
-                          itemName: item.metric_label,
-                        });
-                      }}
-                    >
-                      <FaTrash />
-                    </Button>
-                  </OverlayTrigger>
-                </Col>
-              </Row>
-            </ListGroupItem>
-          ))}
+                    </Col>
+                    <Col xs="auto">
+                      <OverlayTrigger
+                        placement="top"
+                        overlay={
+                          <Tooltip>
+                            {t("page_motivations.tip_edit_metric")}
+                          </Tooltip>
+                        }
+                      >
+                        <Button
+                          variant="light"
+                          onClick={() => {
+                            setModalCreateEdit({
+                              itemId: item.metric_id,
+                              show: true,
+                              isVersioning: false,
+                            });
+                          }}
+                        >
+                          <FaEdit />
+                        </Button>
+                      </OverlayTrigger>
+                      <OverlayTrigger
+                        placement="top"
+                        overlay={
+                          <Tooltip>
+                            {t("page_motivations.tip_view_metric_tests")}
+                          </Tooltip>
+                        }
+                      >
+                        <Button
+                          variant="light"
+                          onClick={() => {
+                            setMetricModal({
+                              itemId: item.metric_id,
+                              show: true,
+                            });
+                          }}
+                        >
+                          <FaBars />
+                        </Button>
+                      </OverlayTrigger>
+                      <OverlayTrigger
+                        placement="top"
+                        overlay={
+                          <Tooltip>
+                            {t("page_motivations.assign_tests")}
+                          </Tooltip>
+                        }
+                      >
+                        <Link
+                          className="btn btn-light"
+                          to={`/admin/motivations/${mtvId}/metrics-tests/${item.metric_id}`}
+                        >
+                          <FaCog />
+                        </Link>
+                      </OverlayTrigger>
+                      <OverlayTrigger
+                        placement="top"
+                        overlay={<Tooltip>Create New Version</Tooltip>}
+                      >
+                        <Button
+                          className="btn btn-light"
+                          onClick={() => {
+                            setModalCreateEdit({
+                              itemId: item.metric_id,
+                              show: true,
+                              isVersioning: true,
+                            });
+                          }}
+                        >
+                          <FaCodeBranch />
+                        </Button>
+                      </OverlayTrigger>
+                      <OverlayTrigger
+                        placement="top"
+                        overlay={
+                          <Tooltip id="tip-delete">
+                            {t("page_motivations.tip_delete_metric")}
+                          </Tooltip>
+                        }
+                      >
+                        <Button
+                          className="btn btn-light btn-sm m-1"
+                          onClick={() => {
+                            setDeleteMetricModalConfig({
+                              ...deleteMetricModalConfig,
+                              show: true,
+                              itemId: item.metric_id,
+                              itemName: item.metric_label,
+                            });
+                          }}
+                        >
+                          <FaTrash />
+                        </Button>
+                      </OverlayTrigger>
+                    </Col>
+                  </Row>
+                </ListGroupItem>
+                {isExpanded &&
+                  hasVersions &&
+                  item.metric_versions?.map((version) => (
+                    <ListGroupItem key={`version-${version.metric_id}`}>
+                      <Row>
+                        <Col>
+                          <div
+                            className="d-flex flex-column"
+                            style={{ paddingLeft: "4.3rem" }}
+                          >
+                            <div className="d-flex gap-2 text-sm text-gray-900 font-weight-500 items-center cursor-pointer">
+                              <div className="flex text-sm text-gray-900 font-weight-500 items-center">
+                                {version.metric_label}
+                              </div>
+                              <span
+                                className="badge bg-secondary"
+                                style={{ width: "fit-content" }}
+                              >
+                                {version.metric_version
+                                  ? `v${version.metric_version}`
+                                  : "old version"}
+                              </span>
+                            </div>
+                            <div className="text-xs text-gray-600">
+                              {version.metric_description}
+                            </div>
+                            <div>
+                              <span
+                                className="text-muted"
+                                style={{
+                                  fontSize: "0.64rem",
+                                }}
+                              >
+                                {version.metric_id}
+                              </span>
+                            </div>
+                          </div>
+                        </Col>
+                        <Col xs="auto" style={{ marginRight: "5.3rem" }}>
+                          <OverlayTrigger
+                            placement="top"
+                            overlay={
+                              <Tooltip>
+                                {t("page_motivations.tip_edit_metric")}
+                              </Tooltip>
+                            }
+                          >
+                            <Button
+                              variant="light"
+                              onClick={() => {
+                                setModalCreateEdit({
+                                  itemId: version.metric_id,
+                                  show: true,
+                                  isVersioning: false,
+                                });
+                              }}
+                            >
+                              <FaEdit />
+                            </Button>
+                          </OverlayTrigger>
+                          <OverlayTrigger
+                            placement="top"
+                            overlay={
+                              <Tooltip>
+                                {t("page_motivations.tip_view_metric_tests")}
+                              </Tooltip>
+                            }
+                          >
+                            <Button
+                              variant="light"
+                              onClick={() => {
+                                setMetricModal({
+                                  itemId: version.metric_id,
+                                  show: true,
+                                });
+                              }}
+                            >
+                              <FaBars />
+                            </Button>
+                          </OverlayTrigger>
+                          <OverlayTrigger
+                            placement="top"
+                            overlay={
+                              <Tooltip>
+                                {t("page_motivations.assign_tests")}
+                              </Tooltip>
+                            }
+                          >
+                            <Link
+                              className="btn btn-light"
+                              to={`/admin/motivations/${mtvId}/metrics-tests/${version.metric_id}`}
+                            >
+                              <FaCog />
+                            </Link>
+                          </OverlayTrigger>
+                        </Col>
+                      </Row>
+                    </ListGroupItem>
+                  ))}
+              </Fragment>
+            );
+          })}
         </ListGroup>
       </div>
     </div>

--- a/src/pages/tests/components/TestRow.tsx
+++ b/src/pages/tests/components/TestRow.tsx
@@ -82,16 +82,16 @@ const TestRow: React.FC<TestRowProps> = ({
             />
           </div>
           <div className="ms-2 d-flex flex-column justify-content-between ">
-            <div>
-              {test.tes}{" "}
-              {hasVersions && test.is_latest_version !== false && (
-                <span className="ms-2 badge bg-success">
-                  latest
-                  {test?.version ? ` v${test.version}` : ""}
-                </span>
-              )}
-            </div>
-
+            {test.tes}
+            {hasVersions && test.is_latest_version !== false && (
+              <span
+                className="badge bg-success mt-1"
+                style={{ width: "fit-content" }}
+              >
+                latest
+                {test?.version ? ` v${test.version}` : ""}
+              </span>
+            )}
             <div>
               <span style={{ fontSize: "0.64rem" }} className="text-muted">
                 {test.id}

--- a/src/pages/tests/components/TestTable.tsx
+++ b/src/pages/tests/components/TestTable.tsx
@@ -88,7 +88,7 @@ const TestTable: React.FC<TestTableProps> = ({
               onClick={() => onSortChange("lastTouch")}
               className="cat-cursor-pointer text-nowrap"
             >
-              {t("fields.modified")}{" "}
+              {t("fields.modified")}
               {SortMarker("lastTouch", sortBy, sortOrder)}
             </span>
           </th>
@@ -121,7 +121,12 @@ const TestTable: React.FC<TestTableProps> = ({
                   item.test_versions?.map((version) => (
                     <TestVersionRow
                       key={`version-${version.id}`}
-                      version={version}
+                      id={version.id}
+                      version={version.version}
+                      label={version.label}
+                      description={version.description}
+                      last_touch={version.last_touch}
+                      used_by_motivations={version?.used_by_motivations}
                       onView={onViewTest}
                       onEdit={onEditTest}
                     />

--- a/src/pages/tests/components/TestVersionRow.tsx
+++ b/src/pages/tests/components/TestVersionRow.tsx
@@ -2,17 +2,29 @@ import React from "react";
 import { Button, OverlayTrigger, Tooltip } from "react-bootstrap";
 import { FaBars, FaEdit } from "react-icons/fa";
 import { useTranslation } from "react-i18next";
-import { RegistryTest } from "@/types/tests";
+import { MotivationReference } from "@/types";
 import { MotivationRefList } from "@/components/MotivationRefList";
 
 interface TestVersionRowProps {
-  version: RegistryTest;
-  onView: (testId: string) => void;
-  onEdit: (testId: string) => void;
+  id: string;
+  label: string;
+  description: string;
+  last_touch?: string;
+  type_algorithm_label?: string;
+  version?: string;
+  used_by_motivations?: MotivationReference[];
+  onView?: (testId: string) => void;
+  onEdit?: (testId: string) => void;
 }
 
 const TestVersionRow: React.FC<TestVersionRowProps> = ({
+  id,
   version,
+  label,
+  description,
+  last_touch,
+  type_algorithm_label,
+  used_by_motivations,
   onView,
   onEdit,
 }) => {
@@ -29,42 +41,53 @@ const TestVersionRow: React.FC<TestVersionRowProps> = ({
     <tr className="version-row">
       <td className="align-middle">
         <div className="d-flex flex-column gap-2 ps-4">
-          <span className="w-25 badge bg-secondary px-2 py-1 text-center text-truncate">
-            {version?.version ? `v${version.version}` : "old version"}
+          <span
+            className="badge bg-secondary px-2 py-1 text-center text-truncate"
+            style={{ width: "fit-content" }}
+          >
+            {version ? `v${version}` : "old version"}
           </span>
           <span style={{ fontSize: "0.64rem" }} className="text-muted">
-            {version.id}
+            {id}
           </span>
         </div>
       </td>
-      <td className="align-middle">{version.label}</td>
-      <td className="align-middle">{version.description}</td>
+      <td className="align-middle">{label}</td>
+      <td className="align-middle">{description}</td>
       <td className="align-middle">
-        <small>{version?.last_touch?.split("T")[0]}</small>
+        {last_touch ? (
+          <small>{last_touch?.split("T")[0]}</small>
+        ) : (
+          type_algorithm_label && <span>{type_algorithm_label}</span>
+        )}
       </td>
       <td>
-        {version?.used_by_motivations ? (
-          <MotivationRefList motivations={version.used_by_motivations || []} />
+        {used_by_motivations ? (
+          <MotivationRefList motivations={used_by_motivations || []} />
         ) : null}
       </td>
       <td>
         <div className="d-flex flex-nowrap">
-          <OverlayTrigger placement="top" overlay={tooltipView}>
-            <Button
-              className="btn btn-light btn-sm m-1"
-              onClick={() => onView(version.id)}
-            >
-              <FaBars />
-            </Button>
-          </OverlayTrigger>
-          <OverlayTrigger placement="top" overlay={tooltipEdit}>
-            <Button
-              className="btn btn-light btn-sm m-1"
-              onClick={() => onEdit(version.id)}
-            >
-              <FaEdit />
-            </Button>
-          </OverlayTrigger>
+          {onView && (
+            <OverlayTrigger placement="top" overlay={tooltipView}>
+              <Button
+                className="btn btn-light btn-sm m-1"
+                onClick={() => onView(id)}
+              >
+                <FaBars />
+              </Button>
+            </OverlayTrigger>
+          )}
+          {onEdit && (
+            <OverlayTrigger placement="top" overlay={tooltipEdit}>
+              <Button
+                className="btn btn-light btn-sm m-1"
+                onClick={() => onEdit(id)}
+              >
+                <FaEdit />
+              </Button>
+            </OverlayTrigger>
+          )}
         </div>
       </td>
     </tr>

--- a/src/types/registry.ts
+++ b/src/types/registry.ts
@@ -6,6 +6,8 @@ export interface RegistryMetric {
   metric_mtr: string;
   metric_label: string;
   metric_description: string;
+  metric_version?: string;
+  metric_versions?: RegistryMetric[];
   type_algorithm_id: string;
   type_algorithm_label: string;
   type_algorithm_description: string;

--- a/src/types/tests.ts
+++ b/src/types/tests.ts
@@ -7,7 +7,7 @@ export interface RegistryTest {
   label: string;
   description: string;
   last_touch?: string;
-  version?: number;
+  version?: string;
   test_method_id?: string;
   label_test_definition?: string;
   motivation_id?: string;


### PR DESCRIPTION
This PR implements versioning support for metrics within the motivation view, allowing an admin to view, manage, and create new versions of metrics.

- Implemented the API endpoint integration for creating new metric versions
- Added support for displaying metrics with their version history
- Updated the MotivationMetricDetailsModal to work with the new versioning structure
- Updated the search functionality to include all versions in search results