### PR TITLE
[CAT-892] - Implement test method preview components and improve create test form UI

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -660,6 +660,11 @@ a.plain:hover {
   background: #e6f4ea;
 }
 
+.bg-danger-cat {
+  color: #b02a37 !important;
+  background: #f8d7da;
+}
+
 .bg-primary-cat {
   color: #1967d2 !important;
   background: #d2e3fc;
@@ -824,14 +829,14 @@ a.plain:hover {
 }
 
 .form-group-label {
-  margin-bottom: 0.2rem;
+  margin-bottom: 0.1rem;
   font-size: 16px;
   font-weight: 500;
   color: #555;
 }
 
 .test-methods-sidebar-container {
-  max-height: 85vh;
+  max-height: 80vh;
   overflow-y: auto;
 }
 

--- a/src/pages/assessments/components/tests/EvidenceURLS.tsx
+++ b/src/pages/assessments/components/tests/EvidenceURLS.tsx
@@ -48,8 +48,8 @@ export const EvidenceURLS = (props: EvidenceURLSProps) => {
         </small>
       )}
 
-      <Row cclassName="justify-content-md-right">
-        <Col md={11}>
+      <Row className="justify-content-md-right">
+        <Col md={10}>
           <InputGroup size="sm">
             <Form.Control
               id="input-add-url"
