### PR TITLE
CAT-896 Support automated group of tests in the ui

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -117,6 +117,12 @@
   border-top: transparent;
 }
 
+.cat-alert-warning-colors {
+  color: #856404;
+  background-color: #fff3cd;
+  border-color: #ffeeba;
+}
+
 #motivation-tabs .tab-content .tab-pane {
   height: auto;
   min-height: 200px;

--- a/src/assets/locales/en.json
+++ b/src/assets/locales/en.json
@@ -99,7 +99,9 @@
     "next": "Next",
     "restore": "Restore",
     "publish": "Publish",
-    "unpublish": "Unpublish"
+    "unpublish": "Unpublish",
+    "run_test_group": "Run Test Group",
+    "running_test_group": "Test Group is running..."
   },
   "fields": {
     "actions": "Actions",
@@ -389,7 +391,8 @@
     "reimport": "Please try to import a different file...",
     "share1": "This is a",
     "share2": "shared",
-    "share3": "assessment from another user, which includes the following actor information"
+    "share3": "assessment from another user, which includes the following actor information",
+    "include_group_tests": "This assessment includes the following automated group test(s):"
   },
   "page_preview": {
     "title": "Preview Assessment",

--- a/src/pages/assessments/AssessmentEdit.tsx
+++ b/src/pages/assessments/AssessmentEdit.tsx
@@ -15,6 +15,7 @@ import {
   AssessmentEditMode,
   ActorOrgAsmtType,
   AssessmentCriterion,
+  AutoGroupTest,
 } from "@/types";
 import { useParams } from "react-router";
 import {
@@ -56,6 +57,8 @@ import { ShareModal } from "./components/ShareModal";
 import { Comments } from "./components/Comments";
 import FormCheckInput from "react-bootstrap/esm/FormCheckInput";
 import { useTranslation } from "react-i18next";
+import { GroupTestModal } from "./components/tests/GroupTestModal";
+import { FaGears } from "react-icons/fa6";
 
 type AssessmentEditProps = {
   mode: AssessmentEditMode;
@@ -65,6 +68,11 @@ interface ShareModalConfig {
   show: boolean;
   name: string;
   id: string;
+}
+
+interface GroupTestModalConfig {
+  group: AutoGroupTest | null;
+  show: boolean;
 }
 
 type Guide = {
@@ -105,6 +113,13 @@ const AssessmentEdit = ({
     text: "",
     show: false,
   });
+
+  // state to show/hide group_testing_modal
+  const [groupTestModalConfig, setGroupTestModalConfig] =
+    useState<GroupTestModalConfig>({
+      group: null,
+      show: false,
+    });
 
   // Share Modal
   const [shareModalConfig, setShareModalConfig] = useState<ShareModalConfig>({
@@ -280,6 +295,10 @@ const AssessmentEdit = ({
     if (activeTab > 1) {
       handleChangeTab(activeTab - 1);
     }
+  }
+
+  function handleAutoTestGroup(autogroup: AutoGroupTest) {
+    setGroupTestModalConfig({ group: autogroup, show: true });
   }
 
   function handleUpdateAssessment(exit: boolean) {
@@ -468,6 +487,10 @@ const AssessmentEdit = ({
     }
   }
 
+  const handleUpdateAutoResults = (assessment: Assessment) => {
+    setAssessment(assessment);
+  };
+
   const handleImport = (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
     if (file) {
@@ -596,8 +619,25 @@ const AssessmentEdit = ({
         : false
       : wizardTabActive && activeTab < 3;
 
+  // check if assessment has automated test groups
+  const hasAutoGroups =
+    assessment && assessment?.automated_group_test?.length > 0;
+
   return (
     <>
+      {hasAutoGroups && (
+        <GroupTestModal
+          show={
+            groupTestModalConfig.show && Boolean(groupTestModalConfig.group)
+          }
+          groupTest={groupTestModalConfig.group}
+          onHide={() => {
+            setGroupTestModalConfig({ group: null, show: false });
+          }}
+          assessment={assessment}
+          onUpdateResults={handleUpdateAutoResults}
+        />
+      )}
       <ShareModal
         show={shareModalConfig.show}
         name={shareModalConfig.name}
@@ -1000,7 +1040,37 @@ const AssessmentEdit = ({
                   className="row bg-secondary"
                   style={{ height: "1px" }}
                 ></div>
+                {hasAutoGroups && (
+                  <div className="row cat-alert-warning-colors p-2">
+                    <div>
+                      <small className="me-2">
+                        <FaGears size="1.2rem" className="me-2" />
+                        {t("page_assessment_edit.include_group_tests")}
+                      </small>
+
+                      {assessment?.automated_group_test.map((item) => {
+                        return (
+                          <Button
+                            size="sm"
+                            variant="success"
+                            key={item.test_method}
+                            onClick={() => {
+                              setGroupTestModalConfig({
+                                group: item,
+                                show: true,
+                              });
+                            }}
+                          >
+                            {item.test_method}
+                          </Button>
+                        );
+                      })}
+                    </div>
+                  </div>
+                )}
                 <CriteriaTabs
+                  onAutoTestGroup={handleAutoTestGroup}
+                  autogroups={assessment?.automated_group_test}
                   principles={assessment?.principles || []}
                   resetActiveTab={resetCriterionTab}
                   onTestChange={handleCriterionChange}

--- a/src/pages/assessments/MotivationAssessmentEditor.tsx
+++ b/src/pages/assessments/MotivationAssessmentEditor.tsx
@@ -159,6 +159,8 @@ export const MotivationAssessmentEditor = () => {
           )}
           <div className="row bg-secondary" style={{ height: "1px" }}></div>
           <CriteriaTabs
+            autogroups={undefined}
+            onAutoTestGroup={() => {}}
             principles={assessment.principles || []}
             resetActiveTab={resetCriterionTab}
             onTestChange={handleCriterionChange}

--- a/src/pages/assessments/components/CriteriaTabs.tsx
+++ b/src/pages/assessments/components/CriteriaTabs.tsx
@@ -32,6 +32,8 @@ import {
   TestAutoHttpsCheck,
   TestAutoMD1,
   TestAutoG069,
+  TestAutoValidation,
+  AutoGroupTest,
 } from "@/types";
 import {
   TestBinaryForm,
@@ -47,8 +49,11 @@ import { useTranslation } from "react-i18next";
 import { TestAutoMd1Form } from "./tests/TestAutoMd1Form";
 import { TestAutoG069Form } from "./tests/TestAutoG069Form";
 import { defaultG069tokenIntrospection, defaultG069userInfo } from "@/config";
+import { TestAutoValidationForm } from "./tests/TestAutoValidationForm";
 
 type CriteriaTabsProps = {
+  autogroups: AutoGroupTest[] | undefined;
+  onAutoTestGroup(autogroup: AutoGroupTest): void;
   principles: AssessmentPrinciple[];
   resetActiveTab: boolean;
   handleGuide(id: string, title: string, text: string): void;
@@ -280,6 +285,20 @@ export function CriteriaTabs(props: CriteriaTabsProps) {
                     onTestChange={props.onTestChange}
                     criterionId={criterion.id}
                     principleId={principle.id}
+                  />
+                </div>
+              </div>,
+            );
+          } else if (test.type === "Fully-Automated-Validation") {
+            testList.push(
+              <div className="border mt-4" key={test.id}>
+                <div className="cat-test-div">
+                  <TestAutoValidationForm
+                    autogroup={props.autogroups?.find(
+                      (item) => item.test_method === test.type,
+                    )}
+                    test={test as TestAutoValidation}
+                    onAutoGroupTestCall={props.onAutoTestGroup}
                   />
                 </div>
               </div>,

--- a/src/pages/assessments/components/tests/GroupTestModal.tsx
+++ b/src/pages/assessments/components/tests/GroupTestModal.tsx
@@ -1,0 +1,305 @@
+import {
+  Modal,
+  Button,
+  ListGroup,
+  ListGroupItem,
+  Alert,
+} from "react-bootstrap";
+import { useTranslation } from "react-i18next";
+import {
+  AdditionalInfoItem,
+  Assessment,
+  AutoGroupTest,
+  GroupTestParam,
+  GroupTestRef,
+  TestAutoError,
+  TestAutoResponse,
+} from "@/types";
+import { useContext, useEffect, useState } from "react";
+import { FaCircle } from "react-icons/fa6";
+import {
+  FaCheckCircle,
+  FaClock,
+  FaInfoCircle,
+  FaPlay,
+  FaPlayCircle,
+  FaTimesCircle,
+} from "react-icons/fa";
+import { APIClient } from "@/api";
+import { AxiosError } from "axios";
+import { applyAutoGroupResults, queryValue } from "@/utils";
+import { AuthContext } from "@/auth";
+
+interface GroupTestModalProps {
+  groupTest: AutoGroupTest | null;
+  assessment?: Assessment;
+  show: boolean;
+  onHide: () => void;
+  onUpdateResults: (assessment: Assessment) => void;
+}
+/**
+ * Modal component for executing a group of tests
+ */
+
+function initParams(asmt: Assessment, params: GroupTestParam[]) {
+  const result: Record<string, string> = {};
+
+  params.map((param) => {
+    let value = "";
+    if (param.value) value = param.value;
+    else if (param.assessment_ref)
+      value = queryValue(asmt, param.assessment_ref) as string;
+    result[param.name] = value;
+  });
+  return result;
+}
+
+function initGroupTests(
+  asmt: Assessment,
+  testMethod: string,
+): Record<string, GroupTestRef> {
+  const groupTests: Record<string, GroupTestRef> = {};
+
+  asmt.principles.map((pri) => {
+    pri.criteria.map((cri) => {
+      cri.metric.tests.map((test) => {
+        if (test.type === testMethod) {
+          groupTests[test.params] = {
+            criterionId: cri.id,
+            criterionName: cri.name,
+            criterionImperative: cri.imperative,
+            testId: test.id,
+            testName: test.name,
+            result: test.result,
+            message: "",
+          };
+        }
+      });
+    });
+  });
+
+  return groupTests;
+}
+
+export function GroupTestModal(props: GroupTestModalProps) {
+  const { keycloak } = useContext(AuthContext)!;
+  const { t } = useTranslation();
+
+  const [groupTests, setGroupTests] = useState<Record<string, GroupTestRef>>(
+    {},
+  );
+  const [runningTest, setRunningTest] = useState(false);
+  const [params, setParams] = useState<Record<string, string>>({});
+  const [error, setError] = useState<string>("");
+  const [message, setMessage] = useState<string>("");
+  const [execTime, setExecTime] = useState<string>("");
+
+  function handleResults(info: Record<string, AdditionalInfoItem>) {
+    const groupTestsUpdate: Record<string, GroupTestRef> = {};
+
+    Object.keys(info).map((key) => {
+      // update groupTest object that will apply changes to the assessment
+      groupTestsUpdate[key] = {
+        ...groupTests[key],
+        ["result"]: info[key].is_valid ? 1 : 0,
+        ["message"]: info[key].message,
+      };
+    });
+
+    // apply result changes to the assessment
+    if (props.assessment && props.groupTest) {
+      const assessmentUpdated = applyAutoGroupResults(
+        props.assessment,
+        props.groupTest?.test_method,
+        groupTestsUpdate,
+      );
+
+      if (assessmentUpdated) {
+        props.onUpdateResults(assessmentUpdated);
+      }
+    }
+  }
+
+  function handleRunTestGroup(token: string) {
+    // run the check
+    setRunningTest(true);
+
+    APIClient(token)
+      .post<TestAutoResponse | TestAutoError>(
+        props.groupTest?.endpoint || "",
+        params,
+        {
+          validateStatus: (status) => status >= 200 && status < 500,
+        },
+      )
+      .then((resp) => {
+        if (resp.status === 200) {
+          const okResp = resp.data as TestAutoResponse;
+          setMessage(okResp.test_status.message || "");
+          setExecTime(new Date(okResp.last_run).toISOString() || "");
+
+          // handle params
+          handleResults(okResp.additional_info);
+        } else {
+          const errResp = resp.data as TestAutoError;
+          setError(errResp.message || "");
+          setExecTime(new Date().toISOString());
+        }
+      })
+      .catch((error: AxiosError) => {
+        console.log(error);
+      })
+      .finally(() => {
+        setRunningTest(false);
+      });
+  }
+
+  useEffect(() => {
+    setRunningTest(false);
+    if (props.show && props.assessment && props.groupTest) {
+      setGroupTests(
+        initGroupTests(props.assessment, props.groupTest.test_method),
+      );
+      setParams(initParams(props.assessment, props.groupTest.params));
+    } else {
+      setGroupTests({});
+      setParams({});
+      setMessage("");
+      setError("");
+      setExecTime("");
+    }
+  }, [props.show, props.assessment, props.groupTest]);
+
+  return (
+    <Modal
+      show={props.show}
+      onHide={props.onHide}
+      size="lg"
+      aria-labelledby="contained-modal-title-vcenter"
+      centered
+    >
+      <Modal.Header closeButton>
+        <Modal.Title
+          className="d-flex align-items-center gap-1"
+          id="contained-modal-title-vcenter"
+        >
+          {t("Automated Group")}
+          {": "}
+          {props.groupTest?.test_method}
+        </Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        <p>This automated test group contains the following tests:</p>
+        <ListGroup className="mb-2">
+          <div>
+            {Object.keys(groupTests).map((key) => {
+              const item = groupTests[key];
+              return (
+                <ListGroupItem key={key}>
+                  <div className="text-secondary">
+                    <small>{item.criterionId}</small>
+                    <small className="ms-2">
+                      <strong>{item.criterionName}</strong>
+                    </small>
+                    {item.criterionImperative.toLowerCase() === "must" ? (
+                      <small className="ms-2 badge badge-sm bg-light border text-secondary">
+                        required
+                      </small>
+                    ) : null}
+                  </div>
+                  <div className="d-flex d-flex justify-content-between">
+                    <div>
+                      <span>{item.testId}</span>
+                      <strong className="ms-2">{item.testName}</strong>
+                    </div>
+                    <div>
+                      {item.result ? (
+                        item.result ? (
+                          <FaCheckCircle className="text-success" />
+                        ) : (
+                          <FaTimesCircle className="text-danger" />
+                        )
+                      ) : (
+                        <FaCircle className="text-secondary" />
+                      )}
+                    </div>
+                  </div>
+                  {item.message && (
+                    <div className="text-secondary">
+                      <em>
+                        <small>{message}</small>
+                      </em>
+                    </div>
+                  )}
+                </ListGroupItem>
+              );
+            })}
+          </div>
+        </ListGroup>
+        {runningTest ? (
+          <Alert variant="warning" className="py-1">
+            <FaPlayCircle className="me-2" />
+            Test running...
+          </Alert>
+        ) : (
+          <div>
+            {!error && !message && (
+              <Alert variant="warning" className="py-1">
+                <FaInfoCircle className="me-2" />
+                To run this test group please press the button below...
+              </Alert>
+            )}
+            {error && (
+              <Alert variant="danger" className="py-1">
+                <FaTimesCircle className="me-2" />
+                {error}
+                {execTime && (
+                  <div>
+                    <em>
+                      <small>{`last run: ${execTime}`}</small>
+                    </em>
+                  </div>
+                )}
+              </Alert>
+            )}
+            {message && (
+              <Alert variant="success" className="py-1">
+                <FaCheckCircle className="me-2" />
+                {message}
+                {execTime && (
+                  <div>
+                    <em>
+                      <small>{`last run: ${execTime}`}</small>
+                    </em>
+                  </div>
+                )}
+              </Alert>
+            )}
+          </div>
+        )}
+      </Modal.Body>
+      <Modal.Footer className="d-flex justify-content-between">
+        <Button className="btn-secondary" onClick={props.onHide}>
+          {t("buttons.close")}
+        </Button>
+        {runningTest ? (
+          <Button className="btn-secondary" disabled>
+            <FaClock />
+            <span className="ms-2">{t("buttons.running_test_group")}</span>
+          </Button>
+        ) : (
+          <Button
+            className="btn-success"
+            onClick={() => {
+              handleRunTestGroup(keycloak?.token || "");
+            }}
+            disabled={runningTest}
+          >
+            <FaPlay />
+            <span className="ms-2">{t("buttons.run_test_group")}</span>
+          </Button>
+        )}
+      </Modal.Footer>
+    </Modal>
+  );
+}

--- a/src/pages/assessments/components/tests/TestAutoValidationForm.tsx
+++ b/src/pages/assessments/components/tests/TestAutoValidationForm.tsx
@@ -1,0 +1,93 @@
+/**
+ * Component to display a specific auto validation test for the g069 case
+ */
+
+// import { useState } from "react"
+import { Button, Col, Row } from "react-bootstrap";
+
+import { AutoGroupTest, TestAutoValidation } from "@/types";
+import { FaPlay } from "react-icons/fa";
+import { useTranslation } from "react-i18next";
+import { FaGears } from "react-icons/fa6";
+
+interface AssessmentTestProps {
+  autogroup: AutoGroupTest | undefined;
+  test: TestAutoValidation;
+  onAutoGroupTestCall(autogroup: AutoGroupTest): void;
+}
+
+export const TestAutoValidationForm = (props: AssessmentTestProps) => {
+  const { t } = useTranslation();
+
+  // break parameters
+  const textParams = props.test.text.split("|");
+
+  console.log(props.test.result, props.test.result === 1);
+
+  return (
+    <div>
+      <Row>
+        <Col>
+          <h6>
+            <small className="text-muted badge badge-pill border bg-light">
+              <span className="me-4">{props.test.id}</span>
+              {props.test.name}
+            </small>
+          </h6>
+        </Col>
+        <Col xs={3} className="text-start"></Col>
+      </Row>
+
+      <Row>
+        <div>
+          <h5>{textParams[0]}</h5>
+          <div className="mb-2">
+            <span className="me-2">Validation Result:</span>
+            {props.test.result === null ? (
+              <>
+                <span className="badge badge-sm bg-secondary">UNKNOWN</span>
+                <small className="ms-2">
+                  - Please run the group test for result
+                </small>
+              </>
+            ) : props.test.result === 1 ? (
+              <>
+                <span className="badge badge-sm bg-success">PASS</span>
+                {props.test.message && (
+                  <small className="ms-2">- {props.test.message}</small>
+                )}
+              </>
+            ) : (
+              <>
+                <span className="badge badge-sm bg-danger">FAIL</span>
+                {props.test.message && (
+                  <small className="ms-2">- {props.test.message}</small>
+                )}
+              </>
+            )}
+          </div>
+          <div className="mt-1 d-flex d-flex justify-content-between border rounded bg-light">
+            <div className="p-2">
+              <FaGears size="1.2rem" className="me-2 text-muted" />
+              <small>
+                This test is part of the test group:{" "}
+                <code className="text-success">{props.test.type}</code>
+              </small>
+            </div>
+            <Button
+              variant="success"
+              onClick={() => {
+                if (props.autogroup) {
+                  props.onAutoGroupTestCall(props.autogroup);
+                }
+              }}
+            >
+              <FaPlay className="me-2" />
+              {` ${t("buttons.run_test_group")}`}
+            </Button>
+          </div>
+        </div>
+      </Row>
+    </div>
+  );
+};

--- a/src/types/assessment.ts
+++ b/src/types/assessment.ts
@@ -36,6 +36,20 @@ export interface Assessment {
   principles: AssessmentPrinciple[];
   published: boolean;
   shared_with_user: boolean;
+  automated_group_test: AutoGroupTest[];
+}
+
+/** Information on automated group tests */
+export interface AutoGroupTest {
+  endpoint: string;
+  test_method: string;
+  params: GroupTestParam[];
+}
+
+export interface GroupTestParam {
+  name: "string";
+  assessment_ref?: "string";
+  value?: "string";
 }
 
 /** Reference with string id */
@@ -236,6 +250,32 @@ export interface TestAutoResponse {
   additional_info: Record<string, AdditionalInfoItem>;
 }
 
+export interface GroupTestRef {
+  criterionId: string;
+  criterionName: string;
+  criterionImperative: AssessmentCriterionImperative;
+  testId: string;
+  testName: string;
+  result: number | null;
+  message: string;
+}
+
+export interface TestAutoValidation {
+  id: string;
+  name: string;
+  description?: string;
+  guidance?: Guidance;
+  type: "Fully-Automated-Validation";
+  text: string;
+  result: number | null;
+  value: string | null;
+  params: string;
+  evidence_url?: EvidenceURL[];
+  tool_tip: string;
+  message?: string;
+  lastRun?: string;
+}
+
 export interface TestAutoHttpsCheck {
   id: string;
   name: string;
@@ -272,7 +312,8 @@ export type AssessmentTest =
   | TestValueParam
   | TestAutoHttpsCheck
   | TestAutoMD1
-  | TestAutoG069;
+  | TestAutoG069
+  | TestAutoValidation;
 
 export interface EvidenceURL {
   url: string;

--- a/src/utils/assessment.ts
+++ b/src/utils/assessment.ts
@@ -6,6 +6,7 @@ import {
   Metric,
   ResultStats,
   AssessmentTest,
+  GroupTestRef,
 } from "../types";
 
 /** Evaluates all tests of a metric if the metric is number */
@@ -104,4 +105,83 @@ export function evalAssessment(
     mandatory: mandatoryCount,
     optional: optionalCount,
   };
+}
+
+/** iterates over the nested fields based on query to get the appropriate value */
+export function queryValue<T>(obj: T, query: string) {
+  const keys = query.split(".");
+  return keys.reduce((cur: unknown, key: string) => {
+    return cur && typeof cur === "object" && key in cur
+      ? (cur as Record<string, unknown>)[key]
+      : undefined;
+  }, obj);
+}
+
+export function applyAutoGroupResults(
+  assessment: Assessment,
+  group: string,
+  groupTests: Record<string, GroupTestRef>,
+): Assessment | null {
+  // create a deep copy of the existing assessment
+  if (assessment) {
+    // organise criteria results to mandatory and optional
+    const mandatory: (number | null)[] = [];
+    const optional: (number | null)[] = [];
+    let compliance: boolean | null;
+
+    // create a deep copy
+    const asmtUpdate = JSON.parse(JSON.stringify(assessment)) as Assessment;
+
+    asmtUpdate.principles.map((pri) => {
+      pri.criteria.map((cri) => {
+        // for each criterion check the tests and then calculate the metric
+
+        cri.metric.tests.map((test) => {
+          if (test.type === group && test.params in groupTests)
+            test.result = groupTests[test.params].result;
+          test.value = test.result ? "Validated" : "Validation Failed";
+        });
+        const { result, value } = evalMetric(cri.metric);
+        cri.metric.value = value;
+        cri.metric.result = result;
+        if (
+          cri.imperative === AssessmentCriterionImperative.Must ||
+          cri.imperative === AssessmentCriterionImperative.MUST
+        ) {
+          mandatory.push(cri.metric.result);
+        } else {
+          optional.push(cri.metric.result);
+        }
+      });
+    });
+
+    if (mandatory.some((result) => result === null)) {
+      compliance = null;
+    } else {
+      compliance = mandatory.every((result) => result === 1);
+    }
+
+    // get how many optional items have passed
+    const optionalPass: number = optional.reduce(
+      (sum: number, current: number | null) => {
+        if (current && current > 0) {
+          return sum + 1;
+        }
+        return sum;
+      },
+      0,
+    );
+
+    // if there any optional items available, ranking is equal to the percentage of optional passed / total optional
+    // else ranking is 0
+    const ranking =
+      optional.length > 0 ? (optionalPass / optional.length) * 100 : 0;
+
+    asmtUpdate.result.compliance = compliance;
+    asmtUpdate.result.ranking = ranking;
+
+    return asmtUpdate;
+  }
+
+  return null;
 }


### PR DESCRIPTION
### Goal
API has implemented the ability to define groups of automated tests in an assessment and execute them all at once. This functionality needs to be implemented also in the UI. 

First we extend the Assessment definition to hold additional information about automated group tests (the api json provides that optionally - some assessments have it, others don't) 

If an assessment includes automated groups of tests the ui will process them and add an interface section about them giving the ability to the user to run them on demand. Additionally each tests that belongs to a group of tests, gets a Run test group button which fires up a modal and informs the user to run the tests as a group at once. 

### Implementation
- [x] Extend Assessment types
- [x] Add utility function that allows to query an assessment for a specific value based on a field query. This is used by automated test groups to indicate where required values for specific parameters are found in order to be provided for the remote http request. 
- [x] Add utility function that allows to apply results of a group of tests to the assessment. This function takes a list of automated group test results and applies them to the correct Tests inside the assessment. Then it evaluates the assessment.
- [x] Implement Full-Auto-Validation test method both as a type and as a Component Form

