### PR TITLE
CAT-913 Update styling in autotest details

### DIFF
--- a/src/assets/locales/en.json
+++ b/src/assets/locales/en.json
@@ -41,6 +41,7 @@
   "published": "Published",
   "required": "Required",
   "draft": "Draft",
+  "automated_test_details": "Automated test details",
   "compliance_policy": "Compliance Policy",
   "interoperability_guidelines": "Interoperability Guidelines",
   "acceptable_use_policy": "Acceptable Use Policy",
@@ -72,8 +73,11 @@
   "toast_assessment_publish_progress": "Publishing Assessment...",
   "toast_assessment_unpublish_success": "Assessment Unpublished!",
   "toast_assessment_unpublish_progress": "Unpublishing Assessment...",
+  "test_group_contains": "This Automated Test Group contains the following tests",
+  "test_group_run": "To run this test group please press the button below...",
   "param_type": "Parameter Type",
   "test_method": "Test Method",
+  "running_test_group": "Test Group is running...",
   "total": "Total",
   "buttons": {
     "login": "Login",
@@ -109,7 +113,6 @@
     "publish": "Publish",
     "unpublish": "Unpublish",
     "run_test_group": "Run Test Group",
-    "running_test_group": "Test Group is running...",
     "add_group_test": "Add Group Test"
   },
   "fields": {
@@ -173,7 +176,6 @@
     "version": "Version",
     "commit": "Commit"
   },
-
   "page_profile": {
     "title": "User Dashboard",
     "validation_requests_subtitle": "View your current validation requests or create a new one.",

--- a/src/pages/assessments/AssessmentView.tsx
+++ b/src/pages/assessments/AssessmentView.tsx
@@ -4,7 +4,7 @@ import { useParams } from "react-router";
 
 import { useGetAssessment } from "@/api";
 import { DebugJSON } from "./components/DebugJSON";
-import { Alert, Button, Card, Col, Row } from "react-bootstrap";
+import { Button, Card, Col, Row } from "react-bootstrap";
 import { useNavigate } from "react-router-dom";
 import imgAssessmentPass from "@/assets/assessment-pass.png";
 import imgAssessmentBadgePassed from "@/assets/badge-passed.png";
@@ -20,6 +20,7 @@ import { FaArrowUpRightFromSquare } from "react-icons/fa6";
 import AssessmentPdf from "./AssessmentPdf";
 import { useTranslation } from "react-i18next";
 import { prettyPrintRanking } from "@/utils";
+import { AutoTestDetails } from "./components/tests/AutoTestDetails";
 
 // dig through the assessment and collect the completion statistics
 function gatherStats(assessment: Assessment | undefined): AssessmentStats {
@@ -421,49 +422,10 @@ const AssessmentView = ({ isPublic }: { isPublic: boolean }) => {
                                       )}
 
                                     {test.last_run && (
-                                      <div className="ps-4">
-                                        <div>
-                                          <em>
-                                            <small>
-                                              <strong>
-                                                {t("autotest_info")}
-                                              </strong>
-                                            </small>
-                                          </em>
-                                        </div>
-                                        <div className="mt-2">
-                                          {test.last_run && (
-                                            <Alert
-                                              variant={
-                                                test.last_run.code == 200
-                                                  ? "success"
-                                                  : "danger"
-                                              }
-                                            >
-                                              <div>
-                                                <em>
-                                                  <small>
-                                                    <strong>
-                                                      {t("last_run")}:
-                                                    </strong>{" "}
-                                                    {test.last_run.timestamp}
-                                                  </small>
-                                                </em>
-                                              </div>
-                                              <div>
-                                                <em>
-                                                  <small>
-                                                    <strong>
-                                                      {t("message")}:
-                                                    </strong>{" "}
-                                                    {test.last_run.message}
-                                                  </small>
-                                                </em>
-                                              </div>
-                                            </Alert>
-                                          )}
-                                        </div>
-                                      </div>
+                                      <AutoTestDetails
+                                        details={test.last_run}
+                                        variant="white"
+                                      />
                                     )}
                                   </div>
                                 );

