### PR TITLE
[CAT-890] - Refactor Test Creation UI and functionality

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -751,3 +751,123 @@ a.plain:hover {
 .form-check-input:valid:focus.is-valid {
   box-shadow: none !important;
 }
+
+.test-container {
+  max-width: 1800px;
+  margin: 0 auto;
+}
+
+.test-section-header {
+  font-size: 17px !important;
+  font-weight: 500 !important;
+}
+
+.test-header-description {
+  display: block;
+  margin-top: 0.25rem;
+  font-size: 12px;
+  color: #505050;
+}
+
+.test-method-item {
+  padding: 8px 16px;
+}
+
+.test-method-item.selected-method {
+  background-color: #eee !important;
+  box-shadow: inset 3px 0 0 #007bff;
+}
+
+.form-control {
+  padding: 4px 8px !important;
+  font-size: 15px !important;
+  font-weight: 500 !important;
+}
+
+.form-group {
+  margin-bottom: 0.5rem;
+}
+
+.form-group-label {
+  margin-bottom: 0.2rem;
+  font-size: 16px;
+  font-weight: 500;
+  color: #555;
+}
+
+.test-methods-sidebar-container {
+  max-height: 85vh;
+  overflow-y: auto;
+}
+
+.test-method-search {
+  margin-top: 1rem;
+}
+
+.test-method-search input {
+  font-size: 14px !important;
+  border-radius: 4px;
+}
+
+.test-method-filters {
+  margin-top: 0.75rem;
+}
+
+.form-check-inline {
+  margin-right: 0.5rem;
+}
+
+.form-check-label {
+  font-size: 13px;
+  color: #555;
+}
+
+.test-method-spinner {
+  padding: 1.5rem;
+  color: #007bff;
+  text-align: center;
+}
+
+.test-method-empty {
+  padding: 1.5rem;
+  font-size: 14px;
+  color: #6c757d;
+  text-align: center;
+}
+
+.test-methods-sidebar-container h6,
+.test-content-container h6 {
+  font-size: 16px;
+}
+
+.test-methods-sidebar-container small,
+.test-content-container small {
+  font-size: 12px;
+}
+
+.test-method-label {
+  font-size: 14px;
+  color: #333;
+}
+
+.test-method-description {
+  margin-top: 3px;
+  overflow: hidden;
+  font-size: 12px;
+  line-height: 1.3;
+  color: #505050;
+  text-overflow: ellipsis;
+}
+
+.test-preview-section {
+  padding: 4px;
+}
+
+.test-preview-section h5 {
+  font-size: 15px;
+  color: #333;
+}
+
+.test-content-container .fw-medium {
+  font-size: 14px;
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -35,6 +35,7 @@ import MotivationCriteriaPrinciples from "./pages/motivations/MotivationCriteria
 import Criteria from "./pages/criteria/Criteria";
 import MotivationMetricTests from "./pages/motivations/MotivationMetricTests";
 import Tests from "./pages/tests/Tests";
+import CreateTest from "./pages/tests/components/CreateTest";
 import Metrics from "./pages/metrics/Metrics";
 import AdminAssessments from "./pages/admin/AdminAssessments";
 import AboutCat from "./pages/about/AboutCat";
@@ -250,6 +251,24 @@ function App() {
                 </Route>
                 <Route path="/admin/tests" element={<ProtectedRoute />}>
                   <Route index element={<Tests />} />
+                </Route>
+                <Route
+                  path="/admin/tests/create-test"
+                  element={<ProtectedRoute />}
+                >
+                  <Route index element={<CreateTest />} />
+                </Route>
+                <Route
+                  path="/admin/tests/edit-test/:testId"
+                  element={<ProtectedRoute />}
+                >
+                  <Route index element={<CreateTest />} />
+                </Route>
+                <Route
+                  path="/admin/tests/create-version-test/:testId"
+                  element={<ProtectedRoute />}
+                >
+                  <Route index element={<CreateTest />} />
                 </Route>
                 <Route path="/admin/assessments" element={<ProtectedRoute />}>
                   <Route index element={<AdminAssessments />} />

--- a/src/api/services/registry.ts
+++ b/src/api/services/registry.ts
@@ -47,12 +47,13 @@ export const useGetAllTestMethods = ({
   token,
   isRegistered,
   size,
+  search = "",
 }: ApiOptions) =>
   useInfiniteQuery({
-    queryKey: ["all-test-methods"],
+    queryKey: ["all-test-methods", search],
     queryFn: async ({ pageParam = 1 }) => {
       const response = await APIClient(token).get<RegistryResourceResponse>(
-        `/v1/registry/tests/test-method?size=${size}&page=${pageParam}`,
+        `/v1/registry/tests/test-method?size=${size}&page=${pageParam}&search=${search}`,
       );
       return response.data;
     },

--- a/src/assets/locales/en.json
+++ b/src/assets/locales/en.json
@@ -710,7 +710,8 @@
     "toast_update_success": "Test Updated!",
     "toast_update_progress": "Updating Test...",
     "toast_create_version_success": "New test version successfully created!",
-    "toast_create_version_progress": "Creating new test version..."
+    "toast_create_version_progress": "Creating new test version...",
+    "update": "Update Test"
   },
   "page_metrics": {
     "title": "Metrics",

--- a/src/pages/tests/Tests.tsx
+++ b/src/pages/tests/Tests.tsx
@@ -11,7 +11,7 @@ import TestsHeader from "./components/TestsHeader";
 import TestSearch from "./components/TestSearch";
 import TestTable from "./components/TestTable";
 import TestPagination from "./components/TestPagination";
-import TestModal from "./components/TestModal";
+import { useNavigate } from "react-router-dom";
 
 type TestsState = {
   sortOrder: string;
@@ -19,13 +19,6 @@ type TestsState = {
   page: number;
   size: number;
   search: string;
-};
-
-type TestModalConfig = {
-  id: string;
-  show: boolean;
-  isEditing?: boolean;
-  isVersioning?: boolean;
 };
 
 type TestModalDetailsConfig = {
@@ -44,6 +37,7 @@ interface DeleteModalConfig {
 function Tests() {
   const { t } = useTranslation();
   const { keycloak, registered } = useContext(AuthContext)!;
+  const navigate = useNavigate();
 
   const alert = useRef<AlertInfo>({
     message: "",
@@ -65,13 +59,6 @@ function Tests() {
     page: 1,
     size: 10,
     search: "",
-  });
-
-  const [testModalCfg, setTestModalCfg] = useState<TestModalConfig>({
-    id: "",
-    show: false,
-    isEditing: false,
-    isVersioning: false,
   });
 
   const [testDetailsModalCfg, setTestDetailsModalCfg] =
@@ -149,9 +136,7 @@ function Tests() {
 
   return (
     <>
-      <TestsHeader
-        onCreateTest={() => setTestModalCfg({ id: "", show: true })}
-      />
+      <TestsHeader />
       <TestSearch
         searchValue={opts.search}
         onSearchChange={(searchText) =>
@@ -178,19 +163,11 @@ function Tests() {
             show: true,
           })
         }
-        onEditTest={(testId) =>
-          setTestModalCfg({
-            id: testId,
-            show: true,
-            isEditing: true,
-          })
+        onEditTest={(testId: string) =>
+          navigate(`/admin/tests/edit-test/${testId}`)
         }
-        onCreateVersion={(testId) =>
-          setTestModalCfg({
-            id: testId,
-            show: true,
-            isVersioning: true,
-          })
+        onCreateVersion={(testId: string) =>
+          navigate(`/admin/tests/create-version-test/${testId}`)
         }
         onDeleteTest={(testId, name) =>
           setDeleteModalConfig({
@@ -223,22 +200,6 @@ function Tests() {
         }}
         handleDelete={handleDeleteConfirmed}
       />
-      {testModalCfg?.show && (
-        <TestModal
-          id={testModalCfg.id}
-          show={testModalCfg.show}
-          isEditing={testModalCfg?.isEditing}
-          isVersioning={testModalCfg?.isVersioning}
-          onHide={() => {
-            setTestModalCfg({
-              id: "",
-              show: false,
-              isVersioning: false,
-              isEditing: false,
-            });
-          }}
-        />
-      )}
       <TestDetailsModal
         id={testDetailsModalCfg.id}
         show={testDetailsModalCfg.show}

--- a/src/pages/tests/components/CreateTest.tsx
+++ b/src/pages/tests/components/CreateTest.tsx
@@ -1,0 +1,352 @@
+import {
+  useCreateTest,
+  useGetAllTestMethods,
+  useGetTest,
+  useUpdateTest,
+  useCreateTestVersion,
+} from "@/api/services/registry";
+import { AuthContext } from "@/auth";
+import { AlertInfo, RegistryResource } from "@/types";
+import { TestInput, TestParam } from "@/types/tests";
+import { useContext, useEffect, useRef, useState } from "react";
+import toast from "react-hot-toast";
+import { useTranslation } from "react-i18next";
+import { useParams, useLocation, useNavigate } from "react-router-dom";
+import TestModalContainer from "./TestModalContainer";
+
+function CreateTest() {
+  const alert = useRef<AlertInfo>({
+    message: "",
+  });
+  const { keycloak, registered } = useContext(AuthContext)!;
+
+  const navigate = useNavigate();
+
+  const location = useLocation();
+  const { testId } = useParams();
+  const isEditing = location.pathname.includes("/edit-test/");
+  const isVersioning = location.pathname.includes("/create-version-test/");
+
+  const { t } = useTranslation();
+
+  const [testMethods, setTestMethods] = useState<RegistryResource[]>([]);
+  const [showErrors, setShowErrors] = useState(false);
+  const [searchTerm, setSearchTerm] = useState<string>("");
+  const [filterType, setFilterType] = useState<string>("all");
+  const [isSearching, setIsSearching] = useState<boolean>(false);
+  const searchTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const [test, setTest] = useState<TestInput>({
+    label: "",
+    tes: "",
+    description: "",
+    test_method_id: "",
+    label_test_definition: "",
+    param_type: "onscreen",
+    test_params: "",
+    test_question: "",
+    tool_tip: "",
+  });
+
+  const [params, setParams] = useState<TestParam[]>([]);
+  const [hasEvidence, setHasEvidence] = useState<boolean>(false);
+
+  const addNewParams = (numberOfParams = 1) => {
+    const tmpParams = Array.from(
+      { length: numberOfParams },
+      (_, i) => i + 1,
+    )?.map((i) => ({
+      id: i,
+      name: "",
+      text: "",
+      tooltip: "",
+    }));
+
+    setParams(tmpParams);
+  };
+
+  // Only fetch test data if we're editing or creating a version
+  const { data } = useGetTest({
+    id: ((isEditing || isVersioning) && testId) || "",
+    token: keycloak?.token || "",
+    isRegistered: registered,
+  });
+
+  // Watch for changes in test_method_id to update the selected method
+  useEffect(() => {
+    if (test.test_method_id) {
+      const method = testMethods.find((m) => m.id === test.test_method_id);
+      if (method) {
+        addNewParams(method?.num_params);
+      }
+    }
+  }, [test.test_method_id, testMethods, testId, data]);
+
+  useEffect(() => {
+    if (testId && data) {
+      // split params
+      const paramNames = data?.test_params?.split("|") || [];
+      const paramTexts = data?.test_question?.split("|") || [];
+      const paramTips = data?.tool_tip?.split("|") || [];
+      const params: TestParam[] = [];
+
+      // Check if evidence exists in the loaded parameters
+      const evidenceIndex = paramNames?.indexOf("evidence");
+      const evidenceExists = evidenceIndex !== -1;
+      setHasEvidence(evidenceExists);
+
+      // Add all parameters except evidence to the params array
+      for (let i = 0; i < paramNames.length; i++) {
+        if (paramNames[i] !== "evidence") {
+          params.push({
+            id: i,
+            name: paramNames[i],
+            text: paramTexts[i],
+            tooltip: paramTips[i],
+          });
+        }
+      }
+
+      setTest(data);
+      setParams(params);
+    }
+  }, [data, testId]);
+
+  const updateParamTestDef = () => {
+    let names = "";
+    let text = "";
+    let tips = "";
+    const subParams = params.filter((item) => item.name !== "evidence");
+
+    // iterate over params (minus evidence) and update test def
+    subParams.forEach((item) => {
+      names === ""
+        ? (names = item.name)
+        : item?.name && (names = names + "|" + item.name);
+      text === ""
+        ? (text = item.text)
+        : item?.text && (text = text + "|" + item.text);
+      tips === ""
+        ? (tips = item.tooltip)
+        : item?.tooltip && (tips = tips + "|" + item.tooltip);
+    });
+
+    // Add evidence parameter if toggle is on
+    if (hasEvidence) {
+      names = names === "" ? "evidence" : names + "|evidence";
+    }
+
+    setTest((test) => ({
+      ...test,
+      test_question: text,
+      test_params: names,
+      tool_tip: tips,
+    }));
+  };
+
+  const updateParam = (id: number, field: keyof TestParam, value: string) => {
+    setParams((prevParams) =>
+      prevParams.map((param) =>
+        param.id === id ? { ...param, [field]: value } : param,
+      ),
+    );
+  };
+
+  const getSearchString = () => {
+    if (filterType === "manual") {
+      return "Manual";
+    } else if (filterType === "automated") {
+      return "Auto";
+    }
+    return "";
+  };
+
+  const {
+    data: testMethodsData,
+    fetchNextPage: tmFetchNextPage,
+    hasNextPage: tmHasNextPage,
+    refetch: refetchTestMethods,
+  } = useGetAllTestMethods({
+    size: 5,
+    token: keycloak?.token || "",
+    isRegistered: registered,
+    search: getSearchString(),
+  });
+
+  useEffect(() => {
+    // gather all test methods
+    let tmpTestMethods: RegistryResource[] = [];
+
+    // iterate over backend pages and gather all items in the metric types array
+    if (testMethodsData?.pages) {
+      testMethodsData.pages.map((page) => {
+        tmpTestMethods = [...tmpTestMethods, ...page.content];
+      });
+      if (tmHasNextPage) {
+        tmFetchNextPage();
+      }
+    }
+
+    tmpTestMethods = tmpTestMethods?.filter(
+      (testMethod) =>
+        testMethod?.label !== "String-Auto" &&
+        testMethod?.label !== "String-Manual",
+    );
+
+    setTestMethods(tmpTestMethods);
+  }, [testMethodsData, tmHasNextPage, tmFetchNextPage]);
+
+  function handleValidate() {
+    setShowErrors(true);
+    return test.tes !== "" && test.label !== "";
+  }
+
+  const mutateCreate = useCreateTest(keycloak?.token || "", test);
+
+  const mutateUpdate = useUpdateTest(keycloak?.token || "", testId || "", test);
+
+  const mutateCreateVersion = useCreateTestVersion({
+    token: keycloak?.token || "",
+    id: testId || "",
+    test,
+  });
+
+  function handleCreate() {
+    updateParamTestDef();
+    const promise = mutateCreate
+      .mutateAsync()
+      .catch((err) => {
+        alert.current = {
+          message: "Error: " + err.response.data.message,
+        };
+        throw err;
+      })
+      .then(() => {
+        alert.current = {
+          message: t("page_tests.toast_create_success"),
+        };
+        // Navigate back to tests list after successful creation
+        setTimeout(() => {
+          navigate("/admin/tests");
+        }, 1500);
+      });
+    toast.promise(promise, {
+      loading: t("page_tests.toast_create_progress"),
+      success: () => `${alert.current.message}`,
+      error: () => `${alert.current.message}`,
+    });
+  }
+
+  function handleUpdate() {
+    updateParamTestDef();
+    const promise = mutateUpdate
+      .mutateAsync()
+      .catch((err) => {
+        alert.current = {
+          message: "Error: " + err.response.data.message,
+        };
+        throw err;
+      })
+      .then(() => {
+        alert.current = {
+          message: t("page_tests.toast_update_success"),
+        };
+        // Navigate back to tests list after successful update
+        setTimeout(() => {
+          navigate("/admin/tests");
+        }, 1500);
+      });
+    toast.promise(promise, {
+      loading: t("page_tests.toast_update_progress"),
+      success: () => `${alert.current.message}`,
+      error: () => `${alert.current.message}`,
+    });
+  }
+
+  function handleCreateNewVersion() {
+    updateParamTestDef();
+    const promise = mutateCreateVersion
+      .mutateAsync()
+      .catch((err) => {
+        alert.current = {
+          message: "Error: " + err.response.data.message,
+        };
+        throw err;
+      })
+      .then(() => {
+        alert.current = {
+          message: t("page_tests.toast_create_version_success"),
+        };
+        // Navigate back to tests list after successful version creation
+        setTimeout(() => {
+          navigate("/admin/tests");
+        }, 1500);
+      });
+    toast.promise(promise, {
+      loading: t("page_tests.toast_create_version_progress"),
+      success: () => `${alert.current.message}`,
+      error: () => `${alert.current.message}`,
+    });
+  }
+
+  const areParamsDisabled =
+    test.test_method_id === "" || test.test_method_id == null;
+
+  // Add handlers for search and filter functionality with debounce
+  const handleSearchChange = (value: string) => {
+    setSearchTerm(value);
+    setIsSearching(true);
+
+    // Clear previous timeout
+    if (searchTimeoutRef.current) {
+      clearTimeout(searchTimeoutRef.current);
+    }
+
+    // Set new timeout for debounce (300ms)
+    searchTimeoutRef.current = setTimeout(() => {
+      const filteredMethods =
+        testMethodsData?.pages
+          .flatMap((page) => page.content)
+          .filter((method) =>
+            method.label.toLowerCase().includes(value.toLowerCase()),
+          ) || [];
+      setTestMethods(filteredMethods);
+      setIsSearching(false);
+    }, 300);
+  };
+
+  const handleFilterChange = (value: string) => {
+    setFilterType(value);
+    setIsSearching(true);
+    refetchTestMethods().finally(() => {
+      setIsSearching(false);
+    });
+  };
+
+  return (
+    <TestModalContainer
+      id={testId}
+      isEditing={isEditing}
+      isVersioning={isVersioning}
+      testMethods={testMethods}
+      showErrors={showErrors}
+      test={test}
+      params={params}
+      hasEvidence={hasEvidence}
+      areParamsDisabled={areParamsDisabled}
+      searchTerm={searchTerm}
+      filterType={filterType}
+      isSearching={isSearching}
+      setTest={setTest}
+      setHasEvidence={setHasEvidence}
+      updateParam={updateParam}
+      handleValidate={handleValidate}
+      handleCreate={handleCreate}
+      handleUpdate={handleUpdate}
+      handleCreateNewVersion={handleCreateNewVersion}
+      handleSearchChange={handleSearchChange}
+      handleFilterChange={handleFilterChange}
+    />
+  );
+}
+
+export default CreateTest;

--- a/src/pages/tests/components/TestHeaderForm.tsx
+++ b/src/pages/tests/components/TestHeaderForm.tsx
@@ -1,11 +1,4 @@
-import {
-  Col,
-  InputGroup,
-  OverlayTrigger,
-  Row,
-  Tooltip,
-  Form,
-} from "react-bootstrap";
+import { OverlayTrigger, Tooltip } from "react-bootstrap";
 import { FaInfoCircle } from "react-icons/fa";
 import { useTranslation } from "react-i18next";
 import { TestInput } from "@/types/tests";
@@ -23,105 +16,127 @@ function TestHeaderForm(props: TestHeaderFormProps) {
   const { t } = useTranslation();
 
   return (
-    <>
-      <Row>
-        <InputGroup className="mt-2">
-          <InputGroup.Text id="label-test-tes">
-            <OverlayTrigger
-              placement="top"
-              overlay={
-                <Tooltip id={`tooltip-top`}>{t("page_tests.tip_tes")}</Tooltip>
-              }
+    <div className="test-header-form">
+      <div className="row gx-4 gy-0">
+        <div className="col-md-6">
+          <div className="form-group">
+            <label
+              htmlFor="input-test-tes"
+              className="d-flex align-items-center form-group-label"
             >
-              <span className="me-2 d-flex align-items-center">
-                <FaInfoCircle />
-              </span>
-            </OverlayTrigger>
-            <span>{t("fields.tes").toUpperCase()} (*):</span>
-          </InputGroup.Text>
-          <Form.Control
-            aria-describedby="label-metric-mtr"
-            id="input-test-tes"
-            disabled={isEditing || isVersioning}
-            onChange={(e) => {
-              setTest({
-                ...test,
-                tes: e.target.value,
-              });
-            }}
-            value={test.tes}
-          />
-        </InputGroup>
-        {showErrors && test.tes === "" && (
-          <span className="text-danger">{t("required")}</span>
-        )}
-        <InputGroup className="mt-2">
-          <InputGroup.Text id="label-test-label">
-            <OverlayTrigger
-              placement="top"
-              overlay={
-                <Tooltip id={`tooltip-top`}>
-                  {t("page_tests.tip_label")}
-                </Tooltip>
-              }
-            >
-              <span className="me-2 d-flex align-items-center">
-                <FaInfoCircle />
-              </span>
-            </OverlayTrigger>
-            <span>{t("fields.label")} (*):</span>
-          </InputGroup.Text>
-          <Form.Control
-            id="input-test-label"
-            aria-describedby="label-test-label"
-            value={test.label}
-            onChange={(e) => {
-              setTest({
-                ...test,
-                label: e.target.value,
-              });
-            }}
-          />
-        </InputGroup>
-        {showErrors && test.label === "" && (
-          <span className="text-danger">{t("required")}</span>
-        )}
-      </Row>
-      <Row className="mt-2">
-        <Col>
-          <div className="d-flex">
-            <OverlayTrigger
-              placement="top"
-              overlay={
-                <Tooltip id={`tooltip-top`}>
-                  {t("page_tests.tip_test_description")}
-                </Tooltip>
-              }
-            >
-              <span className="ms-1 me-2 d-flex align-items-center">
-                <FaInfoCircle />
-              </span>
-            </OverlayTrigger>
-            <span>{t("fields.description")} (*):</span>
+              <span className="fw-medium">{t("fields.tes").toUpperCase()}</span>
+              <span className="ms-1 text-danger">*</span>
+              <OverlayTrigger
+                placement="top"
+                overlay={
+                  <Tooltip id="tooltip-tes">{t("page_tests.tip_tes")}</Tooltip>
+                }
+              >
+                <span className="ms-1">
+                  <FaInfoCircle style={{ marginBottom: "3px" }} />
+                </span>
+              </OverlayTrigger>
+            </label>
+            <input
+              className={`form-control ${showErrors && test.tes === "" ? "is-invalid" : ""}`}
+              type="text"
+              id="input-test-tes"
+              disabled={isEditing || isVersioning}
+              onChange={(e) => {
+                setTest({
+                  ...test,
+                  tes: e.target.value,
+                });
+              }}
+              value={test.tes}
+            />
+            {showErrors && test.tes === "" && (
+              <div className="invalid-feedback">{t("required")}</div>
+            )}
           </div>
-          <Form.Control
-            className="mt-1"
-            as="textarea"
-            rows={2}
-            value={test.description}
-            onChange={(e) => {
-              setTest({
-                ...test,
-                description: e.target.value,
-              });
-            }}
-          />
-          {showErrors && test.description === "" && (
-            <span className="text-danger">{t("required")}</span>
-          )}
-        </Col>
-      </Row>
-    </>
+        </div>
+
+        <div className="col-md-6">
+          <div className="form-group">
+            <label
+              htmlFor="input-test-label"
+              className="d-flex align-items-center form-group-label"
+            >
+              <span className="fw-medium">{t("fields.label")}</span>
+              <span className="ms-1 text-danger">*</span>
+              <OverlayTrigger
+                placement="top"
+                overlay={
+                  <Tooltip id="tooltip-label">
+                    {t("page_tests.tip_label")}
+                  </Tooltip>
+                }
+              >
+                <span className="ms-1">
+                  <FaInfoCircle style={{ marginBottom: "3px" }} />
+                </span>
+              </OverlayTrigger>
+            </label>
+            <input
+              type="text"
+              id="input-test-label"
+              value={test.label}
+              onChange={(e) => {
+                setTest({
+                  ...test,
+                  label: e.target.value,
+                });
+              }}
+              className={`form-control ${showErrors && test.label === "" ? "is-invalid" : ""}`}
+            />
+            {showErrors && test.label === "" && (
+              <div className="invalid-feedback">{t("required")}</div>
+            )}
+          </div>
+        </div>
+
+        <div className="col-12">
+          <div className="form-group">
+            <label
+              htmlFor="input-test-description"
+              className="d-flex align-items-center form-group-label"
+            >
+              <span className="fw-medium">{t("fields.description")}</span>
+              <OverlayTrigger
+                placement="top"
+                overlay={
+                  <Tooltip id="tooltip-description">
+                    {t("page_tests.tip_description")}
+                  </Tooltip>
+                }
+              >
+                <span className="ms-1">
+                  <FaInfoCircle style={{ marginBottom: "3px" }} />
+                </span>
+              </OverlayTrigger>
+            </label>
+            <textarea
+              id="input-test-description"
+              rows={2}
+              value={test.description}
+              onChange={(e) => {
+                setTest({
+                  ...test,
+                  description: e.target.value,
+                });
+              }}
+              className={`form-control ${
+                showErrors && test.description === "" ? "is-invalid" : ""
+              }`}
+              style={{ minHeight: "60px" }}
+            />
+            {showErrors && test.description === "" && (
+              <div className="invalid-feedback">{t("required")}</div>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
   );
 }
 

--- a/src/pages/tests/components/TestMethodAndParams.tsx
+++ b/src/pages/tests/components/TestMethodAndParams.tsx
@@ -1,19 +1,8 @@
-import {
-  OverlayTrigger,
-  Row,
-  Tooltip,
-  Col,
-  InputGroup,
-  Form,
-  Button,
-} from "react-bootstrap";
-import { FaInfoCircle, FaTrash } from "react-icons/fa";
-import { RegistryResource } from "@/types";
+import { OverlayTrigger, Tooltip, Form } from "react-bootstrap";
+import { FaInfoCircle } from "react-icons/fa";
 import { TestInput, TestParam } from "@/types/tests";
-import { useTranslation } from "react-i18next";
 
 interface TestMethodAndParamsProps {
-  testMethods: RegistryResource[];
   showErrors: boolean;
   test: TestInput;
   params: TestParam[];
@@ -21,238 +10,131 @@ interface TestMethodAndParamsProps {
   areParamsDisabled: boolean;
   setTest: (value: TestInput) => void;
   setHasEvidence: (value: boolean) => void;
-  addNewParam: () => void;
   updateParam: (id: number, field: keyof TestParam, value: string) => void;
-  removeParam: (id: number) => void;
 }
 
 function TestMethodAndParams(props: TestMethodAndParamsProps) {
   const {
-    testMethods,
-    showErrors,
-    test,
     params,
     hasEvidence,
     areParamsDisabled,
-    setTest,
     setHasEvidence,
-    addNewParam,
     updateParam,
-    removeParam,
   } = props;
-  const { t } = useTranslation();
 
   return (
-    <>
-      <Row>
-        <Col className="mb-1">
-          <InputGroup className="mt-2">
-            <InputGroup.Text id="label-test-method">
-              <OverlayTrigger
-                placement="top"
-                overlay={
-                  <Tooltip id={`tooltip-top`}>
-                    {t("page_tests.tip_test_method")}
-                  </Tooltip>
-                }
-              >
-                <span className="me-2 d-flex align-items-center">
-                  <FaInfoCircle />
-                </span>
-              </OverlayTrigger>
-              {t("page_tests.test_method")} (*):
-            </InputGroup.Text>
-            <Form.Select
-              id="input-test-method"
-              aria-describedby="label-test-method"
-              placeholder={t("page_tests.select_test_method")}
-              onChange={(e) => {
-                setTest({
-                  ...test,
-                  test_method_id: e.target.value,
-                });
-              }}
-              value={test.test_method_id ? test.test_method_id : ""}
+    <div className="mt-3">
+      <div className="mb-3">
+        <div className="d-flex align-items-center gap-3">
+          <div className="d-flex align-items-center">
+            <span className="fw-medium form-group-label">
+              Evidence parameter
+            </span>
+            <OverlayTrigger
+              placement="top"
+              overlay={
+                <Tooltip id="evidence-tooltip">
+                  Please provide an evidence of via a public source or URL to
+                  validate the information with an official reference.
+                </Tooltip>
+              }
             >
-              <>
-                <option value="" disabled>
-                  {t("page_tests.select_test_method")}
-                </option>
-                {testMethods.map((item) => (
-                  <option key={item.id} value={item.id}>
-                    {item.label}
-                  </option>
-                ))}
-              </>
-            </Form.Select>
-          </InputGroup>
-          {showErrors && test.test_method_id === "" && (
-            <span className="text-danger">{t("required")}</span>
-          )}
-          {test.test_method_id != "" && (
-            <div className="bg-light text-secondary border rounded mt-2 p-3">
-              <small>
-                {
-                  testMethods.find((item) => item.id == test.test_method_id)
-                    ?.description
-                }
-              </small>
-            </div>
-          )}
-        </Col>
-      </Row>
-      <Row className="mt-2">
-        <div className="border-top p-2 ms-2">
-          <div className="d-flex align-items-center mb-3 mt-2">
-            <div className="me-3 d-flex align-items-center">
-              <span className="me-1 ">Evidence parameter</span>
-              <OverlayTrigger
-                placement="top"
-                overlay={
-                  <Tooltip id="evidence-tooltip">
-                    Please provide an evidence of via a public source or URL to
-                    validate the information with an official reference.
-                  </Tooltip>
-                }
-              >
-                <span>
-                  <FaInfoCircle className="mb-1" />
-                </span>
-              </OverlayTrigger>
-            </div>
-            {areParamsDisabled ? (
-              <OverlayTrigger
-                placement="top"
-                overlay={
-                  <Tooltip id="toggle-tooltip">
-                    You must select a test method before adding an evidence
-                    parameter
-                  </Tooltip>
-                }
-              >
-                <Form.Check
-                  aria-label="evidence-toggle"
-                  checked={hasEvidence}
-                  id="evidence-toggle"
-                  isValid
-                  onChange={(e) => {
-                    console.log("e.target.checked", e.target.checked);
-                    if (e.target.checked && areParamsDisabled) {
-                      return;
-                    }
-                    setHasEvidence(e.target.checked);
-                  }}
-                  type="switch"
-                />
-              </OverlayTrigger>
-            ) : (
+              <span className="ms-1">
+                <FaInfoCircle className="mb-1" />
+              </span>
+            </OverlayTrigger>
+          </div>
+          {areParamsDisabled ? (
+            <OverlayTrigger
+              placement="top"
+              overlay={
+                <Tooltip id="evidence-toggle-tooltip">
+                  You must select a test method before adding an evidence
+                  parameter
+                </Tooltip>
+              }
+            >
               <Form.Check
                 aria-label="evidence-toggle"
                 checked={hasEvidence}
                 id="evidence-toggle"
-                isValid
+                disabled={areParamsDisabled}
                 onChange={(e) => {
-                  setHasEvidence(e.target.checked);
+                  if (!areParamsDisabled) {
+                    setHasEvidence(e.target.checked);
+                  }
                 }}
                 type="switch"
               />
-            )}
-          </div>
-          <div className="d-flex align-items-center mb-3">
-            <span>{t("page_tests.parameters")}:</span>
-            {areParamsDisabled ? (
-              <OverlayTrigger
-                placement="top"
-                overlay={
-                  <Tooltip id="toggle-tooltip">
-                    You must select a test method before adding parameters
-                  </Tooltip>
-                }
-              >
-                <Button
-                  className="ms-2"
-                  size="sm"
-                  variant="success"
-                  onClick={() => {
-                    if (areParamsDisabled) {
-                      return;
-                    }
-                    addNewParam();
-                  }}
-                >
-                  {t("page_tests.parameters_add")}
-                </Button>
-              </OverlayTrigger>
-            ) : (
-              <Button
-                className="ms-2"
-                size="sm"
-                variant="success"
-                onClick={() => {
-                  addNewParam();
-                }}
-              >
-                {t("page_tests.parameters_add")}
-              </Button>
-            )}
-          </div>
+            </OverlayTrigger>
+          ) : (
+            <Form.Check
+              aria-label="evidence-toggle"
+              checked={hasEvidence}
+              id="evidence-toggle"
+              onChange={(e) => {
+                setHasEvidence(e.target.checked);
+              }}
+              type="switch"
+            />
+          )}
+        </div>
+      </div>
 
-          {params?.length > 0 &&
-            params.map((param, index) => (
-              <div key={`param-group-${param.id}`}>
-                <div className="d-flex flex-column gap-2">
-                  <div className="w-100 d-flex justify-content-between gap-3">
-                    <Form.Control
-                      id={`param-${param.id}-name`}
-                      value={param.name}
-                      onChange={(e) => {
-                        updateParam(param.id, "name", e.target.value);
-                      }}
-                      placeholder="Name (*)"
-                      size="sm"
-                      className="w-50"
-                    />
-                    <Button
-                      size="sm"
-                      variant="danger"
-                      onClick={() => {
-                        removeParam(param.id);
-                      }}
-                    >
-                      <FaTrash />
-                    </Button>
-                  </div>
+      <div className="d-flex justify-content-between align-items-center mb-1">
+        <span className="fw-medium form-group-label">Test Parameters</span>
+      </div>
 
-                  <Form.Control
-                    as="textarea"
-                    rows={2}
-                    id={`param-${param.id}-text`}
-                    value={param.text}
+      {params?.length > 0 &&
+        params.map((param, index) => (
+          <div key={`param-group-${param.id}`} className="mb-1">
+            <div className="d-flex flex-column">
+              <div className="d-flex justify-content-between align-items-start">
+                <div className="form-group mb-2 w-100">
+                  <input
+                    type="text"
+                    id={`param-${param.id}-name`}
+                    value={param?.name || ""}
                     onChange={(e) => {
-                      updateParam(param.id, "text", e.target.value);
+                      updateParam(param.id, "name", e.target.value);
                     }}
-                    placeholder="Test Question (*)"
-                    size="sm"
-                  />
-
-                  <Form.Control
-                    as="textarea"
-                    rows={2}
-                    id={`param-${param.id}-tooltip`}
-                    value={param.tooltip}
-                    onChange={(e) => {
-                      updateParam(param.id, "tooltip", e.target.value);
-                    }}
-                    placeholder="Tooltip / Guidance for the end user"
-                    size="sm"
+                    placeholder="Parameter Name *"
+                    className="form-control"
+                    disabled={areParamsDisabled}
                   />
                 </div>
-                {index < params?.length - 1 && <hr className="my-4" />}
               </div>
-            ))}
-        </div>
-      </Row>
-    </>
+              <div className="form-group mb-2">
+                <textarea
+                  id={`param-${param.id}-text`}
+                  rows={2}
+                  value={param?.text || ""}
+                  onChange={(e) => {
+                    updateParam(param.id, "text", e.target.value);
+                  }}
+                  placeholder="Question Text *"
+                  className="form-control"
+                  disabled={areParamsDisabled}
+                />
+              </div>
+              <div className="form-group">
+                <textarea
+                  id={`param-${param.id}-tooltip`}
+                  rows={2}
+                  value={param?.tooltip || ""}
+                  onChange={(e) => {
+                    updateParam(param.id, "tooltip", e.target.value);
+                  }}
+                  placeholder="Help Text"
+                  className="form-control"
+                  disabled={areParamsDisabled}
+                />
+              </div>
+            </div>
+            {index + 1 < params.length && <hr className="my-3" />}
+          </div>
+        ))}
+    </div>
   );
 }
 

--- a/src/pages/tests/components/TestModalContainer.tsx
+++ b/src/pages/tests/components/TestModalContainer.tsx
@@ -1,4 +1,4 @@
-import { Modal, Button } from "react-bootstrap";
+import { Button } from "react-bootstrap";
 import { FaFile, FaEdit, FaCodeBranch } from "react-icons/fa";
 import { RegistryResource } from "@/types";
 import { TestInput, TestParam } from "@/types/tests";
@@ -8,176 +8,318 @@ import TestHeaderForm from "./TestHeaderForm";
 import TestMethodAndParams from "./TestMethodAndParams";
 
 export interface TestModalUIProps {
-  id: string;
-  show: boolean;
+  id?: string;
+  show?: boolean;
+  onHide?: () => void;
+  addNewParam?: () => void;
+  removeParam?: (id: number) => void;
   isEditing?: boolean;
   isVersioning?: boolean;
-  onHide: () => void;
   testMethods: RegistryResource[];
   showErrors: boolean;
   test: TestInput;
   params: TestParam[];
   hasEvidence: boolean;
   areParamsDisabled: boolean;
+  searchTerm?: string;
+  filterType?: string;
+  isSearching?: boolean;
   setTest: (value: TestInput) => void;
   setHasEvidence: (value: boolean) => void;
-  addNewParam: () => void;
   updateParam: (id: number, field: keyof TestParam, value: string) => void;
-  removeParam: (id: number) => void;
   handleValidate: () => boolean;
   handleCreate: () => void;
   handleUpdate: () => void;
   handleCreateNewVersion: () => void;
+  handleSearchChange?: (value: string) => void;
+  handleFilterChange?: (value: string) => void;
 }
 
 function TestModalContainer(props: TestModalUIProps) {
   const {
     id,
-    show,
     isEditing,
     isVersioning,
-    onHide,
     testMethods,
     showErrors,
     test,
     params,
     hasEvidence,
     areParamsDisabled,
+    searchTerm = "",
+    filterType = "all",
+    isSearching = false,
     setTest,
     setHasEvidence,
-    addNewParam,
     updateParam,
-    removeParam,
     handleValidate,
     handleCreate,
     handleUpdate,
     handleCreateNewVersion,
+    handleSearchChange,
+    handleFilterChange,
   } = props;
+
+  console.log("test:", test);
 
   const { t } = useTranslation();
 
   return (
-    <Modal
-      show={show}
-      onHide={onHide}
-      size="xl"
-      aria-labelledby="contained-modal-title-vcenter"
-      centered
-      scrollable
-    >
-      <Modal.Header closeButton>
-        <Modal.Title
-          className="d-flex align-items-center gap-1"
-          id="contained-modal-title-vcenter"
-        >
-          {id && isVersioning ? (
-            <>
-              <FaCodeBranch className="me-2" />
-              {t("page_tests.create_new_version")}
-            </>
-          ) : id && isEditing ? (
-            <>
-              <FaEdit className="me-2" />
-              {t("page_tests.update")}
-            </>
-          ) : (
-            <>
-              <FaFile className="me-2" />
-              {t("page_tests.create_new")}
-            </>
-          )}
-        </Modal.Title>
-      </Modal.Header>
-      <Modal.Body
-        style={{
-          display: "flex",
-          gap: "1rem",
-        }}
-      >
-        <div style={{ width: "50%" }}>
-          <TestHeaderForm
-            isEditing={isEditing}
-            isVersioning={isVersioning}
-            setTest={setTest}
-            showErrors={showErrors}
-            test={test}
-          />
-          <TestMethodAndParams
-            testMethods={testMethods}
-            test={test}
-            setTest={setTest}
-            params={params}
-            showErrors={showErrors}
-            setHasEvidence={setHasEvidence}
-            hasEvidence={hasEvidence}
-            areParamsDisabled={areParamsDisabled}
-            addNewParam={addNewParam}
-            updateParam={updateParam}
-            removeParam={removeParam}
-          />
+    <div className="test-container py-3 px-5">
+      <div className="row mb-3">
+        <div className="col-12">
+          <div className="d-flex align-items-center">
+            <h2>
+              {id && isVersioning ? (
+                <>
+                  <FaCodeBranch className="me-2" />
+                  {t("page_tests.create_new_version")}
+                </>
+              ) : id && isEditing ? (
+                <>
+                  <FaEdit className="me-2" />
+                  {t("page_tests.update")}
+                </>
+              ) : (
+                <>
+                  <FaFile className="me-2" />
+                  {t("page_tests.create_new")}
+                </>
+              )}
+            </h2>
+          </div>
         </div>
-        <div
-          style={{
-            width: "1px",
-            height: "auto",
-            backgroundColor: "#ccc",
-            margin: "0 1rem",
-            position: "sticky",
-            top: 0,
-          }}
-        ></div>
-        <div style={{ width: "50%" }}>
-          <TestPreviewModal
-            test={test}
-            params={params}
-            testMethodName={
-              testMethods.find((m) => m.id === test?.test_method_id)?.label
-            }
-            hasEvidenceParam={hasEvidence}
-          />
-        </div>
-      </Modal.Body>
+      </div>
 
-      <Modal.Footer className="d-flex justify-content-between">
-        <Button className="btn-secondary" onClick={onHide}>
-          {t("buttons.cancel")}
-        </Button>
-        {id && isVersioning ? (
-          <Button
-            className="btn-success"
-            onClick={() => {
-              if (handleValidate() === true) {
-                handleCreateNewVersion();
-              }
-            }}
-          >
-            {t("buttons.create_version")}
-          </Button>
-        ) : id && isEditing ? (
-          <Button
-            className="btn-success"
-            onClick={() => {
-              if (handleValidate() === true) {
-                handleUpdate();
-              }
-            }}
-          >
-            {t("buttons.update")}
-          </Button>
-        ) : (
-          <Button
-            className="btn-success"
-            onClick={() => {
-              if (handleValidate() === true) {
-                handleCreate();
-              }
-            }}
-          >
-            {t("buttons.create")}
-          </Button>
-        )}
-      </Modal.Footer>
-    </Modal>
+      <div className="row g-4 mb-4">
+        <div className="col-md-4 col-lg-3">
+          <div className="test-methods-sidebar-container border rounded-3 shadow-sm d-flex flex-column">
+            <div className="p-3 border-bottom bg-light flex-shrink-0 rounded-top-3">
+              <h6 className="mb-0 fw-bold test-section-header">Test Methods</h6>
+              <small className="test-header-description">
+                Select a test method to add to your assessment
+              </small>
+            </div>
+
+            {/* Search Box */}
+            <div className="my-2 px-3">
+              <input
+                type="text"
+                className="form-control form-control-sm rounded-2"
+                placeholder="Search test methods..."
+                value={searchTerm}
+                onChange={(e) => handleSearchChange?.(e.target.value)}
+              />
+            </div>
+
+            {/* Filter Type Radio Buttons */}
+            <div className="d-flex justify-content-center px-1 mb-2 gap-2">
+              <div className="form-check form-check-inline">
+                <input
+                  className="form-check-input"
+                  type="radio"
+                  id="filterAll"
+                  name="filterType"
+                  value="all"
+                  checked={filterType === "all"}
+                  onChange={() => handleFilterChange?.("all")}
+                />
+                <label className="form-check-label" htmlFor="filterAll">
+                  All
+                </label>
+              </div>
+              <div className="form-check form-check-inline">
+                <input
+                  className="form-check-input"
+                  type="radio"
+                  id="filterManual"
+                  name="filterType"
+                  value="manual"
+                  checked={filterType === "manual"}
+                  onChange={() => handleFilterChange?.("manual")}
+                />
+                <label className="form-check-label" htmlFor="filterManual">
+                  Manual Tests
+                </label>
+              </div>
+              <div className="form-check form-check-inline">
+                <input
+                  className="form-check-input"
+                  type="radio"
+                  id="filterAuto"
+                  name="filterType"
+                  value="automated"
+                  checked={filterType === "automated"}
+                  onChange={() => handleFilterChange?.("automated")}
+                />
+                <label className="form-check-label" htmlFor="filterAuto">
+                  Automated Tests
+                </label>
+              </div>
+            </div>
+
+            <div
+              className="test-methods-list flex-grow-1"
+              style={{
+                overflowY: "auto",
+                overflowX: "hidden",
+                minHeight: 0,
+                maxHeight: "100%",
+              }}
+            >
+              {isSearching ? (
+                <div className="test-method-spinner">
+                  <div
+                    className="spinner-border spinner-border-sm text-primary me-2"
+                    role="status"
+                  >
+                    <span className="visually-hidden">Loading...</span>
+                  </div>
+                  <span>Searching...</span>
+                </div>
+              ) : testMethods.length === 0 ? (
+                <div className="test-method-empty">
+                  No test methods found. Try adjusting your search criteria.
+                </div>
+              ) : (
+                testMethods.map((method) => (
+                  <div
+                    key={method.id}
+                    onClick={() =>
+                      setTest({ ...test, test_method_id: method.id })
+                    }
+                    className={`test-method-item border-bottom ${
+                      test.test_method_id === method.id ? "selected-method" : ""
+                    }`}
+                    style={{
+                      cursor: "pointer",
+                      borderLeft:
+                        test.test_method_id === method.id
+                          ? "3px solid #007bff"
+                          : "3px solid transparent",
+                    }}
+                    onMouseEnter={(e) => {
+                      if (test.test_method_id !== method.id) {
+                        e.currentTarget.style.background = "#f8f9fa";
+                      }
+                    }}
+                    onMouseLeave={(e) => {
+                      if (test.test_method_id !== method.id) {
+                        e.currentTarget.style.background = "transparent";
+                      }
+                    }}
+                  >
+                    <div className="fw-bold mb-1 test-method-label">
+                      {method.label}
+                    </div>
+                    <div className="test-method-description">
+                      {method.description}
+                    </div>
+                  </div>
+                ))
+              )}
+            </div>
+          </div>
+        </div>
+
+        {/* Configure Your Test Content Container */}
+        <div className="col-md-8 col-lg-9">
+          <div className="test-content-container border rounded-3 shadow-sm">
+            <div className="p-3 border-bottom bg-light flex-shrink-0 rounded-top-3">
+              <h6 className="mb-0 fw-bold test-section-header">
+                {testMethods.find((m) => m.id === test?.test_method_id)
+                  ?.label || "Configure your test"}
+              </h6>
+              <small className="test-header-description">
+                {test?.test_method_id
+                  ? "Configure test parameters and preview below"
+                  : "Select a test method from the left sidebar to get started"}
+              </small>
+            </div>
+            <div className="px-4 py-3">
+              <TestHeaderForm
+                isEditing={isEditing}
+                isVersioning={isVersioning}
+                setTest={setTest}
+                showErrors={showErrors}
+                test={test}
+              />
+              {test?.test_method_id && (
+                <TestMethodAndParams
+                  test={test}
+                  setTest={setTest}
+                  params={params}
+                  showErrors={showErrors}
+                  setHasEvidence={setHasEvidence}
+                  hasEvidence={hasEvidence}
+                  areParamsDisabled={areParamsDisabled}
+                  updateParam={updateParam}
+                />
+              )}
+              <hr className="my-3" />
+              <div className="test-preview-section">
+                <div className="mb-1 test-section-header">Preview Test</div>
+                <div className="border rounded bg-light p-3">
+                  <TestPreviewModal
+                    test={test}
+                    params={params}
+                    testMethodName={
+                      testMethods.find((m) => m.id === test?.test_method_id)
+                        ?.label
+                    }
+                    hasEvidenceParam={hasEvidence}
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="row mt-5">
+        <div className="col-12">
+          <div className="d-flex justify-content-between">
+            <Button className="btn btn-secondary" href="/admin/tests">
+              Back
+            </Button>
+            {id && isVersioning ? (
+              <Button
+                className="btn btn-success"
+                onClick={() => {
+                  if (handleValidate() === true) {
+                    handleCreateNewVersion();
+                  }
+                }}
+              >
+                {t("buttons.create_version")}
+              </Button>
+            ) : id && isEditing ? (
+              <Button
+                className="btn btn-success"
+                onClick={() => {
+                  if (handleValidate() === true) {
+                    handleUpdate();
+                  }
+                }}
+              >
+                {t("buttons.update")}
+              </Button>
+            ) : (
+              <Button
+                className="btn btn-success"
+                onClick={() => {
+                  if (handleValidate() === true) {
+                    handleCreate();
+                  }
+                }}
+              >
+                {t("buttons.create")}
+              </Button>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
   );
 }
 

--- a/src/pages/tests/components/TestPreviewModal.tsx
+++ b/src/pages/tests/components/TestPreviewModal.tsx
@@ -293,24 +293,18 @@ const TestPreviewModal: React.FC<TestPreviewProps> = ({
   };
 
   return (
-    <div
-      className="mt-1"
-      style={{ borderRadius: 0, border: "none", wordBreak: "break-word" }}
-    >
-      <div className="text-black">
-        <h4 className="mb-2">Test Preview</h4>
-      </div>
+    <div style={{ borderRadius: 0, border: "none", wordBreak: "break-word" }}>
       <div>
-        <div className="p-2 ps-0">
+        <div className="p-2">
           <div className="d-flex align-items-start mb-3">
             <div>
               <h5>
                 {test.tes || t("{TES Name placeholder}")} -{" "}
                 {test.label || t("{Test Label placeholder}")}
               </h5>
-              <p className="text-muted mb-2">
+              <h5 className="text-muted mb-2">
                 {test.description || t("{Test Description placeholder}")}
-              </p>
+              </h5>
               {testMethodName && (
                 <span className="badge bg-secondary me-1">
                   {testMethodName}
@@ -340,7 +334,7 @@ const TestPreviewModal: React.FC<TestPreviewProps> = ({
             {params.length > 0 ? (
               renderParams()
             ) : (
-              <p className="text-muted">{t("No parameters defined yet")}</p>
+              <h5 className="text-muted">{t("No parameters defined yet")}</h5>
             )}
           </div>
         </div>

--- a/src/pages/tests/components/TestsHeader.tsx
+++ b/src/pages/tests/components/TestsHeader.tsx
@@ -1,13 +1,8 @@
-import React from "react";
 import { Button } from "react-bootstrap";
 import { FaPlus } from "react-icons/fa";
 import { useTranslation } from "react-i18next";
 
-interface TestsHeaderProps {
-  onCreateTest: () => void;
-}
-
-const TestsHeader: React.FC<TestsHeaderProps> = ({ onCreateTest }) => {
+const TestsHeader = () => {
   const { t } = useTranslation();
 
   return (
@@ -19,7 +14,7 @@ const TestsHeader: React.FC<TestsHeaderProps> = ({ onCreateTest }) => {
         </h2>
       </div>
       <div className="col-md-auto cat-heading-right">
-        <Button variant="warning" onClick={onCreateTest}>
+        <Button href="/admin/tests/create-test" variant="warning">
           <FaPlus /> {t("buttons.create_new")}
         </Button>
       </div>

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -38,6 +38,7 @@ export interface RegistryResource {
   id: string;
   label: string;
   description: string;
+  num_params?: number;
 }
 
 export interface MetricResponse {
@@ -92,7 +93,10 @@ export type OrganisationRORSearchParams = ApiAuthOptions & {
   page?: number;
 };
 
-export type ApiOptions = ApiAuthOptions & ApiPaginationOptions;
+export type ApiOptions = ApiAuthOptions &
+  ApiPaginationOptions & {
+    search?: string;
+  };
 
 export type ApproveRejectProps = {
   toReject?: boolean;


### PR DESCRIPTION
This PR replaces the modal-based test creation interface with a full-page layout and separates test methods from the actual content

- Migrated from modal to dedicated page routes for test creation, editing, and versioning
- Implemented split layout with test methods sidebar and configuration content area
- Added test method search with debounce functionality and type filtering (All/Manual/Automated)
- Improved parameter handling based on selected test method's num_params field
- Updated navigation flow for better UX
- Verified test creation/editing functionality in full-page layout
- Confirmed search and filtering works as expected