### PR TITLE
[CAT-912] - Refactor Application Routing to Use Constants Routes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 import { AuthProvider, ProtectedRoute, KeycloakLogout } from "@/auth";
 import { Header, Footer } from "@/components";
+import ROUTES from "@/routes";
 import {
   Home,
   Profile,
@@ -89,23 +90,26 @@ function App() {
             <Header />
             <main className="cat-main-view">
               <Routes>
-                <Route path="/" element={<Home />} />
-                <Route path="/about/cat" element={<AboutCat />} />
+                <Route path={ROUTES.HOME} element={<Home />} />
+                <Route path={ROUTES.ABOUT.CAT} element={<AboutCat />} />
                 <Route
-                  path="/about/interoperability"
+                  path={ROUTES.ABOUT.INTEROPERABILITY}
                   element={<Interoperability />}
                 />
                 <Route
-                  path="/about/acceptable-use"
+                  path={ROUTES.ABOUT.ACCEPTABLE_USE}
                   element={<AcceptableUse />}
                 />
-                <Route path="/about/privacy" element={<Privacy />} />
-                <Route path="/about/disclaimer" element={<Disclaimer />} />
-                <Route path="/pid-selection" element={<PidSelection />} />
-                <Route path="/about/cookies" element={<Cookies />} />
-                <Route path="/about/terms" element={<Terms />} />
+                <Route path={ROUTES.ABOUT.PRIVACY} element={<Privacy />} />
                 <Route
-                  path="/assessments/create/:valID"
+                  path={ROUTES.ABOUT.DISCLAIMER}
+                  element={<Disclaimer />}
+                />
+                <Route path={ROUTES.PID_SELECTION} element={<PidSelection />} />
+                <Route path={ROUTES.ABOUT.COOKIES} element={<Cookies />} />
+                <Route path={ROUTES.ABOUT.TERMS} element={<Terms />} />
+                <Route
+                  path={ROUTES.ASSESSMENTS.CREATE_WITH_VALIDATION}
                   element={<ProtectedRoute />}
                 >
                   <Route
@@ -115,7 +119,10 @@ function App() {
                     }
                   />
                 </Route>
-                <Route path="/assessments/import" element={<ProtectedRoute />}>
+                <Route
+                  path={ROUTES.ASSESSMENTS.IMPORT}
+                  element={<ProtectedRoute />}
+                >
                   {/* Use AssessmentEdit component with mode = import */}
                   <Route
                     index
@@ -124,7 +131,10 @@ function App() {
                     }
                   />
                 </Route>
-                <Route path="/assessments/create/" element={<ProtectedRoute />}>
+                <Route
+                  path={ROUTES.ASSESSMENTS.CREATE}
+                  element={<ProtectedRoute />}
+                >
                   <Route
                     index
                     element={
@@ -133,70 +143,94 @@ function App() {
                   />
                 </Route>
                 <Route
-                  path="/assessments/:asmtId/view"
+                  path={ROUTES.ASSESSMENTS.VIEW}
                   element={<ProtectedRoute />}
                 >
                   {/* Use AssessmentView component with isPublic = false */}
                   <Route index element={<AssessmentView isPublic={false} />} />
                 </Route>
-                <Route path="/assessments/:asmtId" element={<ProtectedRoute />}>
+                <Route
+                  path={ROUTES.ASSESSMENTS.EDIT}
+                  element={<ProtectedRoute />}
+                >
                   {/* Use AssessmentEdit component with mode = edit */}
                   <Route
                     index
                     element={<AssessmentEdit mode={AssessmentEditMode.Edit} />}
                   />
                 </Route>
-                <Route path="/assess" element={<Assessments />} />
-                <Route path="/assessments" element={<ProtectedRoute />}>
+                <Route
+                  path={ROUTES.ASSESSMENTS.ASSESS}
+                  element={<Assessments />}
+                />
+                <Route
+                  path={ROUTES.ASSESSMENTS.ROOT}
+                  element={<ProtectedRoute />}
+                >
                   <Route index element={<AssessmentsList />} />
                 </Route>
                 <Route
-                  path="/public-assessments"
+                  path={ROUTES.PUBLIC_ASSESSMENTS.ROOT}
                   element={<AssessmentsList listPublic={true} />}
                 />
                 <Route
-                  path="/public-assessments/:asmtId/view"
+                  path={ROUTES.PUBLIC_ASSESSMENTS.VIEW}
                   element={<AssessmentView isPublic={true} />}
                 />
 
-                <Route path="/profile" element={<ProtectedRoute />}>
+                <Route path={ROUTES.PROFILE.ROOT} element={<ProtectedRoute />}>
                   <Route index element={<Profile />} />
                 </Route>
-                <Route path="/profile/update" element={<ProtectedRoute />}>
+                <Route
+                  path={ROUTES.PROFILE.UPDATE}
+                  element={<ProtectedRoute />}
+                >
                   <Route index element={<ProfileUpdate />} />
                 </Route>
-                <Route path="/admin/users" element={<ProtectedRoute />}>
+                <Route path={ROUTES.ADMIN.USERS} element={<ProtectedRoute />}>
                   <Route index element={<AdminUsers />} />
                 </Route>
                 <Route
-                  path="/admin/users/view/:id"
+                  path={ROUTES.ADMIN.USER_VIEW}
                   element={<ProtectedRoute />}
                 >
                   <Route index element={<ViewUsers />} />
                 </Route>
-                <Route path="/validations/request" element={<ProtectedRoute />}>
+                <Route
+                  path={ROUTES.VALIDATIONS.REQUEST}
+                  element={<ProtectedRoute />}
+                >
                   <Route index element={<RequestValidation />} />
                 </Route>
-                <Route path="/subjects" element={<ProtectedRoute />}>
+                <Route path={ROUTES.SUBJECTS} element={<ProtectedRoute />}>
                   <Route index element={<Subjects />} />
                 </Route>
-                <Route path="/validations" element={<ProtectedRoute />}>
+                <Route
+                  path={ROUTES.VALIDATIONS.ROOT}
+                  element={<ProtectedRoute />}
+                >
                   <Route index element={<ValidationList />} />
                 </Route>
-                <Route path="/validations/:id" element={<ProtectedRoute />}>
+                <Route
+                  path={ROUTES.VALIDATIONS.VIEW}
+                  element={<ProtectedRoute />}
+                >
                   <Route index element={<ValidationDetails />} />
                 </Route>
-                <Route path="/admin/validations" element={<ProtectedRoute />}>
+                <Route
+                  path={ROUTES.ADMIN.VALIDATIONS}
+                  element={<ProtectedRoute />}
+                >
                   <Route index element={<AdminValidations />} />
                 </Route>
                 <Route
-                  path="/admin/validations/:id"
+                  path={ROUTES.ADMIN.VALIDATION_VIEW}
                   element={<ProtectedRoute />}
                 >
                   <Route index element={<ValidationDetails admin={true} />} />
                 </Route>
                 <Route
-                  path="/admin/validations/:id/reject"
+                  path={ROUTES.ADMIN.VALIDATION_REJECT}
                   element={<ProtectedRoute />}
                 >
                   <Route
@@ -205,7 +239,7 @@ function App() {
                   />
                 </Route>
                 <Route
-                  path="/admin/validations/:id/approve"
+                  path={ROUTES.ADMIN.VALIDATION_APPROVE}
                   element={<ProtectedRoute />}
                 >
                   <Route
@@ -215,103 +249,124 @@ function App() {
                     }
                   />
                 </Route>
-                <Route path="/admin/motivations" element={<ProtectedRoute />}>
+                <Route
+                  path={ROUTES.ADMIN.MOTIVATIONS.ROOT}
+                  element={<ProtectedRoute />}
+                >
                   <Route index element={<Motivations />} />
                 </Route>
                 <Route
-                  path="/admin/motivations/:id"
+                  path={ROUTES.ADMIN.MOTIVATIONS.VIEW}
                   element={<ProtectedRoute />}
                 >
                   <Route index element={<MotivationDetails />} />
                 </Route>
                 <Route
-                  path="/admin/motivations/:mtvId/manage-criteria-principles"
+                  path={ROUTES.ADMIN.MOTIVATIONS.MANAGE_CRITERIA}
                   element={<ProtectedRoute />}
                 >
                   <Route index element={<MotivationCriteriaPrinciples />} />
                 </Route>
                 <Route
-                  path="/admin/motivations/:mtvId/actors/:actId"
+                  path={ROUTES.ADMIN.MOTIVATIONS.ACTOR_CRITERIA}
                   element={<ProtectedRoute />}
                 >
                   <Route index element={<MotivationActorCriteria />} />
                 </Route>
                 <Route
-                  path="/admin/motivations/:mtvId/metrics-tests/:mtrId"
+                  path={ROUTES.ADMIN.MOTIVATIONS.METRICS_TESTS}
                   element={<ProtectedRoute />}
                 >
                   <Route index element={<MotivationMetricTests />} />
                 </Route>
                 <Route
-                  path="/admin/motivations/:mtvId/templates/actors/:actId"
+                  path={ROUTES.ADMIN.MOTIVATIONS.TEMPLATES}
                   element={<ProtectedRoute />}
                 >
                   <Route index element={<MotivationAssessmentEditor />} />
                 </Route>
-                <Route path="/admin/principles" element={<ProtectedRoute />}>
+                <Route
+                  path={ROUTES.ADMIN.PRINCIPLES.ROOT}
+                  element={<ProtectedRoute />}
+                >
                   <Route index element={<Principles />} />
                 </Route>
-                <Route path="/admin/criteria" element={<ProtectedRoute />}>
+                <Route
+                  path={ROUTES.ADMIN.CRITERIA.ROOT}
+                  element={<ProtectedRoute />}
+                >
                   <Route index element={<Criteria />} />
                 </Route>
-                <Route path="/admin/tests" element={<ProtectedRoute />}>
+                <Route
+                  path={ROUTES.ADMIN.TESTS.ROOT}
+                  element={<ProtectedRoute />}
+                >
                   <Route index element={<Tests />} />
                 </Route>
                 <Route
-                  path="/admin/tests/create-test"
+                  path={ROUTES.ADMIN.TESTS.CREATE}
                   element={<ProtectedRoute />}
                 >
                   <Route index element={<CreateTest />} />
                 </Route>
                 <Route
-                  path="/admin/tests/edit-test/:testId"
+                  path={ROUTES.ADMIN.TESTS.EDIT}
                   element={<ProtectedRoute />}
                 >
                   <Route index element={<CreateTest />} />
                 </Route>
                 <Route
-                  path="/admin/tests/create-version-test/:testId"
+                  path={ROUTES.ADMIN.TESTS.CREATE_VERSION}
                   element={<ProtectedRoute />}
                 >
                   <Route index element={<CreateTest />} />
                 </Route>
-                <Route path="/admin/assessments" element={<ProtectedRoute />}>
+                <Route
+                  path={ROUTES.ADMIN.ASSESSMENTS}
+                  element={<ProtectedRoute />}
+                >
                   <Route index element={<AdminAssessments />} />
                 </Route>
-                <Route path="/admin/metrics" element={<ProtectedRoute />}>
+                <Route
+                  path={ROUTES.ADMIN.METRICS.ROOT}
+                  element={<ProtectedRoute />}
+                >
                   <Route index element={<Metrics />} />
                 </Route>
-                <Route path="/login" element={<ProtectedRoute />}>
+                <Route path={ROUTES.LOGIN} element={<ProtectedRoute />}>
                   <Route index element={<Profile />} />
                 </Route>
-                <Route path="/admin/settings" element={<ProtectedRoute />}>
+                <Route
+                  path={ROUTES.ADMIN.SETTINGS.ROOT}
+                  element={<ProtectedRoute />}
+                >
                   <Route index element={<Settings />} />
                 </Route>
                 <Route
-                  path="/admin/settings/test-methods"
+                  path={ROUTES.ADMIN.SETTINGS.TEST_METHODS}
                   element={<ProtectedRoute />}
                 >
                   <Route index element={<TestMethodsSettings />} />
                 </Route>
                 <Route
-                  path="/admin/settings/metric-types"
+                  path={ROUTES.ADMIN.SETTINGS.METRIC_TYPES}
                   element={<ProtectedRoute />}
                 >
                   <Route index element={<MetricTypesSettings />} />
                 </Route>
                 <Route
-                  path="/admin/settings/algorithms"
+                  path={ROUTES.ADMIN.SETTINGS.ALGORITHMS}
                   element={<ProtectedRoute />}
                 >
                   <Route index element={<AlgorithmsSettings />} />
                 </Route>
                 <Route
-                  path="/admin/settings/benchmark-types"
+                  path={ROUTES.ADMIN.SETTINGS.BENCHMARK_TYPES}
                   element={<ProtectedRoute />}
                 >
                   <Route index element={<BenchmarkTypesSettings />} />
                 </Route>
-                <Route path="/logout" element={<KeycloakLogout />} />
+                <Route path={ROUTES.LOGOUT} element={<KeycloakLogout />} />
               </Routes>
             </main>
             <Footer />

--- a/src/api/services/assessments.ts
+++ b/src/api/services/assessments.ts
@@ -21,6 +21,7 @@ import {
 } from "@/types";
 import { AxiosError } from "axios";
 import { handleBackendError } from "@/utils";
+import ROUTES from "../../routes";
 
 export function useCreateAssessment(token: string) {
   const navigate = useNavigate();
@@ -30,7 +31,7 @@ export function useCreateAssessment(token: string) {
     },
     // for the time being redirect to assessment list
     onSuccess: () => {
-      navigate("/assessments");
+      navigate(ROUTES.ASSESSMENTS.ROOT);
     },
   });
 }

--- a/src/auth/KeycloakLogout.tsx
+++ b/src/auth/KeycloakLogout.tsx
@@ -1,6 +1,7 @@
 import { useContext, useEffect } from "react";
 import { Navigate } from "react-router-dom";
 import { AuthContext } from "@/auth";
+import ROUTES from "../routes";
 
 export const KeycloakLogout = () => {
   const { keycloak } = useContext(AuthContext)!;
@@ -16,5 +17,5 @@ export const KeycloakLogout = () => {
     logout();
   }, [keycloak]);
 
-  return <Navigate to="/" replace={true} />;
+  return <Navigate to={ROUTES.HOME} replace={true} />;
 };

--- a/src/auth/ProtectedRoute.tsx
+++ b/src/auth/ProtectedRoute.tsx
@@ -4,6 +4,7 @@ import { AuthContext } from "@/auth";
 import Keycloak from "keycloak-js";
 import KeycloakConfig from "@/keycloak.json";
 import { useUserRegister, useGetProfile } from "@/api";
+import ROUTES from "@/routes";
 
 import UserMenu from "@/components/UserMenu";
 import AdminMenu from "@/components/AdminMenu";
@@ -100,7 +101,8 @@ export function ProtectedRoute() {
   // check if a non-admin user tries to access an admin view
   useEffect(() => {
     if (authenticated && adminRoute && profileData) {
-      if (profileData.user_type.toLowerCase() !== "admin") navigate("/profile");
+      if (profileData.user_type.toLowerCase() !== "admin")
+        navigate(ROUTES.PROFILE.ROOT);
     }
   }, [authenticated, adminRoute, profileData, navigate]);
 

--- a/src/components/AdminMenu.tsx
+++ b/src/components/AdminMenu.tsx
@@ -10,6 +10,7 @@ import {
 } from "react-icons/fa";
 import { FaClipboardQuestion, FaFileCircleCheck } from "react-icons/fa6";
 import { Link, useLocation } from "react-router-dom";
+import ROUTES from "../routes";
 
 function isSel(path: string, name: string): boolean {
   return path.toLowerCase() === name.toLowerCase();
@@ -28,7 +29,7 @@ export default function AdminMenu() {
           <div>
             <li>
               <Link
-                to="/profile"
+                to={ROUTES.PROFILE.ROOT}
                 className={`cat-nav-link-item ${isSel(userPath, "profile") ? "active" : ""}`}
               >
                 <FaUsers /> {t("profile")}
@@ -36,7 +37,7 @@ export default function AdminMenu() {
             </li>
             <li>
               <Link
-                to="/validations"
+                to={ROUTES.VALIDATIONS.ROOT}
                 className={`cat-nav-link-item ${isSel(userPath, "validations") ? "active" : ""}`}
               >
                 <FaUsers /> {t("validations")}
@@ -44,7 +45,7 @@ export default function AdminMenu() {
             </li>
             <li>
               <Link
-                to="/assessments"
+                to={ROUTES.ASSESSMENTS.ROOT}
                 className={`cat-nav-link-item ${isSel(userPath, "assessments") ? "active" : ""}`}
               >
                 <FaUsers /> {t("assessments")}
@@ -52,7 +53,7 @@ export default function AdminMenu() {
             </li>
             <li>
               <Link
-                to="/subjects"
+                to={ROUTES.SUBJECTS}
                 className={`cat-nav-link-item ${isSel(userPath, "subjects") ? "active" : ""}`}
               >
                 <FaUsers /> {t("subjects")}
@@ -66,7 +67,7 @@ export default function AdminMenu() {
           <div>
             <li>
               <Link
-                to="/admin/users"
+                to={ROUTES.ADMIN.USERS}
                 className={`cat-nav-link-item ${isSel(adminPath, "users") ? "active" : ""}`}
               >
                 <FaUsers /> {t("users")}
@@ -74,7 +75,7 @@ export default function AdminMenu() {
             </li>
             <li>
               <Link
-                to="/admin/validations"
+                to={ROUTES.ADMIN.VALIDATIONS}
                 className={`cat-nav-link-item ${isSel(adminPath, "validations") ? "active" : ""}`}
               >
                 <FaCheckCircle /> {t("validations")}
@@ -82,7 +83,7 @@ export default function AdminMenu() {
             </li>
             <li>
               <Link
-                to="/admin/assessments"
+                to={ROUTES.ADMIN.ASSESSMENTS}
                 className={`cat-nav-link-item ${isSel(adminPath, "assessments") ? "active" : ""}`}
               >
                 <FaFileCircleCheck /> {t("assessments")}
@@ -96,7 +97,7 @@ export default function AdminMenu() {
           <div>
             <li>
               <Link
-                to="/admin/motivations"
+                to={ROUTES.ADMIN.MOTIVATIONS.ROOT}
                 className={`cat-nav-link-item ${isSel(adminPath, "motivations") ? "active" : ""}`}
               >
                 <FaFile /> {t("motivations")}
@@ -104,7 +105,7 @@ export default function AdminMenu() {
             </li>
             <li>
               <Link
-                to="/admin/principles"
+                to={ROUTES.ADMIN.PRINCIPLES.ROOT}
                 className={`cat-nav-link-item ${isSel(adminPath, "principles") ? "active" : ""}`}
               >
                 <FaTags /> {t("principles")}
@@ -112,7 +113,7 @@ export default function AdminMenu() {
             </li>
             <li>
               <Link
-                to="/admin/criteria"
+                to={ROUTES.ADMIN.CRITERIA.ROOT}
                 className={`cat-nav-link-item ${isSel(adminPath, "criteria") ? "active" : ""}`}
               >
                 <FaAward /> {t("criteria")}
@@ -120,7 +121,7 @@ export default function AdminMenu() {
             </li>
             <li>
               <Link
-                to="/admin/tests"
+                to={ROUTES.ADMIN.TESTS.ROOT}
                 className={`cat-nav-link-item ${isSel(adminPath, "tests") ? "active" : ""}`}
               >
                 <FaClipboardQuestion /> {t("tests")}
@@ -128,7 +129,7 @@ export default function AdminMenu() {
             </li>
             <li>
               <Link
-                to="/admin/metrics"
+                to={ROUTES.ADMIN.METRICS.ROOT}
                 className={`cat-nav-link-item ${isSel(adminPath, "metrics") ? "active" : ""}`}
               >
                 <FaBorderNone /> {t("metrics")}
@@ -142,7 +143,7 @@ export default function AdminMenu() {
           <div>
             <li>
               <Link
-                to="/admin/settings"
+                to={ROUTES.ADMIN.SETTINGS.ROOT}
                 className={`cat-nav-link-item ${isSel(adminPath, "settings") ? "active" : ""}`}
               >
                 <FaCog /> {t("Settings")}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -8,6 +8,7 @@ import { Link } from "react-router-dom";
 import packageJson from "@/../package.json";
 import { useTranslation } from "react-i18next";
 import { linksDocs, linksGithub } from "@/config";
+import ROUTES from "../routes";
 
 function Footer() {
   // tag build information on footer
@@ -25,29 +26,29 @@ function Footer() {
             <h6>{t("footer.about_category")}</h6>
             <ul className="list-unstyled">
               <li>
-                <Link to="/about/cat">{t("footer.about_cat")}</Link>
+                <Link to={ROUTES.ABOUT.CAT}>{t("footer.about_cat")}</Link>
               </li>
               <li>
-                <Link to="/about/interoperability">
+                <Link to={ROUTES.ABOUT.INTEROPERABILITY}>
                   {t("interoperability_guidelines")}
                 </Link>
               </li>
               <li>
-                <Link to="/about/acceptable-use">
+                <Link to={ROUTES.ABOUT.ACCEPTABLE_USE}>
                   {t("acceptable_use_policy")}
                 </Link>
               </li>
               <li>
-                <Link to="/about/terms">{t("page_terms.title")}</Link>
+                <Link to={ROUTES.ABOUT.TERMS}>{t("page_terms.title")}</Link>
               </li>
               <li>
-                <Link to="/about/cookies">{t("page_cookies.title")}</Link>
+                <Link to={ROUTES.ABOUT.COOKIES}>{t("page_cookies.title")}</Link>
               </li>
               <li>
-                <Link to="/about/privacy">{t("privacy_statement")}</Link>
+                <Link to={ROUTES.ABOUT.PRIVACY}>{t("privacy_statement")}</Link>
               </li>
               <li>
-                <Link to="/about/disclaimer">{t("disclaimer")}</Link>
+                <Link to={ROUTES.ABOUT.DISCLAIMER}>{t("disclaimer")}</Link>
               </li>
             </ul>
           </Col>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -8,6 +8,7 @@ import { AuthContext } from "@/auth";
 import { FaUser, FaShieldAlt } from "react-icons/fa";
 import { UserProfile } from "@/types";
 import { useTranslation } from "react-i18next";
+import ROUTES from "../routes";
 
 function Header() {
   const { authenticated, keycloak, registered } = useContext(AuthContext)!;
@@ -31,7 +32,7 @@ function Header() {
           <Navbar.Brand>
             {" "}
             {/* Branding logos */}
-            <Link to="/">
+            <Link to={ROUTES.HOME}>
               <img
                 src={logo}
                 height="46"
@@ -49,7 +50,7 @@ function Header() {
               {authenticated && userProfile?.id && (
                 <>
                   <NavItem>
-                    <Link to="/validations" className="cat-nav-link">
+                    <Link to={ROUTES.VALIDATIONS.ROOT} className="cat-nav-link">
                       {t("validations").toUpperCase()}
                     </Link>
                   </NavItem>
@@ -57,12 +58,12 @@ function Header() {
               )}
 
               <NavItem>
-                <Link to="/assess" className="cat-nav-link">
+                <Link to={ROUTES.ASSESSMENTS.ASSESS} className="cat-nav-link">
                   {t("assessments").toUpperCase()}
                 </Link>
               </NavItem>
               <NavItem>
-                <Link to="/pid-selection" className="cat-nav-link">
+                <Link to={ROUTES.PID_SELECTION} className="cat-nav-link">
                   {t("pid_selection").toUpperCase()}
                 </Link>
               </NavItem>
@@ -73,7 +74,7 @@ function Header() {
               {!authenticated && (
                 <Link
                   id="login-button"
-                  to="/login"
+                  to={ROUTES.LOGIN}
                   className="btn btn-primary my-2"
                 >
                   {t("buttons.login")}
@@ -88,39 +89,48 @@ function Header() {
                   </Dropdown.Toggle>
 
                   <Dropdown.Menu>
-                    <Dropdown.Item as={Link} to="/profile">
+                    <Dropdown.Item as={Link} to={ROUTES.PROFILE.ROOT}>
                       {t("profile")}
                     </Dropdown.Item>
 
                     {userProfile?.user_type === "Admin" && (
                       <>
                         <Dropdown.Divider />
-                        <Dropdown.Item as={Link} to="/admin/motivations">
+                        <Dropdown.Item
+                          as={Link}
+                          to={ROUTES.ADMIN.MOTIVATIONS.ROOT}
+                        >
                           <FaShieldAlt /> {t("motivations")}
                         </Dropdown.Item>
-                        <Dropdown.Item as={Link} to="/admin/principles">
+                        <Dropdown.Item
+                          as={Link}
+                          to={ROUTES.ADMIN.PRINCIPLES.ROOT}
+                        >
                           <FaShieldAlt /> {t("principles")}
                         </Dropdown.Item>
-                        <Dropdown.Item as={Link} to="/admin/criteria">
+                        <Dropdown.Item
+                          as={Link}
+                          to={ROUTES.ADMIN.CRITERIA.ROOT}
+                        >
                           <FaShieldAlt /> {t("criteria")}
                         </Dropdown.Item>
-                        <Dropdown.Item as={Link} to="/admin/users">
+                        <Dropdown.Item as={Link} to={ROUTES.ADMIN.USERS}>
                           <FaShieldAlt /> {t("users")}
                         </Dropdown.Item>
                         <Dropdown.Item
                           id="admin_validation"
                           as={Link}
-                          to="/admin/validations"
+                          to={ROUTES.ADMIN.VALIDATIONS}
                         >
                           <FaShieldAlt /> {t("validations")}
                         </Dropdown.Item>
-                        <Dropdown.Item as={Link} to="/admin/assessments">
+                        <Dropdown.Item as={Link} to={ROUTES.ADMIN.ASSESSMENTS}>
                           <FaShieldAlt /> {t("assessments")}
                         </Dropdown.Item>
                         <Dropdown.Divider />
                       </>
                     )}
-                    <Dropdown.Item as={Link} to="/logout">
+                    <Dropdown.Item as={Link} to={ROUTES.LOGOUT}>
                       {t("buttons.logout")}
                     </Dropdown.Item>
                   </Dropdown.Menu>

--- a/src/components/MotivationRefList.tsx
+++ b/src/components/MotivationRefList.tsx
@@ -1,5 +1,6 @@
 import { MotivationReference } from "@/types";
 import { Link } from "react-router-dom";
+import ROUTES, { buildRoute } from "../routes";
 
 /**
  * Small component to display a short list of motivations in which the item is included.
@@ -16,7 +17,7 @@ export const MotivationRefList = ({
           <span className="badge bg-primary-cat border">
             <Link
               className="text-muted"
-              to={`/admin/motivations/${item.id}`}
+              to={buildRoute(ROUTES.ADMIN.MOTIVATIONS.VIEW, { mtvId: item.id })}
             >{`${item.label}`}</Link>
           </span>
         </span>

--- a/src/components/SettingsLayout.tsx
+++ b/src/components/SettingsLayout.tsx
@@ -7,8 +7,12 @@ import {
   Form,
   Spinner,
   Alert,
+  Button,
 } from "react-bootstrap";
 import { FaLock } from "react-icons/fa";
+import { useNavigate } from "react-router-dom";
+import { useTranslation } from "react-i18next";
+import ROUTES from "../routes";
 
 export interface SettingsItem {
   id: string;
@@ -39,6 +43,9 @@ const SettingsLayout: React.FC<SettingsLayoutProps> = ({
   onToggleItem,
   itemTypeName,
 }) => {
+  const navigate = useNavigate();
+  const { t } = useTranslation();
+
   if (isLoading) {
     return (
       <Container fluid className="py-4">
@@ -160,6 +167,15 @@ const SettingsLayout: React.FC<SettingsLayoutProps> = ({
           </Card>
         </Col>
       </Row>
+      <Button
+        className="mt-4"
+        variant="secondary"
+        onClick={() => {
+          navigate(ROUTES.ADMIN.SETTINGS.ROOT);
+        }}
+      >
+        {t("buttons.back")}
+      </Button>
     </div>
   );
 };

--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from "react-i18next";
 import { FaUsers } from "react-icons/fa";
 import { Link, useLocation } from "react-router-dom";
+import ROUTES from "../routes";
 
 function isSel(path: string, name: string): boolean {
   return path.toLowerCase() === name.toLowerCase();
@@ -18,7 +19,7 @@ export default function UserMenu() {
           <div>
             <li>
               <Link
-                to="/profile"
+                to={ROUTES.PROFILE.ROOT}
                 className={`cat-nav-link-item ${isSel(userPath, "profile") ? "active" : ""}`}
               >
                 <FaUsers /> {t("profile")}
@@ -26,7 +27,7 @@ export default function UserMenu() {
             </li>
             <li>
               <Link
-                to="/validations"
+                to={ROUTES.VALIDATIONS.ROOT}
                 className={`cat-nav-link-item ${isSel(userPath, "validations") ? "active" : ""}`}
               >
                 <FaUsers /> {t("validations")}
@@ -34,7 +35,7 @@ export default function UserMenu() {
             </li>
             <li>
               <Link
-                to="/assessments"
+                to={ROUTES.ASSESSMENTS.ROOT}
                 className={`cat-nav-link-item ${isSel(userPath, "assessments") ? "active" : ""}`}
               >
                 <FaUsers /> {t("assessments")}
@@ -42,7 +43,7 @@ export default function UserMenu() {
             </li>
             <li>
               <Link
-                to="/subjects"
+                to={ROUTES.SUBJECTS}
                 className={`cat-nav-link-item ${isSel(userPath, "subjects") ? "active" : ""}`}
               >
                 <FaUsers /> {t("subjects")}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -6,6 +6,7 @@ import { Link } from "react-router-dom";
 import serviceImg from "@/assets/thumb_service.png";
 import manageImg from "@/assets/thumb_manage.png";
 import ownersImg from "@/assets/thumb_user.png";
+import ROUTES from "../routes";
 
 function Home() {
   const { data } = useGetStatistics();
@@ -22,7 +23,10 @@ function Home() {
             {t("page_home.description")}
             <br />
             <span className="float-right">
-              <Link to="/assess" className="btn btn-light mt-4 ">
+              <Link
+                to={ROUTES.ASSESSMENTS.ASSESS}
+                className="btn btn-light mt-4 "
+              >
                 <FaInfoCircle className="me-2 text-muted" />{" "}
                 {t("buttons.about")}...
               </Link>

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -15,6 +15,7 @@ import { idToColor, trimField } from "@/utils/admin";
 import { Tooltip, OverlayTrigger, TooltipProps } from "react-bootstrap";
 import { CopyToClipboard } from "react-copy-to-clipboard";
 import { useTranslation } from "react-i18next";
+import ROUTES from "@/routes";
 
 function Profile() {
   const { t } = useTranslation();
@@ -115,7 +116,7 @@ function Profile() {
               )}
               <Link
                 id="profile-update-button"
-                to="/profile/update"
+                to={ROUTES.PROFILE.UPDATE}
                 className="btn btn-lt border-black mt-4"
               >
                 {t("buttons.update_details")}
@@ -144,14 +145,14 @@ function Profile() {
                       <div className="mt-4">
                         <Link
                           id="view_validations_button"
-                          to="/validations"
+                          to={ROUTES.VALIDATIONS.ROOT}
                           className="btn btn-light border-black"
                         >
                           {t("buttons.view_list")}
                         </Link>
                         <Link
                           id="create_validation_button"
-                          to="/validations/request"
+                          to={ROUTES.VALIDATIONS.REQUEST}
                           className="btn btn-light border-black mx-3"
                         >
                           <FaPlus /> {t("buttons.create_new")}
@@ -171,14 +172,14 @@ function Profile() {
                       <div className="mt-4">
                         <Link
                           id="view_assessments_button"
-                          to="/assessments"
+                          to={ROUTES.ASSESSMENTS.ROOT}
                           className="btn btn-light border-black"
                         >
                           {t("buttons.view_list")}
                         </Link>
                         <Link
                           id="create_assessment_button"
-                          to="/assessments/create"
+                          to={ROUTES.ASSESSMENTS.CREATE}
                           className="btn btn-light border-black mx-3"
                         >
                           <FaPlus /> {t("buttons.create_new")}
@@ -199,14 +200,14 @@ function Profile() {
                       <div className="mt-4">
                         <Link
                           id="view_subjects_button"
-                          to="/subjects"
+                          to={ROUTES.SUBJECTS}
                           className="btn btn-light border-black"
                         >
                           {t("buttons.view_list")}
                         </Link>
                         <Link
                           id="create_subject_button"
-                          to="/subjects?create"
+                          to={`${ROUTES.SUBJECTS}?create`}
                           className="btn btn-light border-black mx-3"
                         >
                           <FaPlus /> {t("buttons.create_new")}

--- a/src/pages/ProfileUpdate.tsx
+++ b/src/pages/ProfileUpdate.tsx
@@ -8,6 +8,7 @@ import { AxiosError } from "axios";
 import { useGetProfile } from "@/api";
 import logoOrcid from "@/assets/logo-orcid-id.svg";
 import { useTranslation } from "react-i18next";
+import ROUTES from "../routes";
 
 type FormData = {
   name: string;
@@ -53,7 +54,7 @@ export default function ProfileUpdate() {
       );
       if (response.status === 200) {
         // if all good go back to profile
-        navigate("/profile");
+        navigate(ROUTES.PROFILE.ROOT);
       }
     } catch (error) {
       const err = error as AxiosError;
@@ -179,7 +180,7 @@ export default function ProfileUpdate() {
             <button
               type="button"
               onClick={() => {
-                navigate("/profile");
+                navigate(ROUTES.PROFILE.ROOT);
               }}
               className="btn btn-dark mx-3"
             >

--- a/src/pages/admin/AdminAssessments.tsx
+++ b/src/pages/admin/AdminAssessments.tsx
@@ -30,6 +30,7 @@ import { AuthContext } from "@/auth";
 import { prettyPrintRanking } from "@/utils";
 import { Link } from "react-router-dom";
 import { DeleteModal } from "@/components/DeleteModal";
+import ROUTES from "../../routes";
 
 import { toast } from "react-hot-toast";
 import { useTranslation } from "react-i18next";
@@ -518,7 +519,10 @@ function AdminAssessments() {
           )}
           <div className="d-flex justify-content-between pb-4">
             <div>
-              <Link className="btn btn-secondary" to="/assess">
+              <Link
+                className="btn btn-secondary"
+                to={ROUTES.ASSESSMENTS.ASSESS}
+              >
                 {t("buttons.back")}
               </Link>
             </div>

--- a/src/pages/admin/AdminUsers.tsx
+++ b/src/pages/admin/AdminUsers.tsx
@@ -26,6 +26,7 @@ import {
 import toast from "react-hot-toast";
 import { idToColor, trimField } from "@/utils/admin";
 import { Link } from "react-router-dom";
+import ROUTES, { buildRoute } from "../../routes";
 import { useTranslation } from "react-i18next";
 import { t } from "i18next";
 import BadgeUserType from "@/components/BadgeUserType";
@@ -450,7 +451,9 @@ export default function AdminUsers() {
                       >
                         <Link
                           className="btn btn-sm btn-light"
-                          to={`/admin/users/view/${item.id}`}
+                          to={buildRoute(ROUTES.ADMIN.USER_VIEW, {
+                            id: item.id.toString(),
+                          })}
                         >
                           <FaBars />
                         </Link>

--- a/src/pages/admin/AdminValidations.tsx
+++ b/src/pages/admin/AdminValidations.tsx
@@ -25,6 +25,7 @@ import {
   FaUserCircle,
 } from "react-icons/fa";
 import { Link } from "react-router-dom";
+import ROUTES, { buildRoute } from "../../routes";
 
 import BadgeStatus from "@/components/BadgeStatus";
 
@@ -299,7 +300,9 @@ export default function AdminValidations() {
                       <OverlayTrigger placement="top" overlay={tooltipView}>
                         <Link
                           className="btn btn-light btn-sm m-1"
-                          to={`/admin/validations/${item.id}`}
+                          to={buildRoute(ROUTES.ADMIN.VALIDATION_VIEW, {
+                            id: item.id.toString(),
+                          })}
                         >
                           <FaBars />
                         </Link>
@@ -308,7 +311,7 @@ export default function AdminValidations() {
                         <OverlayTrigger placement="top" overlay={tooltipAccept}>
                           <Link
                             className="btn btn-light btn-sm m-1"
-                            to={`/admin/validations/${item.id}/approve#alert-spot`}
+                            to={`${buildRoute(ROUTES.ADMIN.VALIDATION_APPROVE, { id: item.id.toString() })}#alert-spot`}
                           >
                             <FaCheck />
                           </Link>
@@ -318,7 +321,7 @@ export default function AdminValidations() {
                         <OverlayTrigger placement="top" overlay={tooltipReject}>
                           <Link
                             className="btn btn-light btn-sm m-1"
-                            to={`/admin/validations/${item.id}/reject/#alert-spot`}
+                            to={`${buildRoute(ROUTES.ADMIN.VALIDATION_REJECT, { id: item.id.toString() })}#alert-spot`}
                           >
                             <FaTimes />
                           </Link>

--- a/src/pages/assessments/AssessmentEdit.tsx
+++ b/src/pages/assessments/AssessmentEdit.tsx
@@ -59,6 +59,7 @@ import FormCheckInput from "react-bootstrap/esm/FormCheckInput";
 import { useTranslation } from "react-i18next";
 import { GroupTestModal } from "./components/tests/GroupTestModal";
 import { FaGears } from "react-icons/fa6";
+import ROUTES from "../../routes";
 
 type AssessmentEditProps = {
   mode: AssessmentEditMode;
@@ -318,7 +319,7 @@ const AssessmentEdit = ({
             message: t("page_assessment_edit.toast_update_success"),
           };
           if (exit) {
-            navigate("/assessments");
+            navigate(ROUTES.ASSESSMENTS.ROOT);
           }
         });
       toast.promise(promise, {
@@ -819,7 +820,7 @@ const AssessmentEdit = ({
                         <small>
                           <FaHandPointRight />{" "}
                           {` ${t("page_assessment_edit.imp5")} `}
-                          <Link to="/assessments">
+                          <Link to={ROUTES.ASSESSMENTS.ROOT}>
                             {t("page_assessment_edit.imp6")}
                           </Link>
                           {` ${t("page_assessment_edit.imp7")} `}

--- a/src/pages/assessments/Assessments.tsx
+++ b/src/pages/assessments/Assessments.tsx
@@ -1,5 +1,6 @@
 import { FaFileImport, FaList, FaPlus } from "react-icons/fa";
 import { Link } from "react-router-dom";
+import ROUTES from "../../routes";
 import schemesImg from "@/assets/thumb_scheme.png";
 import authImg from "@/assets/thumb_auth.png";
 import serviceImg from "@/assets/thumb_service.png";
@@ -78,7 +79,7 @@ function Assessments() {
           <div className="col-md-auto cat-heading-right">
             <Link
               id="view_assessments_button"
-              to="/assessments"
+              to={ROUTES.ASSESSMENTS.ROOT}
               className="btn btn-light border-black me-3"
             >
               <FaList />{" "}
@@ -89,7 +90,7 @@ function Assessments() {
             </Link>
             <Link
               id="assessment_form_button"
-              to={`/assessments/create`}
+              to={ROUTES.ASSESSMENTS.CREATE}
               className="btn btn-warning me-3"
             >
               <FaPlus />{" "}
@@ -97,7 +98,7 @@ function Assessments() {
             </Link>
             <Link
               id="assessment_form_button"
-              to={`/assessments/import`}
+              to={ROUTES.ASSESSMENTS.IMPORT}
               className="btn btn-info"
             >
               <FaFileImport />{" "}

--- a/src/pages/assessments/AssessmentsList.tsx
+++ b/src/pages/assessments/AssessmentsList.tsx
@@ -36,6 +36,7 @@ import { AuthContext } from "@/auth";
 import { getUniqueValuesForKey, prettyPrintRanking } from "@/utils";
 import { Link } from "react-router-dom";
 import { DeleteModal } from "@/components/DeleteModal";
+import ROUTES, { buildRoute } from "../../routes";
 
 import { toast } from "react-hot-toast";
 import { ShareModal } from "./components/ShareModal";
@@ -317,11 +318,17 @@ function AssessmentsList({ listPublic = false }: AssessmentListProps) {
         <div className="col-md-auto cat-heading-right">
           {!listPublic && (
             <>
-              <Link to="/assessments/create" className="btn btn-warning  ms-3">
+              <Link
+                to={ROUTES.ASSESSMENTS.CREATE}
+                className="btn btn-warning  ms-3"
+              >
                 <FaPlus />{" "}
                 <span className="align-middle">{t("buttons.create_new")}</span>
               </Link>
-              <Link to="/assessments/import" className="btn btn-dark  ms-3">
+              <Link
+                to={ROUTES.ASSESSMENTS.IMPORT}
+                className="btn btn-dark  ms-3"
+              >
                 <FaFileImport />{" "}
                 <span className="align-middle">{t("buttons.import")}</span>
               </Link>
@@ -573,7 +580,16 @@ function AssessmentsList({ listPublic = false }: AssessmentListProps) {
                               <Link
                                 id={`view-button-${item.id}`}
                                 className="btn btn-light btn-sm m-1"
-                                to={`/${listPublic ? "public-" : ""}assessments/${item.id}/view`}
+                                to={
+                                  listPublic
+                                    ? buildRoute(
+                                        ROUTES.PUBLIC_ASSESSMENTS.VIEW,
+                                        { asmtId: item.id },
+                                      )
+                                    : buildRoute(ROUTES.ASSESSMENTS.VIEW, {
+                                        asmtId: item.id,
+                                      })
+                                }
                               >
                                 <FaBars />
                               </Link>
@@ -590,7 +606,9 @@ function AssessmentsList({ listPublic = false }: AssessmentListProps) {
                                 <Link
                                   id={`edit-button-${item.id}`}
                                   className="btn btn-light btn-sm m-1"
-                                  to={`/assessments/${item.id}`}
+                                  to={buildRoute(ROUTES.ASSESSMENTS.EDIT, {
+                                    asmtId: item.id,
+                                  })}
                                 >
                                   <FaEdit />
                                 </Link>
@@ -724,7 +742,10 @@ function AssessmentsList({ listPublic = false }: AssessmentListProps) {
           )}
           <div className="d-flex justify-content-between pb-4">
             <div>
-              <Link className="btn btn-secondary" to="/assess">
+              <Link
+                className="btn btn-secondary"
+                to={ROUTES.ASSESSMENTS.ASSESS}
+              >
                 {t("buttons.back")}
               </Link>
             </div>

--- a/src/pages/motivations/MotivationCriteriaPrinciples.tsx
+++ b/src/pages/motivations/MotivationCriteriaPrinciples.tsx
@@ -15,6 +15,7 @@ import {
 import { FaTrashCan } from "react-icons/fa6";
 import { useParams, useNavigate } from "react-router-dom";
 import MotivationPrinciplesModal from "./components/MotivationPrinciplesModal";
+import ROUTES, { buildRoute } from "@/routes";
 
 import { relMtvPrincpleCriterion } from "@/config";
 import {
@@ -171,7 +172,11 @@ export default function MotivationCriteriaPrinciples() {
           alert.current = {
             message: t("page_motivations.toast_manage_cri_success"),
           };
-          navigate(`/admin/motivations/${params.mtvId}`);
+          navigate(
+            buildRoute(ROUTES.ADMIN.MOTIVATIONS.VIEW, {
+              mtvId: params.mtvId!,
+            }),
+          );
         });
       toast.promise(promise, {
         loading: t("page_motivations.toast_manage_cri_progress"),
@@ -444,7 +449,11 @@ export default function MotivationCriteriaPrinciples() {
         <Button
           variant="secondary"
           onClick={() => {
-            navigate(`/admin/motivations/${params.mtvId}`);
+            navigate(
+              buildRoute(ROUTES.ADMIN.MOTIVATIONS.VIEW, {
+                mtvId: params.mtvId!,
+              }),
+            );
           }}
         >
           {t("buttons.back")}

--- a/src/pages/motivations/MotivationDetails.tsx
+++ b/src/pages/motivations/MotivationDetails.tsx
@@ -54,6 +54,7 @@ import { DeleteModal } from "@/components/DeleteModal";
 import { MotivationMetrics } from "./components/MotivationMetrics";
 import { useTranslation } from "react-i18next";
 import { SearchBox } from "@/components/SearchBox";
+import ROUTES, { buildRoute } from "../../routes";
 
 const actorImages: { [key: string]: string } = {
   "PID Service Provider (Role)": serviceImg,
@@ -595,7 +596,13 @@ export default function MotivationDetails() {
                                   >
                                     <Link
                                       className="btn btn-light btn-sm m-1"
-                                      to={`/admin/motivations/${params.id}/templates/actors/${item.id}`}
+                                      to={buildRoute(
+                                        ROUTES.ADMIN.MOTIVATIONS.TEMPLATES,
+                                        {
+                                          mtvId: params.id || "",
+                                          actId: item.id,
+                                        },
+                                      )}
                                     >
                                       <FaBars />
                                     </Link>
@@ -612,7 +619,14 @@ export default function MotivationDetails() {
                                       <>
                                         <Link
                                           className="btn btn-light btn-sm m-1"
-                                          to={`/admin/motivations/${params.id}/actors/${item.id}`}
+                                          to={buildRoute(
+                                            ROUTES.ADMIN.MOTIVATIONS
+                                              .ACTOR_CRITERIA,
+                                            {
+                                              mtvId: params.id || "",
+                                              actId: item.id,
+                                            },
+                                          )}
                                         >
                                           <FaAward />
                                         </Link>
@@ -762,7 +776,7 @@ export default function MotivationDetails() {
         <Button
           variant="secondary"
           onClick={() => {
-            navigate(`/admin/motivations`);
+            navigate(ROUTES.ADMIN.MOTIVATIONS.ROOT);
           }}
         >
           {t("buttons.back")}

--- a/src/pages/motivations/MotivationMetricTests.tsx
+++ b/src/pages/motivations/MotivationMetricTests.tsx
@@ -16,6 +16,7 @@ import { RegistryTest } from "@/types/tests";
 import { useGetAllTests } from "@/api/services/registry";
 import { useTranslation } from "react-i18next";
 import { SearchBox } from "@/components/SearchBox";
+import ROUTES, { buildRoute } from "../../routes";
 
 export default function MotivationMetricTests() {
   const navigate = useNavigate();
@@ -138,7 +139,11 @@ export default function MotivationMetricTests() {
           alert.current = {
             message: t("page_motivations.toast_assign_metric_success"),
           };
-          navigate(`/admin/motivations/${params.mtvId}#metrics`);
+          navigate(
+            buildRoute(ROUTES.ADMIN.MOTIVATIONS.VIEW, {
+              mtvId: params.mtvId!,
+            }) + "#metrics",
+          );
         });
       toast.promise(promise, {
         loading: t("page_motivations.toast_assign_metric_progress"),
@@ -197,7 +202,7 @@ export default function MotivationMetricTests() {
             </div>
             <div>
               <Button
-                href="/admin/tests/create-test"
+                href={ROUTES.ADMIN.TESTS.CREATE}
                 size="sm"
                 variant="warning"
               >
@@ -296,7 +301,11 @@ export default function MotivationMetricTests() {
       <div className="d-flex justify-content-between">
         <Link
           className="btn btn-secondary"
-          to={`/admin/motivations/${params.mtvId}#metrics`}
+          to={
+            buildRoute(ROUTES.ADMIN.MOTIVATIONS.VIEW, {
+              mtvId: params.mtvId!,
+            }) + "#metrics"
+          }
         >
           {t("buttons.back")}
         </Link>

--- a/src/pages/motivations/Motivations.tsx
+++ b/src/pages/motivations/Motivations.tsx
@@ -29,6 +29,7 @@ import {
 } from "@/api/services/motivations";
 import { AlertInfo, Motivation } from "@/types";
 import { Link } from "react-router-dom";
+import ROUTES, { buildRoute } from "../../routes";
 import { MotivationModal } from "./components/MotivationModal";
 import toast from "react-hot-toast";
 import { useTranslation } from "react-i18next";
@@ -292,7 +293,9 @@ export default function Motivations() {
                         >
                           <Link
                             className="btn btn-light btn-sm m-1"
-                            to={`/admin/motivations/${item.id}`}
+                            to={buildRoute(ROUTES.ADMIN.MOTIVATIONS.VIEW, {
+                              mtvId: item.id,
+                            })}
                           >
                             <FaBars />
                           </Link>

--- a/src/pages/motivations/components/MotivationCriteria.tsx
+++ b/src/pages/motivations/components/MotivationCriteria.tsx
@@ -15,6 +15,7 @@ import notavailImg from "@/assets/thumb_notavail.png";
 import { MotivationMetricDetailsModal } from "./MotivationMetricDetailsModal";
 import { FaBars, FaBorderNone, FaEdit } from "react-icons/fa";
 import { Link } from "react-router-dom";
+import ROUTES, { buildRoute } from "../../../routes";
 import { MotivationMetricAssignModal } from "./MotivationMetricAssignModal";
 import { useTranslation } from "react-i18next";
 import { SearchBox } from "@/components/SearchBox";
@@ -130,7 +131,9 @@ export const MotivationCriteria = ({
           ) : (
             <Link
               id="manage-motivation-criteria-principles"
-              to={`/admin/motivations/${mtvId}/manage-criteria-principles`}
+              to={buildRoute(ROUTES.ADMIN.MOTIVATIONS.MANAGE_CRITERIA, {
+                mtvId: mtvId,
+              })}
               className="btn btn-warning"
             >
               <FaEdit className="me-2" />

--- a/src/pages/motivations/components/MotivationMetrics.tsx
+++ b/src/pages/motivations/components/MotivationMetrics.tsx
@@ -31,6 +31,7 @@ import {
 import { MotivationMetricModal } from "./MotivationMetricModal";
 import { useDeleteMotivationMetric, useGetAllMotivationMetrics } from "@/api";
 import { Link } from "react-router-dom";
+import ROUTES, { buildRoute } from "../../../routes";
 import { useTranslation } from "react-i18next";
 import { MotivationMetricDetailsModal } from "./MotivationMetricDetailsModal";
 import toast from "react-hot-toast";
@@ -419,7 +420,10 @@ export const MotivationMetrics = ({
                       >
                         <Link
                           className="btn btn-light"
-                          to={`/admin/motivations/${mtvId}/metrics-tests/${item.metric_id}`}
+                          to={buildRoute(
+                            ROUTES.ADMIN.MOTIVATIONS.METRICS_TESTS,
+                            { mtvId: mtvId, metricId: item.metric_id },
+                          )}
                         >
                           <FaCog />
                         </Link>
@@ -556,7 +560,10 @@ export const MotivationMetrics = ({
                           >
                             <Link
                               className="btn btn-light"
-                              to={`/admin/motivations/${mtvId}/metrics-tests/${version.metric_id}`}
+                              to={buildRoute(
+                                ROUTES.ADMIN.MOTIVATIONS.METRICS_TESTS,
+                                { mtvId: mtvId, metricId: version.metric_id },
+                              )}
                             >
                               <FaCog />
                             </Link>

--- a/src/pages/tests/Tests.tsx
+++ b/src/pages/tests/Tests.tsx
@@ -12,6 +12,7 @@ import TestSearch from "./components/TestSearch";
 import TestTable from "./components/TestTable";
 import TestPagination from "./components/TestPagination";
 import { useNavigate } from "react-router-dom";
+import ROUTES, { buildRoute } from "../../routes";
 
 type TestsState = {
   sortOrder: string;
@@ -164,10 +165,10 @@ function Tests() {
           })
         }
         onEditTest={(testId: string) =>
-          navigate(`/admin/tests/edit-test/${testId}`)
+          navigate(buildRoute(ROUTES.ADMIN.TESTS.EDIT, { testId }))
         }
         onCreateVersion={(testId: string) =>
-          navigate(`/admin/tests/create-version-test/${testId}`)
+          navigate(buildRoute(ROUTES.ADMIN.TESTS.CREATE_VERSION, { testId }))
         }
         onDeleteTest={(testId, name) =>
           setDeleteModalConfig({

--- a/src/pages/tests/components/CreateTest.tsx
+++ b/src/pages/tests/components/CreateTest.tsx
@@ -13,6 +13,7 @@ import toast from "react-hot-toast";
 import { useTranslation } from "react-i18next";
 import { useParams, useLocation, useNavigate } from "react-router-dom";
 import TestModalContainer from "./TestModalContainer";
+import ROUTES from "../../../routes";
 
 function CreateTest() {
   const alert = useRef<AlertInfo>({
@@ -237,7 +238,7 @@ function CreateTest() {
         };
         // Navigate back to tests list after successful creation
         setTimeout(() => {
-          navigate("/admin/tests");
+          navigate(ROUTES.ADMIN.TESTS.ROOT);
         }, 1500);
       });
     toast.promise(promise, {
@@ -263,7 +264,7 @@ function CreateTest() {
         };
         // Navigate back to tests list after successful update
         setTimeout(() => {
-          navigate("/admin/tests");
+          navigate(ROUTES.ADMIN.TESTS.ROOT);
         }, 1500);
       });
     toast.promise(promise, {
@@ -289,7 +290,7 @@ function CreateTest() {
         };
         // Navigate back to tests list after successful version creation
         setTimeout(() => {
-          navigate("/admin/tests");
+          navigate(ROUTES.ADMIN.TESTS.ROOT);
         }, 1500);
       });
     toast.promise(promise, {

--- a/src/pages/tests/components/TestsHeader.tsx
+++ b/src/pages/tests/components/TestsHeader.tsx
@@ -1,6 +1,7 @@
 import { Button } from "react-bootstrap";
 import { FaPlus } from "react-icons/fa";
 import { useTranslation } from "react-i18next";
+import ROUTES from "@/routes";
 
 const TestsHeader = () => {
   const { t } = useTranslation();
@@ -14,7 +15,7 @@ const TestsHeader = () => {
         </h2>
       </div>
       <div className="col-md-auto cat-heading-right">
-        <Button href="/admin/tests/create-test" variant="warning">
+        <Button href={ROUTES.ADMIN.TESTS.CREATE} variant="warning">
           <FaPlus /> {t("buttons.create_new")}
         </Button>
       </div>

--- a/src/pages/validations/RequestValidation.tsx
+++ b/src/pages/validations/RequestValidation.tsx
@@ -20,6 +20,7 @@ import { useTranslation } from "react-i18next";
 import { FaInfoCircle } from "react-icons/fa";
 import { useNavigate, Link } from "react-router-dom";
 import Select, { SingleValue } from "react-select";
+import ROUTES from "../../routes";
 
 function RequestValidation() {
   const navigate = useNavigate();
@@ -140,7 +141,7 @@ function RequestValidation() {
           message: "Validation request succesfully submitted.",
         };
       })
-      .then(() => navigate("/validations"));
+      .then(() => navigate(ROUTES.VALIDATIONS.ROOT));
     toast.promise(promise, {
       loading: "Submitting",
       success: () => `${alert.current.message}`,
@@ -488,7 +489,10 @@ function RequestValidation() {
           >
             {t("buttons.submit")}
           </button>
-          <Link to="/validations" className="my-2 btn btn-secondary mx-3">
+          <Link
+            to={ROUTES.VALIDATIONS.ROOT}
+            className="my-2 btn btn-secondary mx-3"
+          >
             <span>{t("buttons.cancel")}</span>
           </Link>
         </div>

--- a/src/pages/validations/ValidationDetails.tsx
+++ b/src/pages/validations/ValidationDetails.tsx
@@ -23,6 +23,7 @@ import { idToColor, trimField } from "@/utils/admin";
 import { Tooltip, OverlayTrigger, TooltipProps } from "react-bootstrap";
 import { CopyToClipboard } from "react-copy-to-clipboard";
 import { useTranslation } from "react-i18next";
+import ROUTES, { buildRoute } from "../../routes";
 
 function ValidationDetails(props: ValidationProps) {
   const { t } = useTranslation();
@@ -119,7 +120,7 @@ function ValidationDetails(props: ValidationProps) {
                     message: t("page_validation_details.toast_reject_success"),
                   };
                 })
-                .finally(() => navigate("/admin/validations"));
+                .finally(() => navigate(ROUTES.ADMIN.VALIDATIONS));
               toast.promise(promise, {
                 loading: t("page_validation_details.toast_reject_progress"),
                 success: () => `${alert.current.message}`,
@@ -131,7 +132,9 @@ function ValidationDetails(props: ValidationProps) {
           </button>
           <button
             onClick={() => {
-              navigate(`/admin/validations/${params.id}`);
+              navigate(
+                buildRoute(ROUTES.ADMIN.VALIDATION_VIEW, { id: params.id! }),
+              );
             }}
             className="btn btn-dark mx-4"
           >
@@ -172,7 +175,7 @@ function ValidationDetails(props: ValidationProps) {
                     message: t("page_validation_details.toast_approve_success"),
                   };
                 })
-                .finally(() => navigate("/admin/validations"));
+                .finally(() => navigate(ROUTES.ADMIN.VALIDATIONS));
               toast.promise(promise, {
                 loading: t("page_validation_details.toast_approve_progress"),
                 success: () => `${alert.current.message}`,
@@ -184,7 +187,9 @@ function ValidationDetails(props: ValidationProps) {
           </button>
           <button
             onClick={() => {
-              navigate(`/admin/validations/${params.id}`);
+              navigate(
+                buildRoute(ROUTES.ADMIN.VALIDATION_VIEW, { id: params.id! }),
+              );
             }}
             className="btn btn-dark mx-4"
           >
@@ -225,13 +230,13 @@ function ValidationDetails(props: ValidationProps) {
                 <span>
                   <Link
                     className="btn btn-light border-black text-success"
-                    to={`/admin/validations/${params.id}/approve#alert-spot`}
+                    to={`${buildRoute(ROUTES.ADMIN.VALIDATION_APPROVE, { id: params.id || "" })}#alert-spot`}
                   >
                     <FaCheck /> {t("buttons.approve")}
                   </Link>
                   <Link
                     className="btn btn-light mx-4 text-danger border-black"
-                    to={`/admin/validations/${params.id}/reject#alert-spot`}
+                    to={`${buildRoute(ROUTES.ADMIN.VALIDATION_REJECT, { id: params.id || "" })}#alert-spot`}
                   >
                     <FaTimes /> {t("buttons.reject")}
                   </Link>
@@ -404,7 +409,9 @@ function ValidationDetails(props: ValidationProps) {
 
         <Link
           className="btn btn-secondary my-4"
-          to={`${isAdmin.current ? "/admin" : ""}/validations`}
+          to={
+            isAdmin.current ? ROUTES.ADMIN.VALIDATIONS : ROUTES.VALIDATIONS.ROOT
+          }
         >
           {t("buttons.back")}
         </Link>

--- a/src/pages/validations/ValidationList.tsx
+++ b/src/pages/validations/ValidationList.tsx
@@ -14,6 +14,7 @@ import {
 import { Alert, OverlayTrigger, Table, Tooltip } from "react-bootstrap";
 import { useTranslation } from "react-i18next";
 import BadgeStatus from "@/components/BadgeStatus";
+import ROUTES, { buildRoute } from "../../routes";
 
 type ValidationState = {
   sortOrder: string;
@@ -75,7 +76,10 @@ function ValidationList() {
           </h2>
         </div>
         <div className="col-md-auto cat-heading-right">
-          <Link to="/validations/request" className="btn btn-warning mx-2">
+          <Link
+            to={ROUTES.VALIDATIONS.REQUEST}
+            className="btn btn-warning mx-2"
+          >
             <FaPlus className="m2" /> {t("buttons.create_new")}
           </Link>
         </div>
@@ -129,7 +133,9 @@ function ValidationList() {
                         >
                           <Link
                             className="btn btn-light btn-sm m-1"
-                            to={`/validations/${item.id}`}
+                            to={buildRoute(ROUTES.VALIDATIONS.VIEW, {
+                              id: item.id.toString(),
+                            })}
                           >
                             <FaList />
                           </Link>

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -1,0 +1,108 @@
+const ROUTES = {
+  HOME: "/",
+  ABOUT: {
+    CAT: "/about/cat",
+    INTEROPERABILITY: "/about/interoperability",
+    ACCEPTABLE_USE: "/about/acceptable-use",
+    PRIVACY: "/about/privacy",
+    TERMS: "/about/terms",
+    DISCLAIMER: "/about/disclaimer",
+    COOKIES: "/about/cookies",
+  },
+  PID_SELECTION: "/pid-selection",
+  ASSESSMENTS: {
+    ROOT: "/assessments",
+    CREATE: "/assessments/create",
+    CREATE_WITH_VALIDATION: "/assessments/create/:valID",
+    IMPORT: "/assessments/import",
+    EDIT: "/assessments/:asmtId",
+    VIEW: "/assessments/:asmtId/view",
+    ASSESS: "/assess",
+  },
+  PUBLIC_ASSESSMENTS: {
+    ROOT: "/public-assessments",
+    VIEW: "/public-assessments/:asmtId/view",
+  },
+  PROFILE: {
+    ROOT: "/profile",
+    UPDATE: "/profile/update",
+  },
+  SUBJECTS: "/subjects",
+  VALIDATIONS: {
+    ROOT: "/validations",
+    REQUEST: "/validations/request",
+    VIEW: "/validations/:id",
+  },
+  LOGIN: "/login",
+  ADMIN: {
+    DASHBOARD: "/admin",
+    USERS: "/admin/users",
+    USER_VIEW: "/admin/users/view/:id",
+    VALIDATIONS: "/admin/validations",
+    VALIDATION_VIEW: "/admin/validations/:id",
+    VALIDATION_REJECT: "/admin/validations/:id/reject",
+    VALIDATION_APPROVE: "/admin/validations/:id/approve",
+    ASSESSMENTS: "/admin/assessments",
+    SETTINGS: {
+      ROOT: "/admin/settings",
+      TEST_METHODS: "/admin/settings/test-methods",
+      METRIC_TYPES: "/admin/settings/metric-types",
+      ALGORITHMS: "/admin/settings/algorithms",
+      BENCHMARK_TYPES: "/admin/settings/benchmark-types",
+    },
+    MOTIVATIONS: {
+      ROOT: "/admin/motivations",
+      VIEW: "/admin/motivations/:mtvId",
+      MANAGE_CRITERIA: "/admin/motivations/:mtvId/manage-criteria-principles",
+      METRICS_TESTS: "/admin/motivations/:mtvId/metrics-tests/:metricId",
+      ACTOR_CRITERIA: "/admin/motivations/:mtvId/actors/:actId",
+      TEMPLATES: "/admin/motivations/:mtvId/templates/actors/:actId",
+    },
+    CRITERIA: {
+      ROOT: "/admin/criteria",
+      VIEW: "/admin/criteria/:criId",
+    },
+    METRICS: {
+      ROOT: "/admin/metrics",
+      VIEW: "/admin/metrics/:mtrId",
+    },
+    TESTS: {
+      ROOT: "/admin/tests",
+      VIEW: "/admin/tests/:testId",
+      CREATE: "/admin/tests/create-test",
+      EDIT: "/admin/tests/edit-test/:testId",
+      CREATE_VERSION: "/admin/tests/create-version-test/:testId",
+    },
+    PRINCIPLES: {
+      ROOT: "/admin/principles",
+      VIEW: "/admin/principles/:priId",
+    },
+  },
+  REGISTRY: {
+    MOTIVATIONS: "/registry/motivations",
+    CRITERIA: "/registry/criteria",
+    METRICS: "/registry/metrics",
+    TESTS: "/registry/tests",
+    PRINCIPLES: "/registry/principles",
+  },
+  USER_ROLE: {
+    ROOT: "/user-role",
+    REQUESTS: "/user-role-requests",
+    GUIDE: "/user-role-guide",
+    USERS_TABLE: "/users-table",
+  },
+  LOGOUT: "/logout",
+};
+
+// Helper function to build routes with parameters
+export const buildRoute = (
+  template: string,
+  params: Record<string, string>,
+): string => {
+  return Object.entries(params).reduce(
+    (route, [key, value]) => route.replace(`:${key}`, value),
+    template,
+  );
+};
+
+export default ROUTES;


### PR DESCRIPTION
This PR removes all hardcoded route strings from the application and replaces them with constants from a central routes file. 

- Replaced hardcoded paths in <Link> components
- Updated navigate() calls to use route constants instead of strings
- Updated href attributes to use centralized routes
- Added helper function buildRoute for dynamic routes with parameters