--- a/src/pages/assessments/components/tests/AutoTestDetails.tsx
+++ b/src/pages/assessments/components/tests/AutoTestDetails.tsx
@@ -1,0 +1,45 @@
+import { LastRun } from "@/types";
+import { Alert, Col, Row } from "react-bootstrap";
+import { useTranslation } from "react-i18next";
+
+interface AutoTestDetailsProps {
+  variant?: string;
+  details: LastRun;
+}
+
+export const AutoTestDetails = (props: AutoTestDetailsProps) => {
+  const { t } = useTranslation();
+
+  const fmtDate = props.details.timestamp
+    ? new Date(props.details.timestamp)
+        .toLocaleString("en-US", {
+          month: "short",
+          day: "numeric",
+          year: "numeric",
+          hour: "numeric",
+          minute: "2-digit",
+          hour12: false,
+          timeZone: "UTC",
+        })
+        .replace(/,\s*/, " ") + " (UTC)"
+    : "";
+  return (
+    <Alert variant={props.variant ? props.variant : "light"}>
+      <Row>
+        <Col>
+          <small>
+            <strong>{t("automated_test_details")}:</strong>
+          </small>
+        </Col>
+        <Col xs="auto">
+          <small>
+            {t("last_run")}: {fmtDate}
+          </small>
+        </Col>
+      </Row>
+      <div className="mt-1">
+        <small>{props.details.message}</small>
+      </div>
+    </Alert>
+  );
+};

--- a/src/pages/assessments/components/tests/GroupTestModal.tsx
+++ b/src/pages/assessments/components/tests/GroupTestModal.tsx
@@ -30,6 +30,7 @@ import { APIClient } from "@/api";
 import { AxiosError } from "axios";
 import { applyAutoGroupResults, queryValue } from "@/utils";
 import { AuthContext } from "@/auth";