@@ -92,7 +92,6 @@ export const EvidenceURLS = (props: EvidenceURLSProps) => {
         </Col>
 
         <Col md={1}>
-          {" "}
           <span
             className={`btn btn-evidence text-evidence btn-sm float-right ${props?.isPreviewMode && "disabled"}`}
             onClick={handleAddURL}

--- a/src/pages/assessments/components/tests/TestAutoG069Form.tsx
+++ b/src/pages/assessments/components/tests/TestAutoG069Form.tsx
@@ -107,26 +107,33 @@ export const TestAutoG069Form = (props: AssessmentTestProps) => {
     <div>
       <Row>
         <Col>
-          <h6>
-            <small className="text-muted badge badge-pill border bg-light">
-              <span className="me-4">{props.test.id}</span>
-              {props.test.name}
-            </small>
-          </h6>
+          {props.test.id && (
+            <h6>
+              <small
+                className="text-muted badge badge-pill border bg-light"
+                style={{ textWrap: "wrap", textAlign: "start" }}
+              >
+                <span className="me-3">{props.test.id}</span>
+                {props.test.name}
+              </small>
+            </h6>
+          )}
         </Col>
         <Col xs={3} className="text-start"></Col>
       </Row>
 
       <Row>
         <div>
-          <h5>{textParams[0]}</h5>
+          {textParams[0] && <h5>{textParams[0]}</h5>}
           <InputGroup className="mt-1">
             <InputGroup.Text id="label-first-value">
-              <TestToolTip
-                tipId={"params-1-" + props.test.id}
-                tipText={tipParams[0]}
-              />
-              <span className="ms-2">{testParams[0]}</span>:
+              {tipParams[0] && (
+                <TestToolTip
+                  tipId={"params-1-" + props.test.id}
+                  tipText={tipParams[0]}
+                />
+              )}
+              {testParams[0] && <span className="ms-2">{testParams[0]}</span>}:
             </InputGroup.Text>
             <Form.Select
               value={localValue || ""}

--- a/src/pages/assessments/components/tests/TestAutoHttpsCheckForm.tsx
+++ b/src/pages/assessments/components/tests/TestAutoHttpsCheckForm.tsx
@@ -90,26 +90,30 @@ export const TestAutoHttpsCheckForm = (props: AssessmentTestProps) => {
     <div>
       <Row>
         <Col>
-          <h6>
-            <small className="text-muted badge badge-pill border bg-light">
-              <span className="me-4">{props.test.id}</span>
-              {props.test.name}
-            </small>
-          </h6>
+          {props.test.id && (
+            <h6>
+              <small className="text-muted badge badge-pill border bg-light">
+                {props.test.id && <span className="me-4">{props.test.id}</span>}
+                {props.test.name}
+              </small>
+            </h6>
+          )}
         </Col>
         <Col xs={3} className="text-start"></Col>
       </Row>
 
       <Row>
         <div>
-          <h5>{textParams[0]}</h5>
+          {textParams[0] && <h5>{textParams[0]}</h5>}
           <InputGroup className="mt-1">
             <InputGroup.Text id="label-first-value">
-              <TestToolTip
-                tipId={"params-1-" + props.test.id}
-                tipText={tipParams[0]}
-              />
-              <span className="ms-2">{testParams[0]}</span>:
+              {tipParams[0] && (
+                <TestToolTip
+                  tipId={"params-1-" + props.test.id}
+                  tipText={tipParams[0]}
+                />
+              )}
+              {testParams[0] && <span className="ms-2">{testParams[0]}</span>}:
             </InputGroup.Text>
             <Form.Control
               value={localValue || ""}
@@ -175,11 +179,13 @@ export const TestAutoHttpsCheckForm = (props: AssessmentTestProps) => {
         {testParams[testParams.length - 1] === "evidence" && (
           <div className="mt-2">
             <h6>
-              {textParams[1]}{" "}
-              <TestToolTip
-                tipId={"evidence-" + props.test.id}
-                tipText={tipParams[1]}
-              />
+              {textParams[1] && textParams[1]}{" "}
+              {tipParams[1] && (
+                <TestToolTip
+                  tipId={"evidence-" + props.test.id}
+                  tipText={tipParams[1]}
+                />
+              )}
             </h6>
             <EvidenceURLS
               urls={props.test.evidence_url || []}

--- a/src/pages/assessments/components/tests/TestAutoMd1Form.tsx
+++ b/src/pages/assessments/components/tests/TestAutoMd1Form.tsx
@@ -97,26 +97,30 @@ export const TestAutoMd1Form = (props: AssessmentTestProps) => {
     <div>
       <Row>
         <Col>
-          <h6>
-            <small className="text-muted badge badge-pill border bg-light">
-              <span className="me-4">{props.test.id}</span>
-              {props.test.name}
-            </small>
-          </h6>
+          {props.test.id && (
+            <h6>
+              <small className="text-muted badge badge-pill border bg-light">
+                {props.test.id && <span className="me-4">{props.test.id}</span>}
+                {props.test.name}
+              </small>
+            </h6>
+          )}
         </Col>
         <Col xs={3} className="text-start"></Col>
       </Row>
 
       <Row>
         <div>
-          <h5>{textParams[0]}</h5>
+          {textParams[0] && <h5>{textParams[0]}</h5>}
           <InputGroup className="mt-1">
             <InputGroup.Text id="label-first-value">
-              <TestToolTip
-                tipId={"params-1-" + props.test.id}
-                tipText={tipParams[0]}
-              />
-              <span className="ms-2">{testParams[0]}</span>:
+              {tipParams[0] && (
+                <TestToolTip
+                  tipId={"params-1-" + props.test.id}
+                  tipText={tipParams[0]}
+                />
+              )}
+              {testParams[0] && <span className="ms-2">{testParams[0]}</span>}:
             </InputGroup.Text>
             <Form.Control
               value={localValue || ""}
@@ -182,11 +186,13 @@ export const TestAutoMd1Form = (props: AssessmentTestProps) => {
         {testParams[testParams.length - 1] === "evidence" && (
           <div className="mt-2">
             <h6>
-              {textParams[1]}{" "}
-              <TestToolTip
-                tipId={"evidence-" + props.test.id}
-                tipText={tipParams[1]}
-              />
+              {textParams[1] && textParams[1]}{" "}
+              {tipParams[1] && (
+                <TestToolTip
+                  tipId={"evidence-" + props.test.id}
+                  tipText={tipParams[1]}
+                />
+              )}
             </h6>
             <EvidenceURLS
               urls={props.test.evidence_url || []}

--- a/src/pages/assessments/components/tests/TestBinaryParam.tsx
+++ b/src/pages/assessments/components/tests/TestBinaryParam.tsx
@@ -2,7 +2,6 @@
  * Component to display and edit a specific binary test with parameters
  */
 
-// import { useState } from "react"
 import { Form, Row, Col } from "react-bootstrap";
 import { EvidenceURLS } from "./EvidenceURLS";
 import { TestToolTip } from "./TestToolTip";
@@ -40,79 +39,85 @@ export const TestBinaryParamForm = (props: AssessmentTestProps) => {
   }
 
   // break parameters
-  const textParams = props.test.text.split("|");
-  const testDescription = props.test.description;
-  const tipParams = props.test.tool_tip.split("|");
-  const testParams = props.test.params.split("|");
+  const testDescription = props.test?.description;
+  const textParams = props.test.text?.split("|");
+  const tipParams = props.test.tool_tip?.split("|");
+  const testParams = props.test.params?.split("|");
 
   return (
     <div>
       <Row>
-        <Col>
-          <div className="flex items-start justify-between">
-            <div style={{ width: "80%" }}>
-              <div className="flex items-center gap-2">
-                <span className="cat-test-title ">
-                  <span className="">{props.test.id}</span> / {props.test.name}
-                  <span className="mt-2 p-2  fs-6">
-                    <TestToolTip
-                      tipId={"text-" + props.test.id}
-                      tipText={testDescription || ""}
-                    />
-                  </span>
-                </span>
-              </div>
-              <p className="mt-1 pe-4 fw-light fs-6 ">
-                {textParams[0]}{" "}
+        <div style={{ width: "75%" }}>
+          {props.test?.name && (
+            <div className="flex items-center gap-2">
+              <span className="cat-test-title ">
+                <span className="">{props.test.id}</span> / {props.test.name}
                 <span className="mt-2 p-2  fs-6">
                   <TestToolTip
                     tipId={"text-" + props.test.id}
-                    tipText={tipParams[0]}
+                    tipText={testDescription || ""}
                   />
                 </span>
-              </p>
+              </span>
             </div>
-            <div className="flex items-center gap-4" style={{ width: "20%" }}>
-              <Form className="form-binary-test" onSubmit={() => false}>
-                <Form.Check
-                  inline
-                  label={t("Yes")}
-                  value="1"
-                  name="test-input-group"
-                  type="radio"
-                  id="test-check-yes"
-                  className="fs-6 fw-bold  text-secondary"
-                  checked={props.test.value === true}
-                  onChange={handleValueChange}
-                />
-                <Form.Check
-                  inline
-                  label={t("No")}
-                  value="0"
-                  name="test-input-group"
-                  type="radio"
-                  className="fs-6 fw-bold  text-secondary"
-                  id="test-check-no"
-                  checked={props.test.value === false}
-                  onChange={handleValueChange}
-                />
-                {/* here ends the binary test */}
-              </Form>
-            </div>
-          </div>
-        </Col>
+          )}
+        </div>
       </Row>
-      <p></p>
+      <Row className="d-flex justify-content-between">
+        <div style={{ width: "70%", wordBreak: "break-word" }}>
+          {textParams?.[0] && (
+            <p className="mt-1 pe-4 fw-light fs-6 ">
+              {textParams[0]}{" "}
+              <span className="mt-2 p-2  fs-6">
+                <TestToolTip
+                  tipId={"text-" + props.test.id}
+                  tipText={tipParams[0]}
+                />
+              </span>
+            </p>
+          )}
+        </div>
+
+        <div style={{ width: "30%" }}>
+          {textParams?.[0] && (
+            <Form className="form-binary-test" onSubmit={() => false}>
+              <Form.Check
+                inline
+                label={t("fields.yes")}
+                value="1"
+                name="test-input-group"
+                type="radio"
+                id="test-check-yes"
+                className="fs-6 fw-bold  text-secondary"
+                checked={props.test.value === true}
+                onChange={handleValueChange}
+              />
+              <Form.Check
+                inline
+                label={t("fields.no")}
+                value="0"
+                name="test-input-group"
+                type="radio"
+                className="fs-6 fw-bold  text-secondary"
+                id="test-check-no"
+                checked={props.test.value === false}
+                onChange={handleValueChange}
+              />
+              {/* here ends the binary test */}
+            </Form>
+          )}
+        </div>
+      </Row>
       <div>
         <Row>
           <Col>
             {testParams[testParams.length - 1] === "evidence" && (
               <div className="mt-2">
                 <span className="fw-light-500 text-sm text-secondary">
-                  <strong>{textParams[1]} </strong>
+                  <strong>{textParams[textParams?.length - 1]}</strong>
                   <TestToolTip
                     tipId={"evidence-" + props.test.id}
-                    tipText={tipParams[1]}
+                    tipText={tipParams[tipParams?.length - 1]}
                   />
                 </span>
                 <EvidenceURLS

--- a/src/pages/assessments/components/tests/TestValueFormParam.tsx
+++ b/src/pages/assessments/components/tests/TestValueFormParam.tsx
@@ -114,12 +114,14 @@ export const TestValueFormParam = (props: AssessmentTestProps) => {
     <div>
       <Row>
         <Col>
-          <h6>
-            <small className="text-muted badge badge-pill border bg-light m">
-              <span className="me-4">{props.test.id}</span>
-              {props.test.name}
-            </small>
-          </h6>
+          {props.test.id && (
+            <h6>
+              <small className="text-muted badge badge-pill border bg-light m">
+                {props.test.id && <span className="me-4">{props.test.id}</span>}
+                {props.test.name}
+              </small>
+            </h6>
+          )}
         </Col>
         <Col xs={1} className="text-start"></Col>
       </Row>
@@ -127,7 +129,7 @@ export const TestValueFormParam = (props: AssessmentTestProps) => {
       <Row>
         <Col>
           <div>
-            <h5>{textParams[0]}</h5>
+            {textParams[0] && <h5>{textParams[0]}</h5>}
             {automated && (
               <Alert variant="warning">
                 <div>
@@ -149,11 +151,16 @@ export const TestValueFormParam = (props: AssessmentTestProps) => {
             <Row>
               <InputGroup className="mt-1">
                 <InputGroup.Text id="label-first-value">
-                  <TestToolTip
-                    tipId={"params-1-" + props.test.id}
-                    tipText={tipParams[0]}
-                  />
-                  <span className="ms-2">{testParams[0]}</span>:
+                  {tipParams[0] && (
+                    <TestToolTip
+                      tipId={"params-1-" + props.test.id}
+                      tipText={tipParams[0]}
+                    />
+                  )}
+                  {testParams[0] && (
+                    <span className="ms-2">{testParams[0]}</span>
+                  )}
+                  :
                 </InputGroup.Text>
                 <Form.Control
                   value={automated ? "" : localValue || ""}
@@ -174,11 +181,16 @@ export const TestValueFormParam = (props: AssessmentTestProps) => {
                 <Row className="mt-1">
                   <InputGroup className="mt-2">
                     <InputGroup.Text id="label-second-value">
-                      <TestToolTip
-                        tipId={"params-2-" + props.test.id}
-                        tipText={tipParams[1]}
-                      />
-                      <span className="ms-2">{testParams[1]}</span>:
+                      {tipParams[1] && (
+                        <TestToolTip
+                          tipId={"params-2-" + props.test.id}
+                          tipText={tipParams[1]}
+                        />
+                      )}
+                      {testParams[1] && (
+                        <span className="ms-2">{testParams[1]}</span>
+                      )}
+                      :
                     </InputGroup.Text>
                     <Form.Control
                       value={localThreshold || ""}
@@ -200,11 +212,16 @@ export const TestValueFormParam = (props: AssessmentTestProps) => {
                   <Row className="mt-1">
                     <InputGroup className="mt-2">
                       <InputGroup.Text id="label-second-value">
-                        <TestToolTip
-                          tipId={"params-3-" + props.test.id}
-                          tipText={tipParams[2]}
-                        />
-                        <span className="ms-2">{testParams[2]}</span>:
+                        {tipParams[2] && (
+                          <TestToolTip
+                            tipId={"params-3-" + props.test.id}
+                            tipText={tipParams[2]}
+                          />
+                        )}
+                        {testParams[2] && (
+                          <span className="ms-2">{testParams[2]}</span>
+                        )}
+                        :
                       </InputGroup.Text>
                       <Form.Control
                         value={localValue || ""}

--- a/src/pages/tests/components/CreateTest.tsx
+++ b/src/pages/tests/components/CreateTest.tsx
@@ -73,7 +73,7 @@ function CreateTest() {
 
   // Watch for changes in test_method_id to update the selected method
   useEffect(() => {
-    if (test.test_method_id) {
+    if (!testId && test.test_method_id) {
       const method = testMethods.find((m) => m.id === test.test_method_id);
       if (method) {
         addNewParams(method?.num_params);
@@ -87,7 +87,7 @@ function CreateTest() {
       const paramNames = data?.test_params?.split("|") || [];
       const paramTexts = data?.test_question?.split("|") || [];
       const paramTips = data?.tool_tip?.split("|") || [];
-      const params: TestParam[] = [];
+      const tmpParams: TestParam[] = [];
 
       // Check if evidence exists in the loaded parameters
       const evidenceIndex = paramNames?.indexOf("evidence");
@@ -97,7 +97,7 @@ function CreateTest() {
       // Add all parameters except evidence to the params array
       for (let i = 0; i < paramNames.length; i++) {
         if (paramNames[i] !== "evidence") {
-          params.push({
+          tmpParams.push({
             id: i,
             name: paramNames[i],
             text: paramTexts[i],
@@ -107,7 +107,7 @@ function CreateTest() {
       }
 
       setTest(data);
-      setParams(params);
+      setParams(tmpParams);
     }
   }, [data, testId]);
 
@@ -173,6 +173,15 @@ function CreateTest() {
   });
 
   useEffect(() => {
+    if (testMethods?.length > 0 && !test.test_method_id) {
+      setTest((prevTest) => ({
+        ...prevTest,
+        test_method_id: testMethods[0]?.id || "",
+      }));
+    }
+  }, [test.test_method_id, testMethods]);
+
+  useEffect(() => {
     // gather all test methods
     let tmpTestMethods: RegistryResource[] = [];
 
@@ -189,7 +198,8 @@ function CreateTest() {
     tmpTestMethods = tmpTestMethods?.filter(
       (testMethod) =>
         testMethod?.label !== "String-Auto" &&
-        testMethod?.label !== "String-Manual",
+        testMethod?.label !== "String-Manual" &&
+        testMethod?.label !== "Binary-Auto",
     );
 
     setTestMethods(tmpTestMethods);
@@ -315,6 +325,7 @@ function CreateTest() {
   };
 
   const handleFilterChange = (value: string) => {
+    setSearchTerm("");
     setFilterType(value);
     setIsSearching(true);
     refetchTestMethods().finally(() => {

--- a/src/pages/tests/components/TestMethodAndParams.tsx
+++ b/src/pages/tests/components/TestMethodAndParams.tsx
@@ -1,14 +1,12 @@
 import { OverlayTrigger, Tooltip, Form } from "react-bootstrap";
 import { FaInfoCircle } from "react-icons/fa";
-import { TestInput, TestParam } from "@/types/tests";
+import { TestParam } from "@/types/tests";
 
 interface TestMethodAndParamsProps {
   showErrors: boolean;
-  test: TestInput;
   params: TestParam[];
   hasEvidence: boolean;
   areParamsDisabled: boolean;
-  setTest: (value: TestInput) => void;
   setHasEvidence: (value: boolean) => void;
   updateParam: (id: number, field: keyof TestParam, value: string) => void;
 }
@@ -23,88 +21,39 @@ function TestMethodAndParams(props: TestMethodAndParamsProps) {
   } = props;
 
   return (
-    <div className="mt-3">
-      <div className="mb-3">
-        <div className="d-flex align-items-center gap-3">
-          <div className="d-flex align-items-center">
-            <span className="fw-medium form-group-label">
-              Evidence parameter
-            </span>
-            <OverlayTrigger
-              placement="top"
-              overlay={
-                <Tooltip id="evidence-tooltip">
-                  Please provide an evidence of via a public source or URL to
-                  validate the information with an official reference.
-                </Tooltip>
-              }
-            >
-              <span className="ms-1">
-                <FaInfoCircle className="mb-1" />
-              </span>
-            </OverlayTrigger>
-          </div>
-          {areParamsDisabled ? (
-            <OverlayTrigger
-              placement="top"
-              overlay={
-                <Tooltip id="evidence-toggle-tooltip">
-                  You must select a test method before adding an evidence
-                  parameter
-                </Tooltip>
-              }
-            >
-              <Form.Check
-                aria-label="evidence-toggle"
-                checked={hasEvidence}
-                id="evidence-toggle"
-                disabled={areParamsDisabled}
-                onChange={(e) => {
-                  if (!areParamsDisabled) {
-                    setHasEvidence(e.target.checked);
-                  }
-                }}
-                type="switch"
-              />
-            </OverlayTrigger>
-          ) : (
-            <Form.Check
-              aria-label="evidence-toggle"
-              checked={hasEvidence}
-              id="evidence-toggle"
-              onChange={(e) => {
-                setHasEvidence(e.target.checked);
-              }}
-              type="switch"
-            />
-          )}
-        </div>
-      </div>
-
-      <div className="d-flex justify-content-between align-items-center mb-1">
-        <span className="fw-medium form-group-label">Test Parameters</span>
-      </div>
-
+    <div className="mb-2">
       {params?.length > 0 &&
         params.map((param, index) => (
           <div key={`param-group-${param.id}`} className="mb-1">
-            <div className="d-flex flex-column">
-              <div className="d-flex justify-content-between align-items-start">
-                <div className="form-group mb-2 w-100">
-                  <input
-                    type="text"
-                    id={`param-${param.id}-name`}
-                    value={param?.name || ""}
-                    onChange={(e) => {
-                      updateParam(param.id, "name", e.target.value);
-                    }}
-                    placeholder="Parameter Name *"
-                    className="form-control"
-                    disabled={areParamsDisabled}
-                  />
-                </div>
+            <div className="col-md-6 w-100">
+              <div className="mb-1">
+                <label
+                  htmlFor="input-test-param-name"
+                  className="d-flex align-items-center form-group-label"
+                >
+                  <span className="fw-medium">Parameter Name</span>
+                  <span className="ms-1 text-danger">*</span>
+                </label>
+                <input
+                  type="text"
+                  id={`param-${param.id}-name`}
+                  value={param?.name || ""}
+                  onChange={(e) => {
+                    updateParam(param.id, "name", e.target.value);
+                  }}
+                  className="form-control"
+                  disabled={areParamsDisabled}
+                />
               </div>
-              <div className="form-group mb-2">
+
+              <div className="mb-1">
+                <label
+                  htmlFor="input-test-param-question"
+                  className="d-flex align-items-center form-group-label"
+                >
+                  <span className="fw-medium">Question</span>
+                  <span className="ms-1 text-danger">*</span>
+                </label>
                 <textarea
                   id={`param-${param.id}-text`}
                   rows={2}
@@ -112,12 +61,19 @@ function TestMethodAndParams(props: TestMethodAndParamsProps) {
                   onChange={(e) => {
                     updateParam(param.id, "text", e.target.value);
                   }}
-                  placeholder="Question Text *"
                   className="form-control"
                   disabled={areParamsDisabled}
                 />
               </div>
-              <div className="form-group">
+
+              <div className="mb-1">
+                <label
+                  htmlFor="input-test-param-help-text"
+                  className="d-flex align-items-center form-group-label"
+                >
+                  <span className="fw-medium">Help Text</span>
+                  <span className="ms-1 text-danger">*</span>
+                </label>
                 <textarea
                   id={`param-${param.id}-tooltip`}
                   rows={2}
@@ -125,7 +81,6 @@ function TestMethodAndParams(props: TestMethodAndParamsProps) {
                   onChange={(e) => {
                     updateParam(param.id, "tooltip", e.target.value);
                   }}
-                  placeholder="Help Text"
                   className="form-control"
                   disabled={areParamsDisabled}
                 />
@@ -134,6 +89,58 @@ function TestMethodAndParams(props: TestMethodAndParamsProps) {
             {index + 1 < params.length && <hr className="my-3" />}
           </div>
         ))}
+      <div className="d-flex align-items-center gap-3 mt-3">
+        <div className="d-flex align-items-center">
+          <span className="fw-medium form-group-label">Evidence parameter</span>
+          <OverlayTrigger
+            placement="top"
+            overlay={
+              <Tooltip id="evidence-tooltip">
+                Please provide an evidence of via a public source or URL to
+                validate the information with an official reference.
+              </Tooltip>
+            }
+          >
+            <span className="ms-1">
+              <FaInfoCircle className="mb-1" />
+            </span>
+          </OverlayTrigger>
+        </div>
+        {areParamsDisabled ? (
+          <OverlayTrigger
+            placement="top"
+            overlay={
+              <Tooltip id="evidence-toggle-tooltip">
+                You must select a test method before adding an evidence
+                parameter
+              </Tooltip>
+            }
+          >
+            <Form.Check
+              aria-label="evidence-toggle"
+              checked={hasEvidence}
+              id="evidence-toggle"
+              disabled={areParamsDisabled}
+              onChange={(e) => {
+                if (!areParamsDisabled) {
+                  setHasEvidence(e.target.checked);
+                }
+              }}
+              type="switch"
+            />
+          </OverlayTrigger>
+        ) : (
+          <Form.Check
+            aria-label="evidence-toggle"
+            checked={hasEvidence}
+            id="evidence-toggle"
+            onChange={(e) => {
+              setHasEvidence(e.target.checked);
+            }}
+            type="switch"
+          />
+        )}
+      </div>
     </div>
   );
 }

--- a/src/pages/tests/components/TestModalContainer.tsx
+++ b/src/pages/tests/components/TestModalContainer.tsx
@@ -1,9 +1,9 @@
 import { Button } from "react-bootstrap";
-import { FaFile, FaEdit, FaCodeBranch } from "react-icons/fa";
 import { RegistryResource } from "@/types";
 import { TestInput, TestParam } from "@/types/tests";
 import TestPreviewModal from "./TestPreviewModal";
 import { useTranslation } from "react-i18next";
+import { useNavigate } from "react-router-dom";
 import TestHeaderForm from "./TestHeaderForm";
 import TestMethodAndParams from "./TestMethodAndParams";
 
@@ -60,35 +60,23 @@ function TestModalContainer(props: TestModalUIProps) {
     handleFilterChange,
   } = props;
 
-  console.log("test:", test);
-
   const { t } = useTranslation();
+  const navigate = useNavigate();
+
+  const testMethodName = testMethods.find(
+    (m) => m.id === test?.test_method_id,
+  )?.label;
 
   return (
-    <div className="test-container py-3 px-5">
+    <div className="test-container py-3">
       <div className="row mb-3">
-        <div className="col-12">
-          <div className="d-flex align-items-center">
-            <h2>
-              {id && isVersioning ? (
-                <>
-                  <FaCodeBranch className="me-2" />
-                  {t("page_tests.create_new_version")}
-                </>
-              ) : id && isEditing ? (
-                <>
-                  <FaEdit className="me-2" />
-                  {t("page_tests.update")}
-                </>
-              ) : (
-                <>
-                  <FaFile className="me-2" />
-                  {t("page_tests.create_new")}
-                </>
-              )}
-            </h2>
-          </div>
-        </div>
+        <h2 className="text-muted cat-view-heading">
+          {id && isVersioning
+            ? t("page_tests.create_new_version")
+            : id && isEditing
+              ? t("page_tests.update")
+              : t("page_tests.create_new")}
+        </h2>
       </div>
 
       <div className="row g-4 mb-4">
@@ -113,7 +101,7 @@ function TestModalContainer(props: TestModalUIProps) {
             </div>
 
             {/* Filter Type Radio Buttons */}
-            <div className="d-flex justify-content-center px-1 mb-2 gap-2">
+            <div className="d-flex justify-content-center px-1 mb-1 gap-2">
               <div className="form-check form-check-inline">
                 <input
                   className="form-check-input"
@@ -139,7 +127,7 @@ function TestModalContainer(props: TestModalUIProps) {
                   onChange={() => handleFilterChange?.("manual")}
                 />
                 <label className="form-check-label" htmlFor="filterManual">
-                  Manual Tests
+                  Manual
                 </label>
               </div>
               <div className="form-check form-check-inline">
@@ -153,13 +141,13 @@ function TestModalContainer(props: TestModalUIProps) {
                   onChange={() => handleFilterChange?.("automated")}
                 />
                 <label className="form-check-label" htmlFor="filterAuto">
-                  Automated Tests
+                  Automated
                 </label>
               </div>
             </div>
-
+            <hr className="m-0" />
             <div
-              className="test-methods-list flex-grow-1"
+              className="test-methods-list flex-grow-1 mt-2"
               style={{
                 overflowY: "auto",
                 overflowX: "hidden",
@@ -185,9 +173,10 @@ function TestModalContainer(props: TestModalUIProps) {
                 testMethods.map((method) => (
                   <div
                     key={method.id}
-                    onClick={() =>
-                      setTest({ ...test, test_method_id: method.id })
-                    }
+                    onClick={() => {
+                      setTest({ ...test, test_method_id: method?.id || "" });
+                      setHasEvidence(false);
+                    }}
                     className={`test-method-item border-bottom ${
                       test.test_method_id === method.id ? "selected-method" : ""
                     }`}
@@ -227,8 +216,7 @@ function TestModalContainer(props: TestModalUIProps) {
           <div className="test-content-container border rounded-3 shadow-sm">
             <div className="p-3 border-bottom bg-light flex-shrink-0 rounded-top-3">
               <h6 className="mb-0 fw-bold test-section-header">
-                {testMethods.find((m) => m.id === test?.test_method_id)
-                  ?.label || "Configure your test"}
+                Configure Your Test
               </h6>
               <small className="test-header-description">
                 {test?.test_method_id
@@ -244,22 +232,36 @@ function TestModalContainer(props: TestModalUIProps) {
                 showErrors={showErrors}
                 test={test}
               />
-              {test?.test_method_id && (
-                <TestMethodAndParams
-                  test={test}
-                  setTest={setTest}
-                  params={params}
-                  showErrors={showErrors}
-                  setHasEvidence={setHasEvidence}
-                  hasEvidence={hasEvidence}
-                  areParamsDisabled={areParamsDisabled}
-                  updateParam={updateParam}
-                />
-              )}
-              <hr className="my-3" />
-              <div className="test-preview-section">
-                <div className="mb-1 test-section-header">Preview Test</div>
-                <div className="border rounded bg-light p-3">
+              <div className="row mt-3">
+                <div className="col-lg-12 col-xl-6 mb-4">
+                  {test?.test_method_id && (
+                    <div>
+                      <div className="d-flex gap-1 align-items-center mb-1 test-section-header ">
+                        <span className="fw-medium form-group-label">
+                          Test Method Parameters:
+                        </span>
+                        <span className="fw-medium fw-bold">
+                          {testMethodName}
+                        </span>
+                      </div>
+
+                      <div className="border rounded px-3 py-2">
+                        <TestMethodAndParams
+                          params={params}
+                          showErrors={showErrors}
+                          setHasEvidence={setHasEvidence}
+                          hasEvidence={hasEvidence}
+                          areParamsDisabled={areParamsDisabled}
+                          updateParam={updateParam}
+                        />
+                      </div>
+                    </div>
+                  )}
+                </div>
+                <div className="col-lg-12 col-xl-6">
+                  <div className="fw-medium form-group-label mb-2">
+                    Preview Test
+                  </div>
                   <TestPreviewModal
                     test={test}
                     params={params}
@@ -279,7 +281,7 @@ function TestModalContainer(props: TestModalUIProps) {
       <div className="row mt-5">
         <div className="col-12">
           <div className="d-flex justify-content-between">
-            <Button className="btn btn-secondary" href="/admin/tests">
+            <Button className="btn btn-secondary" onClick={() => navigate(-1)}>
               Back
             </Button>
             {id && isVersioning ? (

--- a/src/pages/tests/components/TestPreviewModal.tsx
+++ b/src/pages/tests/components/TestPreviewModal.tsx
@@ -1,8 +1,20 @@
 import React from "react";
-import { Button, Form, InputGroup } from "react-bootstrap";
 import { useTranslation } from "react-i18next";
 import { TestInput, TestParam } from "@/types/tests";
 import { EvidenceURLS, TestToolTip } from "@/pages/assessments/components";
+import { TestBinaryParamForm } from "@/pages/assessments/components/tests/TestBinaryParam";
+import {
+  TestAutoG069,
+  TestAutoHttpsCheck,
+  TestAutoMD1,
+  TestBinaryParam,
+  TestValueParam,
+} from "@/types";
+import { defaultG069userInfo, defaultG069tokenIntrospection } from "@/config";
+import { TestValueFormParam } from "@/pages/assessments/components/tests/TestValueFormParam";
+import { TestAutoG069Form } from "@/pages/assessments/components/tests/TestAutoG069Form";
+import { TestAutoHttpsCheckForm } from "@/pages/assessments/components/tests/TestAutoHttpsCheckForm";
+import { TestAutoMd1Form } from "@/pages/assessments/components/tests/TestAutoMd1Form";
 
 interface TestPreviewProps {
   test: TestInput;
@@ -19,326 +31,209 @@ const TestPreviewModal: React.FC<TestPreviewProps> = ({
 }) => {
   const { t } = useTranslation();
 
-  // Determine the test type based on the test_method_id
-  const getTestType = (): string => {
-    if (!test?.test_method_id) return "binary"; // Default type
+  const testParams: JSX.Element[] = [];
 
-    // Map test_method_id to test type based on the method name
-    const methodName = testMethodName?.toLowerCase() || "";
-    if (methodName.includes("auto-check-url")) return "Auto-Check-Url-Binary";
-    if (methodName.includes("auto-check-string"))
-      return "Auto-Check-String-Binary";
-    if (methodName.includes("auto-check-xml-md1")) {
-      if (methodName.includes("md1a")) return "Auto-Check-Xml-MD1a";
-      if (methodName.includes("md1b1")) return "Auto-Check-Xml-MD1b1";
-      return "Auto-Check-Xml-MD1b2";
-    }
-    if (methodName.includes("value")) return "value";
-    if (methodName.includes("string")) {
-      return "Number-Manual";
-    }
-    if (methodName.includes("number")) return "Number-Manual";
-    if (methodName.includes("ratio")) return "Ratio-Manual";
-    if (methodName.includes("percent")) return "Percent-Manual";
-    if (methodName.includes("trl")) return "TRL-Manual";
-    if (methodName.includes("years")) return "Years-Manual";
+  if (
+    testMethodName === "Binary-Manual-Evidence" ||
+    testMethodName === "Binary-Binary" ||
+    testMethodName === "Binary-Manual"
+  ) {
+    const adaptedTest = {
+      id: test.tes || "",
+      name: test.label || "",
+      description: test.description || "",
+      type: testMethodName || "Binary-Manual",
+      text: params?.map((p) => p.text).join("|") || "",
+      value: "",
+      result: "",
+      params: params?.map((p) => p.name).join("|") || "",
+      tool_tip: params?.map((p) => p.tooltip).join("|") || "",
+      evidence_url: [],
+    } as unknown as TestBinaryParam;
 
-    return "binary";
-  };
+    testParams.push(
+      <TestBinaryParamForm
+        test={adaptedTest}
+        onTestChange={() => {}}
+        criterionId={""}
+        principleId={""}
+      />,
+    );
+  } else if (
+    testMethodName === "Number-Manual" ||
+    testMethodName === "Number-Auto" ||
+    testMethodName === "Ratio-Manual" ||
+    testMethodName === "Percent-Manual" ||
+    testMethodName === "TRL-Manual" ||
+    testMethodName === "Years-Manual"
+  ) {
+    const adaptedTest = {
+      id: test.tes || "",
+      name: test.label || "",
+      type: testMethodName || "Number-Manual",
+      text: params?.map((p) => p.text).join("|") || "",
+      value: "",
+      result: "",
+      suffix: "",
+      unit: "",
+      min_value: 0,
+      max_value: 100,
+      default_value: 0,
+      params: params?.map((p) => p.name).join("|") || "",
+      evidence_url: [],
+      tool_tip: params?.map((p) => p.tooltip).join("|") || "",
+    } as unknown as TestValueParam;
 
-  const renderParams = () => {
-    const testType = getTestType();
+    testParams.push(
+      <TestValueFormParam
+        test={adaptedTest}
+        onTestChange={() => {}}
+        criterionId={""}
+        principleId={""}
+      />,
+    );
+  } else if (testMethodName === "Auto-Check-String-Binary") {
+    const adaptedTest = {
+      id: test.tes || "",
+      name: test.label || "",
+      type: testMethodName || "Auto-Check-String-Binary",
+      text: params?.map((p) => p.text).join("|") || "",
+      value: "",
+      result: "",
+      params: params?.map((p) => p.name).join("|") || "",
+      evidence_url: [],
+      tool_tip: params?.map((p) => p.tooltip).join("|") || "",
+      auto_type: "g069",
+    } as unknown as TestAutoG069;
 
-    if (
-      [
-        "value",
-        "Number-Manual",
-        "Number-Auto",
-        "Ratio-Manual",
-        "Percent-Manual",
-        "TRL-Manual",
-        "Years-Manual",
-      ].includes(testType)
-    ) {
-      return (
-        <div className="mb-2">
-          {params.map((param, index) => (
-            <div key={index} className="border p-2 rounded mb-2 bg-light">
-              <div>
-                <strong className="me-2">
-                  {param.text || t("{Test Question}")}{" "}
-                  {param?.tooltip && (
-                    <span style={{ height: "35px", alignSelf: "start" }}>
-                      <TestToolTip
-                        tipId={"text-" + param.id}
-                        tipText={param.tooltip}
-                      />
-                    </span>
-                  )}
-                </strong>
-              </div>
-              <div className="mt-2">
-                {testType === "TRL-Manual" ? (
-                  <Form.Select
-                    disabled
-                    aria-label="TRL Selection"
-                    className="form-control-sm"
-                  >
-                    <option>{t("Select TRL level")}</option>
-                  </Form.Select>
-                ) : testType === "Ratio-Manual" ? (
-                  <div className="d-flex align-items-center">
-                    <Form.Control
-                      type="text"
-                      disabled
-                      placeholder="0"
-                      size="sm"
-                      className="me-2"
-                    />
-                  </div>
-                ) : testType === "Percent-Manual" ? (
-                  <div className="d-flex align-items-center">
-                    <Form.Control
-                      type="text"
-                      disabled
-                      placeholder="0"
-                      size="sm"
-                      className="me-2"
-                    />
-                    <span>%</span>
-                  </div>
-                ) : testType === "Years-Manual" ? (
-                  <div className="d-flex align-items-center">
-                    <Form.Control
-                      type="text"
-                      disabled
-                      placeholder="0"
-                      size="sm"
-                      className="me-2"
-                    />
-                    <span>{t("years")}</span>
-                  </div>
-                ) : (
-                  <Form.Control
-                    type="text"
-                    disabled
-                    placeholder="0"
-                    size="sm"
-                  />
-                )}
-              </div>
-            </div>
-          ))}
-        </div>
-      );
-    } else if (
-      [
-        "Auto-Check-Url-Binary",
-        "Auto-Check-String-Binary",
-        "Auto-Check-Xml-MD1a",
-        "Auto-Check-Xml-MD1b1",
-        "Auto-Check-Xml-MD1b2",
-      ].includes(testType)
-    ) {
-      return (
-        <div className="mb-2">
-          {params.map((param, index) => (
-            <div key={index} className="border p-2 rounded mb-2 bg-light">
-              <div>
-                <strong className="me-2">
-                  {param.text || t("{Test Question}")}{" "}
-                  {param?.tooltip &&
-                    !(
-                      testType === "Auto-Check-Url-Binary" ||
-                      testType === "Auto-Check-String-Binary"
-                    ) && (
-                      <TestToolTip
-                        tipId={"text-" + param.id}
-                        tipText={param.tooltip}
-                      />
-                    )}
-                </strong>
-              </div>
-              {testType === "Auto-Check-Url-Binary" ? (
-                <>
-                  <InputGroup className="mt-1">
-                    <InputGroup.Text id={`label-${param.id}`}>
-                      <TestToolTip
-                        tipId={`params-${index}-${param.id}`}
-                        tipText={param?.tooltip || ""}
-                      />
-                      <span className="ms-2">{param.name}</span>:
-                    </InputGroup.Text>
-                    <Form.Control
-                      placeholder={t("https://example.com")}
-                      aria-label={t("Enter URL")}
-                      disabled
-                    />
-                    <Button
-                      variant="success"
-                      disabled
-                      className="d-flex align-items-center"
-                    >
-                      <span className="me-1">▶</span>
-                      {t("page_assessment_edit.run_check")}
-                    </Button>
-                  </InputGroup>
-                  <div className="mt-2">
-                    <small className="text-muted">
-                      {t("page_assessment_edit.status_message_placeholder")}
-                    </small>
-                  </div>
-                </>
-              ) : testType === "Auto-Check-String-Binary" ? (
-                <>
-                  <InputGroup className="mt-1">
-                    <InputGroup.Text id={`label-${param.id}`}>
-                      <TestToolTip
-                        tipId={`params-${index}-${param.id}`}
-                        tipText={param?.tooltip || ""}
-                      />
-                      <span className="ms-2">{param.name}</span>:
-                    </InputGroup.Text>
-                    <Form.Select>
-                      <option value="">Select a value</option>
-                      <option value="provider1">Provider 1</option>
-                      <option value="provider2">Provider 2</option>
-                      <option value="provider3">Provider 3</option>
-                    </Form.Select>
-                    <Button
-                      variant="success"
-                      disabled
-                      className="d-flex align-items-center"
-                    >
-                      <span className="me-1">▶</span>
-                      {t("page_assessment_edit.run_check")}
-                    </Button>
-                  </InputGroup>
-                  <div className="mt-3">
-                    <div>
-                      {t("Validation")}
-                      {": "}
-                      <span className="badge bg-secondary">{t("Pending")}</span>
-                    </div>
-                    <div className="mt-2">
-                      <ul className="mb-0">
-                        <li>
-                          <small>
-                            {t("Check item 1")}
-                            {": "}
-                            <span className="badge bg-secondary">
-                              {t("Pending")}
-                            </span>
-                          </small>
-                        </li>
-                        <li>
-                          <small>
-                            {t("Check item 2")}
-                            {": "}
-                            <span className="badge bg-secondary">
-                              {t("Pending")}
-                            </span>
-                          </small>
-                        </li>
-                      </ul>
-                    </div>
-                  </div>
-                </>
-              ) : (
-                <InputGroup className="mt-2" size="sm">
-                  <Form.Control
-                    placeholder={
-                      testType.includes("URL")
-                        ? t("Enter URL")
-                        : t("Enter value")
-                    }
-                    disabled
-                  />
-                  <InputGroup.Text>
-                    <span className="text-muted">{t("Run")}</span>
-                  </InputGroup.Text>
-                </InputGroup>
-              )}
-            </div>
-          ))}
-        </div>
-      );
-    } else {
-      return (
-        <div className="mb-2">
-          {params.map((param, index) => (
-            <div key={index} className="border p-2 rounded mb-2 bg-light">
-              <div className="d-flex align-items-center">
-                <strong>
-                  {param.text || t("{Question}")}{" "}
-                  {param?.tooltip && (
-                    <span className="">
-                      <TestToolTip
-                        tipId={"text-" + param.id}
-                        tipText={param.tooltip}
-                      />
-                    </span>
-                  )}
-                </strong>
-              </div>
-              <div className="d-flex gap-3 mt-2">
-                <Form.Check disabled label={t("Yes")} type="radio" />
-                <Form.Check disabled label={t("No")} type="radio" />
-              </div>
-            </div>
-          ))}
-        </div>
-      );
-    }
-  };
+    testParams.push(
+      <TestAutoG069Form
+        g069param=""
+        test={adaptedTest}
+        onTestChange={() => {}}
+        criterionId={""}
+        principleId={""}
+      />,
+    );
+  } else if (testMethodName === "Auto-Check-AARC-G069-User-Info") {
+    const adaptedTest = {
+      id: test.tes || "",
+      name: test.label || "",
+      type: testMethodName || "Auto-Check-AARC-G069-User-Info",
+      text: params?.map((p) => p.text).join("|") || "",
+      value: "",
+      result: "",
+      params: params?.map((p) => p.name).join("|") || "",
+      evidence_url: [],
+      tool_tip: params?.map((p) => p.tooltip).join("|") || "",
+      auto_type: "g069",
+    } as unknown as TestAutoG069;
+
+    testParams.push(
+      <TestAutoG069Form
+        g069param={defaultG069userInfo}
+        test={adaptedTest}
+        onTestChange={() => {}}
+        criterionId={""}
+        principleId={""}
+      />,
+    );
+  } else if (testMethodName === "Auto-Check-AARC-G069-Token-Introspection") {
+    const adaptedTest = {
+      id: test.tes || "",
+      name: test.label || "",
+      type: testMethodName || "Auto-Check-AARC-G069-Token-Introspection",
+      text: params?.map((p) => p.text).join("|") || "",
+      value: "",
+      result: "",
+      params: params?.map((p) => p.name).join("|") || "",
+      evidence_url: [],
+      tool_tip: params?.map((p) => p.tooltip).join("|") || "",
+      auto_type: "g069",
+    } as unknown as TestAutoG069;
+
+    testParams.push(
+      <TestAutoG069Form
+        g069param={defaultG069tokenIntrospection}
+        test={adaptedTest}
+        onTestChange={() => {}}
+        criterionId={""}
+        principleId={""}
+      />,
+    );
+  } else if (testMethodName === "Auto-Check-Url-Binary") {
+    const adaptedTest = {
+      id: test.tes || "",
+      name: test.label || "",
+      type: testMethodName || "Auto-Check-Url-Binary",
+      text: params?.map((p) => p.text).join("|") || "",
+      value: "",
+      result: "",
+      params: params?.map((p) => p.name).join("|") || "",
+      evidence_url: [],
+      tool_tip: params?.map((p) => p.tooltip).join("|") || "",
+      auto_type: "https",
+    } as unknown as TestAutoHttpsCheck;
+
+    testParams.push(
+      <TestAutoHttpsCheckForm
+        test={adaptedTest}
+        onTestChange={() => {}}
+        criterionId={""}
+        principleId={""}
+      />,
+    );
+  } else if (
+    testMethodName === "Auto-Check-Xml-MD1a" ||
+    testMethodName === "Auto-Check-Xml-MD1b1" ||
+    testMethodName === "Auto-Check-Xml-MD1b2"
+  ) {
+    const adaptedTest = {
+      id: test.tes || "",
+      name: test.label || "",
+      type: testMethodName || "Auto-Check-Xml-MD1a",
+      text: params?.map((p) => p.text).join("|") || "",
+      value: "",
+      result: "",
+      params: params?.map((p) => p.name).join("|") || "",
+      evidence_url: [],
+      tool_tip: params?.map((p) => p.tooltip).join("|") || "",
+      auto_type: "md1",
+    } as unknown as TestAutoMD1;
+
+    testParams.push(
+      <TestAutoMd1Form
+        test={adaptedTest}
+        onTestChange={() => {}}
+        criterionId={""}
+        principleId={""}
+      />,
+    );
+  }
 
   return (
-    <div style={{ borderRadius: 0, border: "none", wordBreak: "break-word" }}>
-      <div>
-        <div className="p-2">
-          <div className="d-flex align-items-start mb-3">
-            <div>
-              <h5>
-                {test.tes || t("{TES Name placeholder}")} -{" "}
-                {test.label || t("{Test Label placeholder}")}
-              </h5>
-              <h5 className="text-muted mb-2">
-                {test.description || t("{Test Description placeholder}")}
-              </h5>
-              {testMethodName && (
-                <span className="badge bg-secondary me-1">
-                  {testMethodName}
-                </span>
-              )}
-            </div>
-          </div>
-          {hasEvidenceParam && (
-            <div className="mb-3">
-              <span className="d-flex align-items-center gap-1">
-                Provide evidence of that via a URL to a page or to a
-                documentation
-                <TestToolTip
-                  tipId="evidence-id"
-                  tipText="A document, web page, or publication describing provisions"
-                />
-              </span>
-              <EvidenceURLS
-                isPreviewMode
-                urls={[]}
-                onListChange={() => {}}
-                noTitle
+    <div className="border rounded cat-test-div">
+      {testParams?.length > 0 ? (
+        testParams
+      ) : (
+        <h5 className="text-muted">{t("No parameters defined yet")}</h5>
+      )}
+      {hasEvidenceParam && (
+        <div className="mt-4 mb-2">
+          <span className="fw-light-500 text-sm text-secondary">
+            <strong>
+              Can you provide public evidence of such a declaration?
+            </strong>
+            <span className="ms-2">
+              <TestToolTip
+                tipId="evidence-id"
+                tipText="A document, web page, or publication describing the intention"
               />
-            </div>
-          )}
-          <div className="ms-1 mb-2">
-            {params.length > 0 ? (
-              renderParams()
-            ) : (
-              <h5 className="text-muted">{t("No parameters defined yet")}</h5>
-            )}
-          </div>
+            </span>
+          </span>
+          <EvidenceURLS urls={[]} onListChange={() => {}} noTitle={true} />
         </div>
-      </div>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
This PR refactors the test preview functionality to use existing test display components for each test method type and improves the styling of the create test form.

- Refactored TestPreviewModal to use existing test method display components
- Added proper mapping of test input fields to component properties for all test types
- Implemented conditional rendering for undefined values across all test method components
- Updated create test form layout to display test parameters and preview side-by-side on large screens