### PR TITLE
CAT-900 Configure auto group tests when adding a new Motivation-Actor…

### DIFF
--- a/src/api/services/motivations.ts
+++ b/src/api/services/motivations.ts
@@ -10,6 +10,7 @@ import { handleBackendError } from "@/utils";
 import {
   ApiOptions,
   ApiOptionsSearch,
+  AutoGroupTest,
   CriImp,
   MetricAssignment,
   MetricFull,
@@ -277,6 +278,7 @@ export const useMotivationAddActor = (
   motivationId: string,
   actorId: string,
   relation: string,
+  autoGroups: AutoGroupTest[],
 ) => {
   const queryClient = useQueryClient();
   return useMutation(
@@ -287,6 +289,7 @@ export const useMotivationAddActor = (
           {
             actor_id: actorId,
             relation: relation,
+            automated_group_test: autoGroups,
           },
         ],
       );

--- a/src/assets/locales/en.json
+++ b/src/assets/locales/en.json
@@ -50,10 +50,13 @@
   "mandatory": "Mandatory",
   "optional": "Optional",
   "unknown": "Unknown",
+  "assessment_ref": "Assessment Reference",
+  "value": "Value",
   "error": "Error",
   "github": "Github",
   "documentation": "Documentation",
   "personal_menu": "My items",
+  "endpoint": "Endpoint",
   "login_alert": "Press login to authenticate",
   "under_motivation": "under motivation",
   "tip_publish_assessment": "Publish Assessment (makes it public)",
@@ -66,6 +69,8 @@
   "toast_assessment_publish_progress": "Publishing Assessment...",
   "toast_assessment_unpublish_success": "Assessment Unpublished!",
   "toast_assessment_unpublish_progress": "Unpublishing Assessment...",
+  "param_type": "Parameter Type",
+  "test_method": "Test Method",
   "total": "Total",
   "buttons": {
     "login": "Login",
@@ -101,7 +106,8 @@
     "publish": "Publish",
     "unpublish": "Unpublish",
     "run_test_group": "Run Test Group",
-    "running_test_group": "Test Group is running..."
+    "running_test_group": "Test Group is running...",
+    "add_group_test": "Add Group Test"
   },
   "fields": {
     "actions": "Actions",
@@ -663,6 +669,8 @@
     "list_principles_subtitle": "Principles related with criteria under motivation",
     "create_principle": "Create Principle",
     "modal_principles_title": "Manage Principles",
+    "tip_test_method": "Please select one test method which identify which assessment tests belong to this group",
+    "select_test_method": "Please select test method",
     "modal_asmt_delete_title": "Delete Assessment Type",
     "modal_asmt_delete_message": "Are you sure you want to delete the following Assessment type ?",
     "asmt_types": "Assessment Types",
@@ -682,7 +690,17 @@
     "metric_details": "Metric details",
     "modal_metric_delete_title": "Delete Metric",
     "modal_metric_delete_message": "Are you sure you want to delete the following Metric ?",
-    "create_new_metric_version": "Create New Metric Version"
+    "create_new_metric_version": "Create New Metric Version",
+    "tip_endpoint": "Please enter a valid endpoint path for the automated group test to call",
+    "select_endpoint": "Enter a valid endpoint path",
+    "group_tests_section": "Group Tests (optional)",
+    "group_test": "Automated Group Test",
+    "info_add_group_tests": "In case you want to have automated groups of tests in this Motivation-Actor please select \"Add Group Test\"",
+    "tip_param_assessment_ref": "A query path in the form of a field or a sequence of nested fields separated by dot (example: organisation.id). These fields should be available in the assessment schema",
+    "tip_param_value": "Enter a specific number or string to be passed as parameter value",
+    "tip_select_param_type": "Please select if the value of the parameter is a reference to value provided by an existing assessment field or a hardcoded value",
+    "select_param_type": "Select the type of the parameter",
+    "tip_param_name": "Please provide a name for this parameter"
   },
   "page_tests": {
     "title": "Tests",

--- a/src/pages/motivations/components/MotivationActorModal.tsx
+++ b/src/pages/motivations/components/MotivationActorModal.tsx
@@ -1,7 +1,13 @@
 import { useMotivationAddActor } from "@/api/services/motivations";
+import { useGetAllTestMethods } from "@/api/services/registry";
 import { AuthContext } from "@/auth";
 import { relMtvActorId } from "@/config";
-import { AlertInfo, MotivationActor } from "@/types";
+import {
+  AlertInfo,
+  AutoGroupTest,
+  MotivationActor,
+  RegistryResource,
+} from "@/types";
 import { useContext, useEffect, useRef, useState } from "react";
 import {
   Modal,
@@ -12,17 +18,28 @@ import {
   Col,
   OverlayTrigger,
   Tooltip,
+  Alert,
+  ListGroup,
 } from "react-bootstrap";
+
 import toast from "react-hot-toast";
 import { useTranslation } from "react-i18next";
-import { FaInfoCircle, FaUser } from "react-icons/fa";
+import {
+  FaCogs,
+  FaInfoCircle,
+  FaPlus,
+  FaTrashAlt,
+  FaUser,
+} from "react-icons/fa";
 
 interface MotivationActorModalProps {
   motivationActors: MotivationActor[];
+
   id: string;
   show: boolean;
   onHide: () => void;
 }
+
 /**
  * Modal component for adding an actor to motivation
  */
@@ -31,27 +48,85 @@ export function MotivationActorModal(props: MotivationActorModalProps) {
     message: "",
   });
   const { t } = useTranslation();
-  const { keycloak } = useContext(AuthContext)!;
+  const { keycloak, registered } = useContext(AuthContext)!;
 
   const [actorId, setActorId] = useState("");
   const [showErrors, setShowErrors] = useState(false);
+  const [autoGroups, setAutoGroups] = useState<AutoGroupTest[]>([]);
+  const [testMethods, setTestMethods] = useState<RegistryResource[]>([]);
+
+  const {
+    data: testMethodsData,
+    fetchNextPage: tmFetchNextPage,
+    hasNextPage: tmHasNextPage,
+  } = useGetAllTestMethods({
+    size: 5,
+    token: keycloak?.token || "",
+    isRegistered: registered,
+    search: "",
+    enabled: true,
+  });
+
+  useEffect(() => {
+    // gather all test methods
+    let tmpTestMethods: RegistryResource[] = [];
+
+    // iterate over backend pages and gather all items in the metric types array
+    if (testMethodsData?.pages) {
+      testMethodsData.pages.map((page) => {
+        tmpTestMethods = [...tmpTestMethods, ...page.content];
+      });
+      if (tmHasNextPage) {
+        tmFetchNextPage();
+      }
+    }
+
+    tmpTestMethods = tmpTestMethods?.filter(
+      (testMethod) =>
+        testMethod?.label !== "String-Auto" &&
+        testMethod?.label !== "String-Manual" &&
+        testMethod?.label !== "Binary-Auto",
+    );
+
+    setTestMethods(tmpTestMethods);
+  }, [testMethodsData, tmHasNextPage, tmFetchNextPage]);
 
   const mutateAddActor = useMotivationAddActor(
     keycloak?.token || "",
     props.id,
     actorId,
     relMtvActorId,
+    autoGroups,
   );
 
   function handleValidate() {
     setShowErrors(true);
-    return actorId !== "";
+
+    // check if actor id is empty and return immediately
+    if (!actorId) return false;
+
+    // check against auto test groups
+    for (const group of autoGroups) {
+      if (!group.endpoint) return false;
+      if (!group.test_method) return false;
+      if (group.params) {
+        for (const param of group.params) {
+          if (!param.name) return false;
+          if ("assessment_ref" in param && param.assessment_ref === "")
+            return false;
+          if ("value" in param && param.value === "") return false;
+        }
+      }
+    }
+
+    return true;
   }
 
   useEffect(() => {
     if (props.show) {
       {
         setActorId("");
+        setAutoGroups([]);
       }
       setShowErrors(false);
     }
@@ -139,6 +214,366 @@ export function MotivationActorModal(props: MotivationActorModalProps) {
             )}
           </Col>
         </Row>
+        <hr />
+
+        <div className="d-flex justify-content-between mb-2">
+          <h5>{t("page_motivations.group_tests_section")}: </h5>
+          <Button
+            variant="warning"
+            size="sm"
+            onClick={() => {
+              setAutoGroups([
+                ...autoGroups,
+                { endpoint: "", test_method: "", params: [] },
+              ]);
+            }}
+          >
+            <FaPlus /> {t("buttons.add_group_test")}
+          </Button>
+        </div>
+        {autoGroups.length === 0 ? (
+          <Alert variant="secondary">
+            <em>{t("page_motivations.info_add_group_tests")}</em>
+          </Alert>
+        ) : (
+          <div>
+            {autoGroups.map((item, index) => (
+              <div key={index} className="p-2 border rounded mb-2">
+                <div className="d-flex justify-content-between mb-1">
+                  <div>
+                    <FaCogs className="me-2" size="1.2rem" />
+                    Automated group test {index + 1}:
+                  </div>
+                  <div>
+                    <Button
+                      onClick={() =>
+                        setAutoGroups((prev) =>
+                          prev.filter((_, i) => i !== index),
+                        )
+                      }
+                      variant="danger"
+                      size="sm"
+                    >
+                      <FaTrashAlt className="me-2" />
+                      Remove
+                    </Button>
+                  </div>
+                </div>
+                <InputGroup>
+                  <OverlayTrigger
+                    placement="top"
+                    overlay={
+                      <Tooltip>{t("page_motivations.tip_test_method")}</Tooltip>
+                    }
+                  >
+                    <InputGroup.Text id={`test-${index}-label-test-method`}>
+                      <FaInfoCircle className="me-2" /> {t("test_method")} (*):
+                    </InputGroup.Text>
+                  </OverlayTrigger>
+                  <Form.Select
+                    id={`test-${index}-input-test-method`}
+                    aria-describedby={`test-${index}-label-test-method`}
+                    value={item.test_method}
+                    onChange={(e) => {
+                      setAutoGroups((prev) =>
+                        prev.map((item, i) =>
+                          i === index
+                            ? { ...item, ["test_method"]: e.target.value }
+                            : item,
+                        ),
+                      );
+                    }}
+                  >
+                    <>
+                      <option value="" disabled>
+                        {t("page_motivations.select_test_method")}
+                      </option>
+                      {testMethods.map((item) => (
+                        <option key={item.id} value={item.label}>
+                          {item.label}
+                        </option>
+                      ))}
+                    </>
+                  </Form.Select>
+                </InputGroup>
+                {showErrors && !item.test_method && (
+                  <small className="text-danger">{t("required")}</small>
+                )}
+
+                <InputGroup className="mt-1">
+                  <OverlayTrigger
+                    placement="top"
+                    overlay={
+                      <Tooltip>{t("page_motivations.tip_endpoint")}</Tooltip>
+                    }
+                  >
+                    <InputGroup.Text id={`test-${index}-label-endpoint`}>
+                      <FaInfoCircle className="me-2" /> {t("endpoint")} (*):
+                    </InputGroup.Text>
+                  </OverlayTrigger>
+                  <Form.Control
+                    id={`test-${index}-input-endpoint`}
+                    placeholder={t("page_motivations.select_endpoint")}
+                    value={item.endpoint}
+                    onChange={(e) => {
+                      setAutoGroups((prev) =>
+                        prev.map((item, i) =>
+                          i === index
+                            ? { ...item, ["endpoint"]: e.target.value }
+                            : item,
+                        ),
+                      );
+                    }}
+                    aria-describedby={`test-${index}-label-endpoint`}
+                  />
+                </InputGroup>
+                {showErrors && !item.endpoint && (
+                  <small className="text-danger">{t("required")}</small>
+                )}
+                <div className="py-2 px-4 rounded border mt-1">
+                  <div className="d-flex justify-content-between">
+                    <div className="me-2">
+                      <strong>Parameters:</strong>
+                    </div>
+                    <div>
+                      <Button
+                        size="sm"
+                        variant="warning"
+                        onClick={() =>
+                          setAutoGroups((prev) =>
+                            prev.map((item, i) =>
+                              i === index
+                                ? {
+                                    ...item,
+                                    ["params"]: [
+                                      ...item.params,
+                                      { name: "", assessment_ref: "" },
+                                    ],
+                                  }
+                                : item,
+                            ),
+                          )
+                        }
+                      >
+                        <FaPlus /> Add Parameter
+                      </Button>
+                    </div>
+                  </div>
+                  <div>
+                    <ListGroup className="m-2">
+                      {autoGroups[index].params.map((paramItem, paramIndex) => (
+                        <ListGroup.Item key={paramIndex}>
+                          <div className="d-flex justify-content-between mb-1">
+                            <div>Parameter {paramIndex + 1}:</div>
+                            <div>
+                              <Button
+                                size="sm"
+                                variant="danger"
+                                onClick={() => {
+                                  setAutoGroups((prev) =>
+                                    prev.map((item, i) =>
+                                      i === index
+                                        ? {
+                                            ...item,
+                                            ["params"]: item.params.filter(
+                                              (_, j) => j !== paramIndex,
+                                            ),
+                                          }
+                                        : item,
+                                    ),
+                                  );
+                                }}
+                              >
+                                <FaTrashAlt className="me-2" />
+                                Remove
+                              </Button>
+                            </div>
+                          </div>
+                          <InputGroup>
+                            <OverlayTrigger
+                              placement="top"
+                              overlay={
+                                <Tooltip>
+                                  {t("page_motivations.tip_select_param_type")}
+                                </Tooltip>
+                              }
+                            >
+                              <InputGroup.Text
+                                id={`test-${index}-param-${paramIndex}-label-param-type`}
+                              >
+                                <FaInfoCircle className="me-2" />{" "}
+                                {t("param_type")} (*):
+                              </InputGroup.Text>
+                            </OverlayTrigger>
+                            <Form.Select
+                              id={`test-${index}-param-${paramIndex}-input-param-type`}
+                              aria-describedby={`test-${index}-param-${paramIndex}-param-type`}
+                              value={
+                                "assessment_ref" in paramItem ? "ref" : "val"
+                              }
+                              onChange={(e) => {
+                                setAutoGroups((prev) =>
+                                  prev.map((item, i) =>
+                                    i === index
+                                      ? {
+                                          ...item,
+                                          ["params"]: item.params.map(
+                                            (subItem, j) =>
+                                              j === paramIndex
+                                                ? e.target.value === "ref"
+                                                  ? {
+                                                      name: subItem.name,
+                                                      assessment_ref: "",
+                                                    }
+                                                  : {
+                                                      name: subItem.name,
+                                                      value: "",
+                                                    }
+                                                : subItem,
+                                          ),
+                                        }
+                                      : item,
+                                  ),
+                                );
+                              }}
+                            >
+                              <>
+                                <option value="" disabled>
+                                  {t("page_motivations.select_param_type")}
+                                </option>
+
+                                <option value="ref">
+                                  {t("assessment_ref")}
+                                </option>
+                                <option value="val">{t("value")}</option>
+                              </>
+                            </Form.Select>
+                          </InputGroup>
+
+                          <InputGroup className="mt-1">
+                            <OverlayTrigger
+                              placement="top"
+                              overlay={
+                                <Tooltip>
+                                  {t("page_motivations.tip_param_name")}
+                                </Tooltip>
+                              }
+                            >
+                              <InputGroup.Text
+                                id={`test-${index}-param-${paramIndex}-label-name`}
+                              >
+                                <FaInfoCircle className="me-2" />{" "}
+                                {t("fields.name")} (*):
+                              </InputGroup.Text>
+                            </OverlayTrigger>
+                            <Form.Control
+                              id={`test-${index}-param-${paramIndex}-input-name`}
+                              value={paramItem.name}
+                              onChange={(e) => {
+                                setAutoGroups((prev) =>
+                                  prev.map((item, i) =>
+                                    i === index
+                                      ? {
+                                          ...item,
+                                          ["params"]: item.params.map(
+                                            (subItem, j) =>
+                                              j === paramIndex
+                                                ? {
+                                                    ...subItem,
+                                                    ["name"]: e.target.value,
+                                                  }
+                                                : subItem,
+                                          ),
+                                        }
+                                      : item,
+                                  ),
+                                );
+                              }}
+                              aria-describedby={`test-${index}-param-${paramIndex}-label-name`}
+                            />
+                          </InputGroup>
+                          {showErrors && !paramItem.name && (
+                            <small className="text-danger">
+                              {t("required")}
+                            </small>
+                          )}
+                          <InputGroup className="mt-1">
+                            <OverlayTrigger
+                              placement="top"
+                              overlay={
+                                <Tooltip>
+                                  {"assessment_ref" in paramItem
+                                    ? t(
+                                        "page_motivations.tip_param_assessment_ref",
+                                      )
+                                    : t("page_motivations.tip_param_value")}
+                                </Tooltip>
+                              }
+                            >
+                              <InputGroup.Text
+                                id={`test-${index}-param-${paramIndex}-label-value`}
+                              >
+                                <FaInfoCircle className="me-2" />{" "}
+                                {"assessment_ref" in paramItem
+                                  ? t("assessment_ref")
+                                  : t("value")}{" "}
+                                (*):
+                              </InputGroup.Text>
+                            </OverlayTrigger>
+                            <Form.Control
+                              id={`test-${index}-param-${paramIndex}-input-value`}
+                              value={
+                                "assessment_ref" in paramItem
+                                  ? paramItem.assessment_ref
+                                  : paramItem.value
+                              }
+                              onChange={(e) => {
+                                setAutoGroups((prev) =>
+                                  prev.map((item, i) =>
+                                    i === index
+                                      ? {
+                                          ...item,
+                                          ["params"]: item.params.map(
+                                            (subItem, j) =>
+                                              j === paramIndex
+                                                ? "assessment_ref" in subItem
+                                                  ? {
+                                                      ...subItem,
+                                                      ["assessment_ref"]:
+                                                        e.target.value,
+                                                    }
+                                                  : {
+                                                      ...subItem,
+                                                      ["value"]: e.target.value,
+                                                    }
+                                                : subItem,
+                                          ),
+                                        }
+                                      : item,
+                                  ),
+                                );
+                              }}
+                              aria-describedby={`test-${index}-param-${paramIndex}-label-value`}
+                            />
+                          </InputGroup>
+                          {showErrors &&
+                            (("assessment_ref" in paramItem &&
+                              paramItem.assessment_ref === "") ||
+                              ("value" in paramItem &&
+                                paramItem.value === "")) && (
+                              <small className="text-danger">
+                                {t("required")}
+                              </small>
+                            )}
+                        </ListGroup.Item>
+                      ))}
+                    </ListGroup>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
       </Modal.Body>
       <Modal.Footer className="d-flex justify-content-between">
         <Button className="btn-secondary" onClick={props.onHide}>

--- a/src/types/assessment.ts
+++ b/src/types/assessment.ts
@@ -47,9 +47,9 @@ export interface AutoGroupTest {
 }
 
 export interface GroupTestParam {
-  name: "string";
-  assessment_ref?: "string";
-  value?: "string";
+  name: string;
+  assessment_ref?: string;
+  value?: string;
 }
 
 /** Reference with string id */


### PR DESCRIPTION
### Goal

Give the ability to administrators to optionally define Groups of Automated Tests in new Assessment Types. When a new Assessment Type is created (through the Add Motivation-Actor) modal the admin should have options to define new groups of automated tests.

Each Group of Automated tests relies on a a specific `test-method` in order to detect and group the tests that belong to it. It also needs to define a remote `endpoint` so that it can be called to perform the test. The endpoint might need additional POST parameters so for each test the user can define a list of parameters with specific values (or references to assessment fields to be used as values)

### Implementation
- [x] Define a type for parameters used in Automated Group Tests
- [x] Refactor backend react query mutation AddMotivationActor so as to accept a list of Automated Group Tests
- [x] Refactor MotivationActor Modal in order to maintain a state list of Automated Group Tests. Based on that list generate ui elements to allow user to fill in information
- [x] Add new i18n values