+import { AutoTestDetails } from "./AutoTestDetails";
 
 interface GroupTestModalProps {
   groupTest: AutoGroupTest | null;
@@ -153,7 +154,7 @@ export function GroupTestModal(props: GroupTestModalProps) {
 
           const lastRunInfo = {
             code: okResp.test_status.code,
-            timestamp: okResp.last_run,
+            timestamp: new Date().toISOString(),
             message: okResp.test_status.message,
           };
           // handle params
@@ -216,7 +217,7 @@ export function GroupTestModal(props: GroupTestModalProps) {
         </Modal.Title>
       </Modal.Header>
       <Modal.Body>
-        <p>This automated test group contains the following tests:</p>
+        <p>{t("test_group_contains")}:</p>
         <ListGroup className="mb-2">
           <div>
             {Object.keys(groupTests).map((key) => {
@@ -230,7 +231,7 @@ export function GroupTestModal(props: GroupTestModalProps) {
                     </small>
                     {item.criterionImperative.toLowerCase() === "must" ? (
                       <small className="ms-2 badge badge-sm bg-light border text-secondary">
-                        required
+                        {t("required")}
                       </small>
                     ) : null}
                   </div>
@@ -240,7 +241,7 @@ export function GroupTestModal(props: GroupTestModalProps) {
                       <strong className="ms-2">{item.testName}</strong>
                     </div>
                     <div>
-                      {item.result ? (
+                      {item.result !== null ? (
                         item.result ? (
                           <FaCheckCircle className="text-success" />
                         ) : (
@@ -254,14 +255,7 @@ export function GroupTestModal(props: GroupTestModalProps) {
                   {item.last_run &&
                     item.last_run.message &&
                     item.last_run.timestamp && (
-                      <div>
-                        <div className="text-light">
-                          <small>Last Run: {item.last_run.timestamp}</small>
-                        </div>
-                        <div className="text-light">
-                          <small>Message: {item.last_run.message}</small>
-                        </div>
-                      </div>
+                      <AutoTestDetails details={item.last_run} />
                     )}
                 </ListGroupItem>
               );
@@ -271,14 +265,14 @@ export function GroupTestModal(props: GroupTestModalProps) {
         {runningTest ? (
           <Alert variant="warning" className="py-1">
             <FaPlayCircle className="me-2" />
-            Test running...
+            {t("running_test_group")}
           </Alert>
         ) : (
           <div>
             {!error && !message && (
               <Alert variant="warning" className="py-1">
                 <FaInfoCircle className="me-2" />
-                To run this test group please press the button below...
+                {t("test_group_run")}
               </Alert>
             )}
             {error && (

--- a/src/pages/assessments/components/tests/TestAutoG069Form.tsx
+++ b/src/pages/assessments/components/tests/TestAutoG069Form.tsx
@@ -3,15 +3,7 @@
  */
 
 // import { useState } from "react"
-import {
-  Alert,
-  Badge,
-  Button,
-  Col,
-  Form,
-  InputGroup,
-  Row,
-} from "react-bootstrap";
+import { Badge, Button, Col, Form, InputGroup, Row } from "react-bootstrap";
 import { TestToolTip } from "./TestToolTip";
 import {
   AssessmentTest,
@@ -26,6 +18,7 @@ import { AuthContext } from "@/auth";
 import { AxiosError } from "axios";
 import { useTranslation } from "react-i18next";
 import { g069Providers } from "@/config";
+import { AutoTestDetails } from "./AutoTestDetails";
 
 interface AssessmentTestProps {
   g069param: string;
@@ -92,7 +85,7 @@ export const TestAutoG069Form = (props: AssessmentTestProps) => {
             value: localValue,
             result: respResult,
             last_run: {
-              timestamp: okResp.last_run,
+              timestamp: new Date().toISOString(),
               message: okResp.test_status.message,
               code: okResp.test_status.code,
             },
@@ -193,11 +186,11 @@ export const TestAutoG069Form = (props: AssessmentTestProps) => {
               okStatus.additional_info[props.g069param] ? (
                 <div>
                   <span>
-                    Validation:{" "}
+                    {t("validation")}:{" "}
                     {okStatus.additional_info[props.g069param].is_valid ? (
-                      <Badge bg="success">PASS</Badge>
+                      <Badge bg="success">{t("pass")}</Badge>
                     ) : (
-                      <Badge bg="danger">FAIL</Badge>
+                      <Badge bg="danger">{t("fail")}</Badge>
                     )}
                   </span>
                   <div>
@@ -213,11 +206,11 @@ export const TestAutoG069Form = (props: AssessmentTestProps) => {
               ) : (
                 <div>
                   <div>{okStatus?.test_status.message}</div>
-                  Validation:{" "}
+                  {t("validation")}:{" "}
                   {okStatus?.test_status.is_valid ? (
-                    <Badge bg="success">PASS</Badge>
+                    <Badge bg="success">{t("pass")}</Badge>
                   ) : (
-                    <Badge bg="danger">FAIL</Badge>
+                    <Badge bg="danger">{t("fail")}</Badge>
                   )}
                   <div className="m-2">
                     <ul>
@@ -245,26 +238,7 @@ export const TestAutoG069Form = (props: AssessmentTestProps) => {
 
         <div className="mt-2">
           {props.test.last_run && (
-            <Alert
-              variant={props.test.last_run.code == 200 ? "success" : "danger"}
-            >
-              <div>
-                <em>
-                  <small>
-                    <strong>{t("last_run")}:</strong>{" "}
-                    {props.test.last_run.timestamp}
-                  </small>
-                </em>
-              </div>
-              <div>
-                <em>
-                  <small>
-                    <strong>{t("message")}:</strong>{" "}
-                    {props.test.last_run.message}
-                  </small>
-                </em>
-              </div>
-            </Alert>
+            <AutoTestDetails details={props.test.last_run} />
           )}
         </div>
       </Row>

--- a/src/pages/assessments/components/tests/TestAutoHttpsCheckForm.tsx
+++ b/src/pages/assessments/components/tests/TestAutoHttpsCheckForm.tsx
@@ -3,7 +3,7 @@
  */
 
 // import { useState } from "react"
-import { Alert, Button, Col, Form, InputGroup, Row } from "react-bootstrap";
+import { Button, Col, Form, InputGroup, Row } from "react-bootstrap";
 import { EvidenceURLS } from "./EvidenceURLS";
 import { TestToolTip } from "./TestToolTip";
 import {
@@ -18,6 +18,7 @@ import { useContext, useState } from "react";
 import { AuthContext } from "@/auth";
 import { AxiosError } from "axios";
 import { useTranslation } from "react-i18next";
+import { AutoTestDetails } from "./AutoTestDetails";
 
 interface AssessmentTestProps {
   test: TestAutoHttpsCheck;
@@ -196,26 +197,7 @@ export const TestAutoHttpsCheckForm = (props: AssessmentTestProps) => {
         )}
         <div className="mt-2">
           {props.test.last_run && (
-            <Alert
-              variant={props.test.last_run.code == 200 ? "success" : "danger"}
-            >
-              <div>
-                <em>
-                  <small>
-                    <strong>{t("last_run")}:</strong>{" "}
-                    {props.test.last_run.timestamp}
-                  </small>
-                </em>
-              </div>
-              <div>
-                <em>
-                  <small>
-                    <strong>{t("message")}:</strong>{" "}
-                    {props.test.last_run.message}
-                  </small>
-                </em>
-              </div>
-            </Alert>
+            <AutoTestDetails details={props.test.last_run} />
           )}
         </div>
       </Row>

--- a/src/pages/assessments/components/tests/TestAutoMd1Form.tsx
+++ b/src/pages/assessments/components/tests/TestAutoMd1Form.tsx
@@ -3,7 +3,7 @@
  */
 
 // import { useState } from "react"
-import { Alert, Button, Col, Form, InputGroup, Row } from "react-bootstrap";
+import { Button, Col, Form, InputGroup, Row } from "react-bootstrap";
 import { EvidenceURLS } from "./EvidenceURLS";
 import { TestToolTip } from "./TestToolTip";
 import {
@@ -19,6 +19,7 @@ import { useContext, useState } from "react";
 import { AuthContext } from "@/auth";
 import { AxiosError } from "axios";
 import { useTranslation } from "react-i18next";
+import { AutoTestDetails } from "./AutoTestDetails";
 
 interface AssessmentTestProps {
   test: TestAutoMD1;
@@ -208,26 +209,7 @@ export const TestAutoMd1Form = (props: AssessmentTestProps) => {
         )}
         <div className="mt-2">
           {props.test.last_run && (
-            <Alert
-              variant={props.test.last_run.code == 200 ? "success" : "danger"}
-            >
-              <div>
-                <em>
-                  <small>
-                    <strong>{t("last_run")}:</strong>{" "}
-                    {props.test.last_run.timestamp}
-                  </small>
-                </em>
-              </div>
-              <div>
-                <em>
-                  <small>
-                    <strong>{t("message")}:</strong>{" "}
-                    {props.test.last_run.message}
-                  </small>
-                </em>
-              </div>
-            </Alert>
+            <AutoTestDetails details={props.test.last_run} />
           )}
         </div>
       </Row>

--- a/src/pages/assessments/components/tests/TestAutoValidationForm.tsx
+++ b/src/pages/assessments/components/tests/TestAutoValidationForm.tsx
@@ -3,12 +3,13 @@
  */
 
 // import { useState } from "react"
-import { Alert, Button, Col, Row } from "react-bootstrap";
+import { Button, Col, Row } from "react-bootstrap";
 
 import { AutoGroupTest, TestAutoValidation } from "@/types";
 import { FaPlay } from "react-icons/fa";
 import { useTranslation } from "react-i18next";
 import { FaGears } from "react-icons/fa6";
+import { AutoTestDetails } from "./AutoTestDetails";
 
 interface AssessmentTestProps {
   autogroup: AutoGroupTest | undefined;
@@ -82,26 +83,7 @@ export const TestAutoValidationForm = (props: AssessmentTestProps) => {
         </div>
         <div className="mt-2">
           {props.test.last_run && (
-            <Alert
-              variant={props.test.last_run.code == 200 ? "success" : "danger"}
-            >
-              <div>
-                <em>
-                  <small>
-                    <strong>{t("last_run")}:</strong>{" "}
-                    {props.test.last_run.timestamp}
-                  </small>
-                </em>
-              </div>
-              <div>
-                <em>
-                  <small>
-                    <strong>{t("message")}:</strong>{" "}
-                    {props.test.last_run.message}
-                  </small>
-                </em>
-              </div>
-            </Alert>
+            <AutoTestDetails details={props.test.last_run} />
           )}
         </div>
       </Row>


### PR DESCRIPTION
### Goal 
Fix styling whenever we display automated test details such as last run and messages

### Implementation
- [x] Create a new component to render automated test details: `AutoTestDetails`
- [x] Organize the rendered output to approach the given example. Reformat the timestamp accordingly
- [x] Add a variant property to be able to render the details with slightly different background when in Editor and when in View Report
- [x] Fix timestamp issue when executing TestGroup (replace given timestamp with utc one)
- [x] Fix pass/fail/unknown icon in test group modal
- [x] Update i18n references

### Screenshots:
---
#### Details in View report:
<img width="1109" alt="image" src="https://github.com/user-attachments/assets/9984826e-32e8-4c83-b500-a79a2df3d505" />


---


#### Details in Editor:
<img width="737" alt="image" src="https://github.com/user-attachments/assets/01884c1b-cc0e-46ad-a691-04b2f7704250" />

