### PR TITLE
[CAT-916] - Implement Assessment Builder with Principles Management

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import {
   // Users,
   ProfileUpdate,
   ValidationDetails,
+  AssessmentBuilder,
 } from "@/pages";
 
 import "@/App.css";
@@ -284,6 +285,12 @@ function App() {
                   element={<ProtectedRoute />}
                 >
                   <Route index element={<MotivationAssessmentEditor />} />
+                </Route>
+                <Route
+                  path={ROUTES.ADMIN.MOTIVATIONS.ASSESSMENT_BUILDER}
+                  element={<ProtectedRoute />}
+                >
+                  <Route index element={<AssessmentBuilder />} />
                 </Route>
                 <Route
                   path={ROUTES.ADMIN.PRINCIPLES.ROOT}

--- a/src/api/services/motivations.ts
+++ b/src/api/services/motivations.ts
@@ -24,6 +24,7 @@ import {
   MotivationMetricResponse,
   MotivationResponse,
   MotivationTypeResponse,
+  PrincipleAssignmentInput,
   PrincipleCriterion,
   PrincipleInput,
   PrincipleResponse,
@@ -761,3 +762,28 @@ export function useCreateMetricVersion(
     },
   });
 }
+
+export const useAssignPrinciplesToMotivation = (
+  token: string,
+  mtvId: string,
+) => {
+  const queryClient = useQueryClient();
+  return useMutation(
+    async (principleAssignments: PrincipleAssignmentInput[]) => {
+      const response = await APIClient(token).post<PrincipleResponse>(
+        `/v1/registry/motivations/${mtvId}/principles`,
+        principleAssignments,
+      );
+      return response.data;
+    },
+
+    {
+      onError: (error: AxiosError) => {
+        return handleBackendError(error);
+      },
+      onSuccess: () => {
+        queryClient.invalidateQueries(["motivation-principles", mtvId]);
+      },
+    },
+  );
+};

--- a/src/api/services/registry.ts
+++ b/src/api/services/registry.ts
@@ -4,6 +4,9 @@ import {
   RegistryMetricResponse,
   RegistryResourceResponse,
   Statistics,
+  PrincipleResponse,
+  Principle,
+  PrincipleInput,
 } from "@/types";
 import {
   useInfiniteQuery,
@@ -20,12 +23,13 @@ export const useGetAllAlgorithms = ({
   token,
   isRegistered,
   size,
+  enabled,
 }: ApiOptions) =>
   useInfiniteQuery({
     queryKey: ["all-algorithms"],
     queryFn: async ({ pageParam = 1 }) => {
       const response = await APIClient(token).get<RegistryResourceResponse>(
-        `/v1/registry/type-algorithm?size=${size}&page=${pageParam}`,
+        `/v1/registry/type-algorithm?size=${size}&page=${pageParam}${enabled ? `&enabled=true` : ""}`,
       );
       return response.data;
     },
@@ -54,7 +58,7 @@ export const useGetAllTestMethods = ({
     queryKey: ["all-test-methods", search],
     queryFn: async ({ pageParam = 1 }) => {
       const response = await APIClient(token).get<RegistryResourceResponse>(
-        `/v1/registry/tests/test-method?size=${size}&page=${pageParam}&search=${search}${enabled ? `&enabled=${enabled}` : ""}`,
+        `/v1/registry/tests/test-method?size=${size}&page=${pageParam}&search=${search}${enabled ? `&enabled=true` : ""}`,
       );
       return response.data;
     },
@@ -91,12 +95,13 @@ export const useGetAllMetricTypes = ({
   token,
   isRegistered,
   size,
+  enabled,
 }: ApiOptions) =>
   useInfiniteQuery({
     queryKey: ["all-metric-types"],
     queryFn: async ({ pageParam = 1 }) => {
       const response = await APIClient(token).get<RegistryResourceResponse>(
-        `/v1/registry/type-metric?size=${size}&page=${pageParam}`,
+        `/v1/registry/type-metric?size=${size}&page=${pageParam}${enabled ? `&enabled=true` : ""}`,
       );
       return response.data;
     },
@@ -118,12 +123,13 @@ export const useGetAllBenchmarkTypes = ({
   token,
   isRegistered,
   size,
+  enabled,
 }: ApiOptions) =>
   useInfiniteQuery({
     queryKey: ["all-benchmark-types"],
     queryFn: async ({ pageParam = 1 }) => {
       const response = await APIClient(token).get<RegistryResourceResponse>(
-        `/v1/registry/benchmark-types?size=${size}&page=${pageParam}`,
+        `/v1/registry/benchmark-types?size=${size}&page=${pageParam}${enabled ? `&enabled=true` : ""}`,
       );
       return response.data;
     },
@@ -378,3 +384,148 @@ export const useGetRegistryMetrics = ({
     },
     enabled: !!token && isRegistered,
   });
+
+export const useGetAllPrinciples = ({
+  token,
+  isRegistered,
+  size,
+}: ApiOptions) =>
+  useInfiniteQuery({
+    queryKey: ["all-principles"],
+    queryFn: async ({ pageParam = 1 }) => {
+      const response = await APIClient(token).get<PrincipleResponse>(
+        `/v1/registry/principles?size=${size}&page=${pageParam}`,
+      );
+      return response.data;
+    },
+    getNextPageParam: (lastPage) => {
+      if (lastPage.number_of_page < lastPage.total_pages) {
+        return lastPage.number_of_page + 1;
+      } else {
+        return undefined;
+      }
+    },
+    onError: (error: AxiosError) => {
+      return handleBackendError(error);
+    },
+    retry: false,
+    enabled: isRegistered,
+  });
+
+export const useGetPrinciples = ({
+  size,
+  page,
+  token,
+  isRegistered,
+  search,
+  sortBy,
+  sortOrder,
+}: ApiOptionsSearch) =>
+  useQuery({
+    queryKey: [
+      "registry-principles",
+      { size, page, sortBy, sortOrder, search },
+    ],
+    queryFn: async () => {
+      let url = `/v1/registry/principles?size=${size}&page=${page}&sort=${sortBy}&order=${sortOrder}`;
+      search ? (url = `${url}&search=${search}`) : null;
+
+      const response = await APIClient(token).get<PrincipleResponse>(url);
+
+      return response.data;
+    },
+    onError: (error: AxiosError) => {
+      return handleBackendError(error);
+    },
+    enabled: !!token && isRegistered,
+  });
+
+export const useGetPrinciple = ({
+  id,
+  token,
+  isRegistered,
+}: {
+  id: string;
+  token: string;
+  isRegistered: boolean;
+}) =>
+  useQuery({
+    queryKey: ["registry-principle", id],
+    queryFn: async () => {
+      const response = await APIClient(token).get<Principle>(
+        `/v1/registry/principles/${id}`,
+      );
+      return response.data;
+    },
+    onError: (error: AxiosError) => {
+      return handleBackendError(error);
+    },
+    enabled: !!token && isRegistered && id !== "" && id !== undefined,
+  });
+
+export const useCreatePrinciple = (
+  token: string,
+  principle: PrincipleInput,
+) => {
+  const queryClient = useQueryClient();
+  return useMutation(
+    async () => {
+      const response = await APIClient(token).post<PrincipleInput>(
+        `/v1/registry/principles`,
+        principle,
+      );
+      return response.data;
+    },
+    {
+      onError: (error: AxiosError) => {
+        return handleBackendError(error);
+      },
+      onSuccess: () => {
+        queryClient.invalidateQueries(["registry-principles"]);
+        queryClient.invalidateQueries(["all-principles"]);
+      },
+    },
+  );
+};
+
+export const useUpdatePrinciple = (
+  token: string,
+  id: string,
+  principle: PrincipleInput,
+) => {
+  const queryClient = useQueryClient();
+  return useMutation(
+    async () => {
+      const response = await APIClient(token).patch<PrincipleInput>(
+        `/v1/registry/principles/${id}`,
+        principle,
+      );
+      return response.data;
+    },
+    {
+      onError: (error: AxiosError) => {
+        return handleBackendError(error);
+      },
+      onSuccess: () => {
+        queryClient.invalidateQueries(["registry-principles"]);
+        queryClient.invalidateQueries(["all-principles"]);
+      },
+    },
+  );
+};
+
+export const useDeletePrinciple = (token: string) => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (principleId: string) => {
+      return APIClient(token).delete(`/v1/registry/principles/${principleId}`);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries(["registry-principles"]);
+      queryClient.invalidateQueries(["all-principles"]);
+    },
+    onError: (error: AxiosError) => {
+      return handleBackendError(error);
+    },
+  });
+};

--- a/src/components/AdminMenu.tsx
+++ b/src/components/AdminMenu.tsx
@@ -1,4 +1,5 @@
 import { useTranslation } from "react-i18next";
+import { useState } from "react";
 import {
   FaAward,
   FaBorderNone,
@@ -7,6 +8,8 @@ import {
   FaTags,
   FaUsers,
   FaCog,
+  FaBars,
+  FaTimes,
 } from "react-icons/fa";
 import { FaClipboardQuestion, FaFileCircleCheck } from "react-icons/fa6";
 import { Link, useLocation } from "react-router-dom";
@@ -19,139 +22,237 @@ function isSel(path: string, name: string): boolean {
 export default function AdminMenu() {
   const adminPath = useLocation().pathname.split("/")[2] ?? "";
   const userPath = useLocation().pathname.split("/")[1] ?? "";
+  const currentPath = useLocation().pathname;
   const { t } = useTranslation();
+
+  const isAssessmentBuilderPage = currentPath.includes("/assessment-builder");
+  const [isSidebarOpen, setIsSidebarOpen] = useState(false);
+
+  if (isAssessmentBuilderPage) {
+    return (
+      <>
+        <div style={{ width: "60px", flexShrink: 0 }}>
+          <div className="d-flex justify-content-center pt-3">
+            <button
+              className="btn btn-light border shadow-sm"
+              onClick={() => setIsSidebarOpen(!isSidebarOpen)}
+            >
+              {isSidebarOpen ? <FaTimes /> : <FaBars />}
+            </button>
+          </div>
+        </div>
+
+        {isSidebarOpen && (
+          <>
+            <div
+              className="position-fixed w-100 h-100"
+              style={{
+                top: 0,
+                left: 0,
+                backgroundColor: "rgba(0,0,0,0.4)",
+                zIndex: 1040,
+              }}
+              onClick={() => setIsSidebarOpen(false)}
+            />
+
+            <div
+              className="position-fixed shadow-lg"
+              style={{
+                position: "absolute",
+                top: "0px",
+                left: 0,
+                zIndex: 1045,
+                height: "100vh",
+                backgroundColor: "rgba(255, 255, 255, 0.95)",
+              }}
+            >
+              <div
+                className="position-absolute"
+                style={{ top: "14px", right: "14px", zIndex: 1046 }}
+              >
+                <button
+                  className="btn btn-dark btn-sm rounded-circle d-flex align-items-center justify-content-center p-2"
+                  onClick={() => setIsSidebarOpen(false)}
+                  style={{
+                    width: "32px",
+                    height: "32px",
+                    border: "none",
+                    boxShadow: "0 2px 8px rgba(0,0,0,0.15)",
+                    backgroundColor: "#495057",
+                    transition: "all 0.2s ease",
+                  }}
+                  onMouseEnter={(e) => {
+                    e.currentTarget.style.backgroundColor = "#343a40";
+                    e.currentTarget.style.transform = "scale(1.05)";
+                  }}
+                  onMouseLeave={(e) => {
+                    e.currentTarget.style.backgroundColor = "#495057";
+                    e.currentTarget.style.transform = "scale(1)";
+                  }}
+                  title="Close sidebar"
+                >
+                  <FaTimes size={14} />
+                </button>
+              </div>
+
+              <div
+                className="cat-sidebar-container"
+                style={{
+                  paddingTop: "20px",
+                  height: "100%",
+                  overflowY: "auto",
+                }}
+              >
+                {renderMenuContent(adminPath, userPath, t)}
+              </div>
+            </div>
+          </>
+        )}
+      </>
+    );
+  }
 
   return (
     <div className="cat-sidebar-container">
-      <ul className="cat-sidebar-nav">
-        <div>
-          <h3 className="cat-sidebar-section">{t("personal_menu")}</h3>
-          <div>
-            <li>
-              <Link
-                to={ROUTES.PROFILE.ROOT}
-                className={`cat-nav-link-item ${isSel(userPath, "profile") ? "active" : ""}`}
-              >
-                <FaUsers /> {t("profile")}
-              </Link>
-            </li>
-            <li>
-              <Link
-                to={ROUTES.VALIDATIONS.ROOT}
-                className={`cat-nav-link-item ${isSel(userPath, "validations") ? "active" : ""}`}
-              >
-                <FaUsers /> {t("validations")}
-              </Link>
-            </li>
-            <li>
-              <Link
-                to={ROUTES.ASSESSMENTS.ROOT}
-                className={`cat-nav-link-item ${isSel(userPath, "assessments") ? "active" : ""}`}
-              >
-                <FaUsers /> {t("assessments")}
-              </Link>
-            </li>
-            <li>
-              <Link
-                to={ROUTES.SUBJECTS}
-                className={`cat-nav-link-item ${isSel(userPath, "subjects") ? "active" : ""}`}
-              >
-                <FaUsers /> {t("subjects")}
-              </Link>
-            </li>
-          </div>
-        </div>
-
-        <div>
-          <h3 className="cat-sidebar-section">{t("manage")}</h3>
-          <div>
-            <li>
-              <Link
-                to={ROUTES.ADMIN.USERS}
-                className={`cat-nav-link-item ${isSel(adminPath, "users") ? "active" : ""}`}
-              >
-                <FaUsers /> {t("users")}
-              </Link>
-            </li>
-            <li>
-              <Link
-                to={ROUTES.ADMIN.VALIDATIONS}
-                className={`cat-nav-link-item ${isSel(adminPath, "validations") ? "active" : ""}`}
-              >
-                <FaCheckCircle /> {t("validations")}
-              </Link>
-            </li>
-            <li>
-              <Link
-                to={ROUTES.ADMIN.ASSESSMENTS}
-                className={`cat-nav-link-item ${isSel(adminPath, "assessments") ? "active" : ""}`}
-              >
-                <FaFileCircleCheck /> {t("assessments")}
-              </Link>
-            </li>
-          </div>
-        </div>
-
-        <div>
-          <h3 className="cat-sidebar-section">{t("library")}</h3>
-          <div>
-            <li>
-              <Link
-                to={ROUTES.ADMIN.MOTIVATIONS.ROOT}
-                className={`cat-nav-link-item ${isSel(adminPath, "motivations") ? "active" : ""}`}
-              >
-                <FaFile /> {t("motivations")}
-              </Link>
-            </li>
-            <li>
-              <Link
-                to={ROUTES.ADMIN.PRINCIPLES.ROOT}
-                className={`cat-nav-link-item ${isSel(adminPath, "principles") ? "active" : ""}`}
-              >
-                <FaTags /> {t("principles")}
-              </Link>
-            </li>
-            <li>
-              <Link
-                to={ROUTES.ADMIN.CRITERIA.ROOT}
-                className={`cat-nav-link-item ${isSel(adminPath, "criteria") ? "active" : ""}`}
-              >
-                <FaAward /> {t("criteria")}
-              </Link>
-            </li>
-            <li>
-              <Link
-                to={ROUTES.ADMIN.TESTS.ROOT}
-                className={`cat-nav-link-item ${isSel(adminPath, "tests") ? "active" : ""}`}
-              >
-                <FaClipboardQuestion /> {t("tests")}
-              </Link>
-            </li>
-            <li>
-              <Link
-                to={ROUTES.ADMIN.METRICS.ROOT}
-                className={`cat-nav-link-item ${isSel(adminPath, "metrics") ? "active" : ""}`}
-              >
-                <FaBorderNone /> {t("metrics")}
-              </Link>
-            </li>
-          </div>
-        </div>
-
-        <div>
-          <h3 className="cat-sidebar-section">{t("system")}</h3>
-          <div>
-            <li>
-              <Link
-                to={ROUTES.ADMIN.SETTINGS.ROOT}
-                className={`cat-nav-link-item ${isSel(adminPath, "settings") ? "active" : ""}`}
-              >
-                <FaCog /> {t("Settings")}
-              </Link>
-            </li>
-          </div>
-        </div>
-      </ul>
+      {renderMenuContent(adminPath, userPath, t)}
     </div>
+  );
+}
+
+function renderMenuContent(
+  adminPath: string,
+  userPath: string,
+  t: ReturnType<typeof useTranslation>["t"],
+) {
+  return (
+    <ul className="cat-sidebar-nav">
+      <div>
+        <h3 className="cat-sidebar-section">{t("personal_menu")}</h3>
+        <div>
+          <li>
+            <Link
+              to={ROUTES.PROFILE.ROOT}
+              className={`cat-nav-link-item ${isSel(userPath, "profile") ? "active" : ""}`}
+            >
+              <FaUsers /> {t("profile")}
+            </Link>
+          </li>
+          <li>
+            <Link
+              to={ROUTES.VALIDATIONS.ROOT}
+              className={`cat-nav-link-item ${isSel(userPath, "validations") ? "active" : ""}`}
+            >
+              <FaUsers /> {t("validations")}
+            </Link>
+          </li>
+          <li>
+            <Link
+              to={ROUTES.ASSESSMENTS.ROOT}
+              className={`cat-nav-link-item ${isSel(userPath, "assessments") ? "active" : ""}`}
+            >
+              <FaUsers /> {t("assessments")}
+            </Link>
+          </li>
+          <li>
+            <Link
+              to={ROUTES.SUBJECTS}
+              className={`cat-nav-link-item ${isSel(userPath, "subjects") ? "active" : ""}`}
+            >
+              <FaUsers /> {t("subjects")}
+            </Link>
+          </li>
+        </div>
+      </div>
+
+      <div>
+        <h3 className="cat-sidebar-section">{t("manage")}</h3>
+        <div>
+          <li>
+            <Link
+              to={ROUTES.ADMIN.USERS}
+              className={`cat-nav-link-item ${isSel(adminPath, "users") ? "active" : ""}`}
+            >
+              <FaUsers /> {t("users")}
+            </Link>
+          </li>
+          <li>
+            <Link
+              to={ROUTES.ADMIN.VALIDATIONS}
+              className={`cat-nav-link-item ${isSel(adminPath, "validations") ? "active" : ""}`}
+            >
+              <FaCheckCircle /> {t("validations")}
+            </Link>
+          </li>
+          <li>
+            <Link
+              to={ROUTES.ADMIN.ASSESSMENTS}
+              className={`cat-nav-link-item ${isSel(adminPath, "assessments") ? "active" : ""}`}
+            >
+              <FaFileCircleCheck /> {t("assessments")}
+            </Link>
+          </li>
+        </div>
+      </div>
+
+      <div>
+        <h3 className="cat-sidebar-section">{t("library")}</h3>
+        <div>
+          <li>
+            <Link
+              to={ROUTES.ADMIN.MOTIVATIONS.ROOT}
+              className={`cat-nav-link-item ${isSel(adminPath, "motivations") ? "active" : ""}`}
+            >
+              <FaFile /> {t("motivations")}
+            </Link>
+          </li>
+          <li>
+            <Link
+              to={ROUTES.ADMIN.PRINCIPLES.ROOT}
+              className={`cat-nav-link-item ${isSel(adminPath, "principles") ? "active" : ""}`}
+            >
+              <FaTags /> {t("principles")}
+            </Link>
+          </li>
+          <li>
+            <Link
+              to={ROUTES.ADMIN.CRITERIA.ROOT}
+              className={`cat-nav-link-item ${isSel(adminPath, "criteria") ? "active" : ""}`}
+            >
+              <FaAward /> {t("criteria")}
+            </Link>
+          </li>
+          <li>
+            <Link
+              to={ROUTES.ADMIN.TESTS.ROOT}
+              className={`cat-nav-link-item ${isSel(adminPath, "tests") ? "active" : ""}`}
+            >
+              <FaClipboardQuestion /> {t("tests")}
+            </Link>
+          </li>
+          <li>
+            <Link
+              to={ROUTES.ADMIN.METRICS.ROOT}
+              className={`cat-nav-link-item ${isSel(adminPath, "metrics") ? "active" : ""}`}
+            >
+              <FaBorderNone /> {t("metrics")}
+            </Link>
+          </li>
+        </div>
+      </div>
+
+      <div>
+        <h3 className="cat-sidebar-section">{t("system")}</h3>
+        <div>
+          <li>
+            <Link
+              to={ROUTES.ADMIN.SETTINGS.ROOT}
+              className={`cat-nav-link-item ${isSel(adminPath, "settings") ? "active" : ""}`}
+            >
+              <FaCog /> {t("Settings")}
+            </Link>
+          </li>
+        </div>
+      </div>
+    </ul>
   );
 }

--- a/src/pages/assessments/AssessmentBuilder.css
+++ b/src/pages/assessments/AssessmentBuilder.css
@@ -1,0 +1,577 @@
+.assessment-builder {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  background-color: #f8f9fa;
+}
+
+.assessment-builder-header {
+  padding: 1rem 1.5rem;
+  background: white;
+  border-bottom: 1px solid #e9ecef;
+}
+
+.header-content {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  max-width: 100%;
+}
+
+.builder-title {
+  margin: 0;
+  font-size: 1.5rem;
+  font-weight: 600;
+  color: #2c3e50;
+}
+
+.header-actions {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.builder-layout {
+  display: flex;
+  flex: 1;
+  gap: 1px;
+  overflow: hidden;
+  background: #e5e7eb;
+}
+
+/* Columns */
+.builder-column {
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  background: white;
+}
+
+.structure-column {
+  flex: 0 0 340px;
+  min-width: 280px;
+  border-left: 1px solid #e9ecef;
+}
+
+.preview-column {
+  flex: 1;
+  min-width: 400px;
+}
+
+.editor-column {
+  flex: 0 0 380px;
+  min-width: 330px;
+  border-right: 1px solid #e9ecef;
+}
+
+/* Column Headers */
+.column-header {
+  display: flex;
+  min-height: 80px;
+  padding: 1rem;
+  border-bottom: 1px solid #e9ecef;
+}
+
+.structure-column .column-header {
+  flex-direction: column;
+  gap: 0.5rem;
+  align-items: flex-start;
+}
+
+.editor-column .column-header {
+  flex-direction: column;
+  align-items: stretch;
+  min-height: auto;
+  padding: 0;
+}
+
+.builder-header-content {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+}
+
+.builder-header-content h3 {
+  padding: 1rem 1rem 0;
+  margin: 0;
+}
+
+.column-header h3 {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: #374151;
+}
+
+.column-description {
+  margin: 0.25rem 0 0;
+  font-size: 0.875rem;
+  font-weight: normal;
+  color: #6b7280;
+}
+
+.column-content {
+  flex: 1;
+  padding: 1rem;
+  overflow-y: auto;
+}
+
+.preview-column .column-content {
+  background: #f8f9fa;
+}
+
+.principle-form {
+  display: flex;
+  flex-direction: column;
+}
+
+.principle-form h4 {
+  padding-bottom: 0.5rem;
+  margin-bottom: 1.5rem;
+  font-size: 1rem;
+  font-weight: 600;
+  color: #374151;
+  border-bottom: 1px solid #e5e7eb;
+}
+
+.btn-primary {
+  display: inline-flex;
+  gap: 0.5rem;
+  align-items: center;
+  justify-content: center;
+  padding: 0.5rem 1rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: white;
+  cursor: pointer;
+  background: #3b82f6;
+  border: none;
+  border-radius: 0.375rem;
+  transition: all 0.2s;
+}
+
+.btn-primary:hover {
+  background: #2563eb;
+  box-shadow: 0 4px 8px rgb(59 130 246 / 30%);
+}
+
+.btn-secondary {
+  display: inline-flex;
+  gap: 0.5rem;
+  align-items: center;
+  justify-content: center;
+  padding: 0.5rem 1rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: #374151;
+  cursor: pointer;
+  background: #f8f9fa;
+  border: 1px solid #d1d5db;
+  border-radius: 0.375rem;
+  transition: all 0.2s;
+}
+
+.btn-secondary:hover {
+  background: #e5e7eb;
+  border-color: #9ca3af;
+  box-shadow: 0 2px 4px rgb(0 0 0 / 10%);
+}
+
+.form-actions {
+  display: flex;
+  gap: 0.75rem;
+  padding-top: 1rem;
+  margin-top: 1.5rem;
+  border-top: 1px solid #e5e7eb;
+}
+
+.form-actions .btn-secondary,
+.form-actions .btn-primary {
+  flex: 1;
+}
+
+.header-actions .btn-secondary,
+.header-actions .btn-primary {
+  padding: 0.5rem 1rem;
+  font-weight: 500;
+  border-radius: 0.375rem;
+  transition: all 0.2s;
+}
+
+.header-actions .btn-secondary {
+  color: #374151;
+  background: #f8f9fa;
+  border: 1px solid #d1d5db;
+}
+
+.header-actions .btn-secondary:hover {
+  background: #e5e7eb;
+  border-color: #9ca3af;
+  box-shadow: 0 2px 4px rgb(0 0 0 / 10%);
+}
+
+.header-actions .btn-primary {
+  color: white;
+  background: #3b82f6;
+  border: none;
+}
+
+.header-actions .btn-primary:hover {
+  background: #2563eb;
+  box-shadow: 0 4px 8px rgb(59 130 246 / 30%);
+}
+
+/* Structure Column Specific */
+.add-principle-btn {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  padding: 0.5rem 0.75rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: white;
+  cursor: pointer;
+  background: #3b82f6;
+  border: none;
+  border-radius: 0.375rem;
+  transition: background-color 0.2s;
+}
+
+.add-principle-btn:hover {
+  background: #2563eb;
+}
+
+.structure-tree {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.tree-item {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  padding: 0.5rem;
+  cursor: pointer;
+  border-radius: 0.375rem;
+  transition: background-color 0.2s;
+}
+
+.tree-item:hover {
+  background: #f3f4f6;
+}
+
+.tree-item.nested {
+  margin-left: 1.5rem;
+}
+
+.tree-item.nested-deeper {
+  margin-left: 3rem;
+}
+
+.tree-item.clickable {
+  cursor: pointer;
+}
+
+.tree-item.clickable:hover {
+  background: #f3f4f6;
+}
+
+.tree-item.principle-item.clickable:hover {
+  background: #bfdbfe;
+}
+
+.tree-item.principle-item {
+  padding: 0.75rem;
+  margin-bottom: 0.25rem;
+  background: #dbeafe;
+  border: 1px solid #93c5fd;
+  border-radius: 0.375rem;
+  opacity: 0.8;
+}
+
+.tree-item.principle-item.selected {
+  background: #bfdbfe;
+  border: 2px solid #1d4ed8;
+  opacity: 1;
+}
+
+.tree-item.principle-item:hover {
+  background: #bfdbfe;
+}
+
+.principle-display {
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: #1d4ed8;
+}
+
+.tree-icon {
+  font-size: 0.875rem;
+  color: #1d4ed8;
+}
+
+.form-group {
+  margin-bottom: 1rem;
+}
+
+.form-group label {
+  display: block;
+  margin-bottom: 0.5rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: #374151;
+}
+
+.form-control {
+  width: 100%;
+  padding: 0.5rem;
+  font-size: 0.875rem;
+  resize: vertical;
+  border: 1px solid #d1d5db;
+  border-radius: 0.375rem;
+  transition: border-color 0.2s;
+}
+
+.form-control:focus {
+  border-color: #3b82f6;
+  outline: none;
+  box-shadow: 0 0 0 3px rgb(59 130 246 / 10%);
+}
+
+.header-actions .btn-primary:disabled {
+  cursor: not-allowed;
+  background: #9ca3af;
+  box-shadow: none;
+}
+
+.header-actions .btn-primary:disabled:hover {
+  background: #9ca3af;
+  box-shadow: none;
+}
+
+.column-content .principle-preview {
+  padding: 1.5rem;
+  margin: 0.5rem;
+  background: #fff;
+  border-radius: 0.5rem;
+  box-shadow: 0 1px 3px rgb(0 0 0 / 10%);
+}
+
+.column-content .cat-view-heading {
+  display: flex;
+  align-items: center;
+  margin-bottom: 1.5rem;
+}
+
+.preview-placeholder {
+  padding: 3rem 1rem;
+  color: #9ca3af;
+  text-align: center;
+}
+
+.preview-placeholder p {
+  margin: 0;
+  font-style: italic;
+}
+
+.column-content .principles-list-container {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.principles-list {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.principles-list h4 {
+  flex-shrink: 0;
+  padding-bottom: 0.5rem;
+  margin-bottom: 1rem;
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: #374151;
+  border-bottom: 1px solid #e5e7eb;
+}
+
+.no-principles {
+  padding: 2rem;
+  font-style: italic;
+  color: #9ca3af;
+  text-align: center;
+}
+
+.principles-list-actions {
+  flex-shrink: 0;
+  margin-bottom: 1rem;
+}
+
+.select-principle-btn {
+  width: 100%;
+  padding: 0.5rem 1rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: white;
+  cursor: pointer;
+  background: #3b82f6;
+  border: none;
+  border-radius: 0.375rem;
+  transition: all 0.2s;
+}
+
+.select-principle-btn:hover {
+  background: #2563eb;
+  box-shadow: 0 4px 8px rgb(59 130 246 / 30%);
+}
+
+.select-principle-btn:disabled {
+  cursor: not-allowed;
+  background: #9ca3af;
+  box-shadow: none;
+}
+
+.select-principle-btn:disabled:hover {
+  background: #9ca3af;
+  box-shadow: none;
+}
+
+.principles-grid {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  gap: 0.5rem;
+  overflow-y: auto;
+}
+
+.principle-card {
+  padding: 0.75rem;
+  cursor: pointer;
+  background: #f8f9fa;
+  border: 1px solid #e5e7eb;
+  border-radius: 0.375rem;
+  transition: all 0.2s;
+}
+
+.principle-card:hover {
+  border-color: #3b82f6;
+  box-shadow: 0 2px 8px rgb(59 130 246 / 10%);
+}
+
+.principle-card.selected {
+  background-color: #eff6ff;
+  border: 2px solid #3b82f6;
+  box-shadow: 0 2px 8px rgb(59 130 246 / 20%);
+}
+
+.principle-card-compact-header {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  margin-bottom: 0.5rem;
+}
+
+.principle-card-icon {
+  flex-shrink: 0;
+  font-size: 0.875rem;
+  color: #3b82f6;
+}
+
+.principle-card-compact-title {
+  flex: 1;
+  margin: 0;
+  font-size: 0.875rem;
+  font-weight: 500;
+  line-height: 1.3;
+  color: #374151;
+}
+
+.principle-card-pri {
+  font-weight: 600;
+  color: #3b82f6;
+}
+
+.principle-card-description {
+  margin: 0;
+  overflow: hidden;
+  font-size: 0.8rem;
+  line-height: 1.3;
+  color: #6b7280;
+}
+
+.principle-tabs {
+  display: flex;
+  align-items: center;
+  width: 100%;
+}
+
+.tab-btn {
+  position: relative;
+  width: 32%;
+  padding: 0.6rem 1rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: #6b7280;
+  text-align: center;
+  cursor: pointer;
+  background: transparent;
+  border: none;
+  border-bottom: 2px solid transparent;
+  border-radius: 0;
+  transition: all 0.2s ease;
+}
+
+.tab-divider {
+  flex: 0 1 1px;
+  height: 95%;
+  background: #d1d5db;
+}
+
+.tab-btn.active {
+  color: #3b82f6;
+  border-bottom-color: #3b82f6;
+}
+
+.tab-btn.disabled,
+.tab-btn:disabled {
+  color: #9ca3af;
+  cursor: not-allowed;
+  background: transparent;
+  opacity: 0.6;
+}
+
+.tab-btn.disabled:hover,
+.tab-btn:disabled:hover {
+  border-bottom-color: transparent;
+}
+
+.tab-btn:hover:not(:disabled, .disabled) {
+  background: #f8f9fa;
+}
+
+@media (width <= 1200px) {
+  .editor-column {
+    flex: 0 0 300px;
+  }
+}
+
+@media (width <= 768px) {
+  .builder-layout {
+    flex-direction: column;
+  }
+
+  .structure-column,
+  .preview-column,
+  .editor-column {
+    flex: none;
+    min-height: 300px;
+  }
+
+  .header-content {
+    flex-direction: column;
+    gap: 1rem;
+    align-items: flex-start;
+  }
+}

--- a/src/pages/assessments/AssessmentBuilder.tsx
+++ b/src/pages/assessments/AssessmentBuilder.tsx
@@ -1,0 +1,721 @@
+import { useParams, useNavigate } from "react-router-dom";
+import { useTranslation } from "react-i18next";
+import { useState, useContext, useRef, useEffect } from "react";
+import { FaTags, FaInfoCircle } from "react-icons/fa";
+import { OverlayTrigger, Tooltip, Button } from "react-bootstrap";
+import { AuthContext } from "@/auth";
+import {
+  useGetAllPrinciples,
+  useCreateMotivationPrinciple,
+  useAssignPrinciplesToMotivation,
+} from "@/api";
+import { useGetMotivationAssessmentType } from "@/api/services/templates";
+import { Principle, AlertInfo, PrincipleInput } from "@/types";
+import toast from "react-hot-toast";
+import "./AssessmentBuilder.css";
+
+// Form modes for principle management
+type PrincipleFormMode = "none" | "select" | "new" | "edit";
+
+interface PrincipleFormState {
+  mode: PrincipleFormMode;
+  data: PrincipleInput;
+  selectedIndex: number;
+}
+
+function AssessmentBuilder() {
+  const { mtvId, actId } = useParams<{
+    mtvId: string;
+    actId?: string;
+  }>();
+
+  const { t } = useTranslation();
+  const { keycloak, registered } = useContext(AuthContext)!;
+  const alert = useRef<AlertInfo>({
+    message: "",
+  });
+  const navigate = useNavigate();
+
+  const { data: assessmentData } = useGetMotivationAssessmentType(
+    mtvId || "",
+    actId || "",
+    keycloak?.token || "",
+    registered,
+  );
+
+  const {
+    data: principlesData,
+    isLoading,
+    fetchNextPage,
+    hasNextPage,
+  } = useGetAllPrinciples({
+    token: keycloak?.token || "",
+    isRegistered: registered,
+    size: 50,
+  });
+
+  const [savedPrinciples, setSavedPrinciples] = useState<PrincipleInput[]>([]);
+  const [principleForm, setPrincipleForm] = useState<PrincipleFormState>({
+    mode: "none",
+    data: { pri: "", label: "", description: "" },
+    selectedIndex: -1,
+  });
+  const [selectedRegistryPrincipleId, setSelectedRegistryPrincipleId] =
+    useState<string | null>(null);
+
+  const mutateCreateMotivationPrinciple = useCreateMotivationPrinciple(
+    keycloak?.token || "",
+    mtvId || "",
+    principleForm.data,
+  );
+
+  const mutateAssignPrinciplesToMotivation = useAssignPrinciplesToMotivation(
+    keycloak?.token || "",
+    mtvId || "",
+  );
+
+  const allPrinciples: Principle[] =
+    principlesData?.pages?.flatMap((page) => page.content) || [];
+
+  const availablePrinciples = allPrinciples.filter(
+    (principle) =>
+      !savedPrinciples.some(
+        (savedPrinciple) => savedPrinciple.pri === principle.pri,
+      ),
+  );
+
+  const selectedRegistryPrinciple = availablePrinciples.find(
+    (p) => p.id === selectedRegistryPrincipleId,
+  );
+
+  // Load existing assessment data and populate saved principles
+  useEffect(() => {
+    if (assessmentData?.principles) {
+      const loadedPrinciples: PrincipleInput[] = assessmentData.principles.map(
+        (principle) => ({
+          pri: principle.id,
+          label: principle.name,
+          description: principle.description,
+        }),
+      );
+      setSavedPrinciples(loadedPrinciples);
+    }
+  }, [assessmentData]);
+
+  const handleAddPrinciple = () => {
+    setPrincipleForm({
+      mode: "select",
+      data: { pri: "", label: "", description: "" },
+      selectedIndex: -1,
+    });
+    setSelectedRegistryPrincipleId(null);
+  };
+
+  const handleSelectTab = () => {
+    setPrincipleForm({
+      ...principleForm,
+      mode: "select",
+      data: { pri: "", label: "", description: "" },
+    });
+  };
+
+  const handleNewTab = () => {
+    setPrincipleForm({
+      ...principleForm,
+      mode: "new",
+      data: { pri: "", label: "", description: "" },
+    });
+  };
+
+  const handleEditTab = () => {
+    // If there are saved principles, automatically select the first one for editing
+    if (savedPrinciples.length > 0) {
+      const firstPrinciple = savedPrinciples[0];
+      setPrincipleForm({
+        mode: "edit",
+        data: {
+          pri: firstPrinciple.pri,
+          label: firstPrinciple.label,
+          description: firstPrinciple.description,
+        },
+        selectedIndex: 0,
+      });
+    }
+  };
+
+  const handleEditPrinciple = (principleIndex: number) => {
+    const principle = savedPrinciples[principleIndex];
+    setPrincipleForm({
+      mode: "edit",
+      data: {
+        pri: principle.pri,
+        label: principle.label,
+        description: principle.description,
+      },
+      selectedIndex: principleIndex,
+    });
+  };
+
+  const hasEditPrincipleChanged = () => {
+    if (principleForm.mode !== "edit" || principleForm.selectedIndex < 0) {
+      return false;
+    }
+    const originalPrinciple = savedPrinciples[principleForm.selectedIndex];
+    if (!originalPrinciple) {
+      return false;
+    }
+    return (
+      principleForm.data.pri !== originalPrinciple.pri ||
+      principleForm.data.label !== originalPrinciple.label ||
+      principleForm.data.description !== originalPrinciple.description
+    );
+  };
+
+  const handlePrincipleInputChange = (
+    field: keyof PrincipleInput,
+    value: string,
+  ) => {
+    setPrincipleForm({
+      ...principleForm,
+      data: {
+        ...principleForm.data,
+        [field]: value,
+      },
+    });
+  };
+
+  const assignPrincipleToMotivationRequest = ({
+    pri,
+    label,
+    description,
+  }: PrincipleInput) => {
+    const promise = mutateCreateMotivationPrinciple
+      .mutateAsync()
+      .catch((err) => {
+        alert.current = {
+          message: "Error: " + (err.response?.data?.message || err.message),
+        };
+        throw err;
+      })
+      .then(() => {
+        alert.current = {
+          message: "Principle added to motivation successfully",
+        };
+
+        const newPrinciple: PrincipleInput = {
+          pri: pri,
+          label: label,
+          description: description,
+        };
+        const updatedPrinciples = [...savedPrinciples, newPrinciple];
+        setSavedPrinciples(updatedPrinciples);
+
+        const newPrincipleIndex = updatedPrinciples.length - 1;
+        setPrincipleForm({
+          mode: "edit",
+          data: {
+            pri: newPrinciple.pri,
+            label: newPrinciple.label,
+            description: newPrinciple.description,
+          },
+          selectedIndex: newPrincipleIndex,
+        });
+      });
+
+    toast.promise(promise, {
+      loading: "Adding principle to motivation...",
+      success: () => `${alert.current.message}`,
+      error: () => `${alert.current.message}`,
+    });
+  };
+
+  const assignSelectedPrincipleToMotivation = () => {
+    if (!selectedRegistryPrinciple || !mtvId) return;
+
+    const principleAssignments = [
+      {
+        principle_id: selectedRegistryPrinciple.id,
+        relation: "maintainedBy", // You can make this configurable if needed
+        annotation_text: "",
+        annotation_url: "",
+      },
+    ];
+
+    const promise = mutateAssignPrinciplesToMotivation
+      .mutateAsync(principleAssignments)
+      .catch((err) => {
+        alert.current = {
+          message: "Error: " + (err.response?.data?.message || err.message),
+        };
+        throw err;
+      })
+      .then(() => {
+        alert.current = {
+          message: "Principle assigned to motivation successfully",
+        };
+
+        const newPrinciple: PrincipleInput = {
+          pri: selectedRegistryPrinciple.pri,
+          label: selectedRegistryPrinciple.label,
+          description: selectedRegistryPrinciple.description,
+        };
+        const updatedPrinciples = [...savedPrinciples, newPrinciple];
+        setSavedPrinciples(updatedPrinciples);
+
+        const newPrincipleIndex = updatedPrinciples.length - 1;
+        setPrincipleForm({
+          mode: "edit",
+          data: {
+            pri: newPrinciple.pri,
+            label: newPrinciple.label,
+            description: newPrinciple.description,
+          },
+          selectedIndex: newPrincipleIndex,
+        });
+
+        // Clear the selected registry principle
+        setSelectedRegistryPrincipleId(null);
+      });
+
+    toast.promise(promise, {
+      loading: "Assigning principle to motivation...",
+      success: () => `${alert.current.message}`,
+      error: () => `${alert.current.message}`,
+    });
+  };
+
+  const handlePrincipleChanges = () => {
+    if (principleForm.mode === "select") {
+      // Assign selected principle from registry to motivation
+      if (selectedRegistryPrincipleId && mtvId) {
+        assignSelectedPrincipleToMotivation();
+      } else if (!mtvId) {
+        if (selectedRegistryPrinciple) {
+          const newPrinciple: PrincipleInput = {
+            pri: selectedRegistryPrinciple.pri,
+            label: selectedRegistryPrinciple.label,
+            description: selectedRegistryPrinciple.description,
+          };
+          const updatedPrinciples = [...savedPrinciples, newPrinciple];
+          setSavedPrinciples(updatedPrinciples);
+
+          // Automatically select the newly added principle for preview
+          const newPrincipleIndex = updatedPrinciples.length - 1;
+          setPrincipleForm({
+            mode: "edit",
+            data: {
+              pri: newPrinciple.pri,
+              label: newPrinciple.label,
+              description: newPrinciple.description,
+            },
+            selectedIndex: newPrincipleIndex,
+          });
+          setSelectedRegistryPrincipleId(null);
+        }
+      }
+    } else if (principleForm.mode === "new") {
+      if (
+        principleForm.data.pri &&
+        principleForm.data.label &&
+        principleForm.data.description
+      ) {
+        if (mtvId) {
+          assignPrincipleToMotivationRequest({
+            pri: principleForm.data.pri,
+            label: principleForm.data.label,
+            description: principleForm.data.description,
+          });
+        } else {
+          const newPrinciple: PrincipleInput = {
+            ...principleForm.data,
+          };
+          const updatedPrinciples = [...savedPrinciples, newPrinciple];
+          setSavedPrinciples(updatedPrinciples);
+
+          // Automatically select the newly created principle for preview
+          const newPrincipleIndex = updatedPrinciples.length - 1;
+          setPrincipleForm({
+            mode: "edit",
+            data: {
+              pri: newPrinciple.pri,
+              label: newPrinciple.label,
+              description: newPrinciple.description,
+            },
+            selectedIndex: newPrincipleIndex,
+          });
+        }
+      }
+    } else if (principleForm.mode === "edit") {
+      if (
+        principleForm.data.pri &&
+        principleForm.data.label &&
+        principleForm.data.description &&
+        principleForm.selectedIndex >= 0
+      ) {
+        const updatedPrinciples = [...savedPrinciples];
+        updatedPrinciples[principleForm.selectedIndex] = {
+          ...updatedPrinciples[principleForm.selectedIndex],
+          pri: principleForm.data.pri,
+          label: principleForm.data.label,
+          description: principleForm.data.description,
+        };
+        setSavedPrinciples(updatedPrinciples);
+      }
+    }
+  };
+
+  const handleCancel = () => {
+    setPrincipleForm({
+      mode: "none",
+      data: { pri: "", label: "", description: "" },
+      selectedIndex: -1,
+    });
+  };
+
+  return (
+    <>
+      <div className="assessment-builder mb-3">
+        <div className="assessment-builder-header">
+          <div className="header-content">
+            <h1 className="builder-title">Assessment Builder</h1>
+            <div className="header-actions">
+              <button className="btn-secondary">Preview</button>
+              <button className="btn-primary">Publish</button>
+            </div>
+          </div>
+        </div>
+
+        {/* Main Layout - Three Columns */}
+        <div className="builder-layout">
+          {/* Left Column - Assessment Structure */}
+          <div className="builder-column structure-column">
+            <div className="column-header">
+              <h3>Assessment Structure</h3>
+              <button
+                className="add-principle-btn"
+                onClick={handleAddPrinciple}
+              >
+                + Add Principle
+              </button>
+            </div>
+            <div className="column-content">
+              <div className="structure-tree">
+                {savedPrinciples.map((principle, principleIndex) => (
+                  <div key={principleIndex}>
+                    <div
+                      className={`tree-item principle-item clickable ${
+                        principleForm.selectedIndex === principleIndex
+                          ? "selected"
+                          : ""
+                      }`}
+                      onClick={() => handleEditPrinciple(principleIndex)}
+                    >
+                      <span className="tree-icon">
+                        <FaTags />
+                      </span>
+                      <span className="principle-display">
+                        {principle.pri} - {principle.label}
+                      </span>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+
+          {/* Center Column - Live Preview */}
+          <div className="builder-column preview-column">
+            <div className="column-header">
+              <div>
+                <h3>Live Preview</h3>
+                <p className="column-description">
+                  Preview how users will see this assessment
+                </p>
+              </div>
+            </div>
+            <div className="column-content">
+              {principleForm.selectedIndex >= 0 ? (
+                <div className="principle-preview">
+                  <div className="cat-view-heading">
+                    <span className="h5 align-middle">
+                      Part of Principle{" "}
+                      {savedPrinciples[principleForm.selectedIndex]?.pri}:{" "}
+                      {savedPrinciples[principleForm.selectedIndex]?.label}
+                    </span>
+                    <OverlayTrigger
+                      placement="top"
+                      overlay={
+                        <Tooltip
+                          id={`tip-pri-${savedPrinciples[principleForm.selectedIndex]?.pri}`}
+                        >
+                          {
+                            savedPrinciples[principleForm.selectedIndex]
+                              ?.description
+                          }
+                        </Tooltip>
+                      }
+                    >
+                      <span className="ms-2 mb-2">
+                        <FaInfoCircle className="text-secondary opacity-50 align-middle" />
+                      </span>
+                    </OverlayTrigger>
+                  </div>
+                </div>
+              ) : (
+                <div className="preview-placeholder">
+                  <p>Select a principle to see the live preview</p>
+                </div>
+              )}
+            </div>
+          </div>
+
+          {/* Right Column - Builder */}
+          <div className="builder-column editor-column">
+            <div className="column-header">
+              <div className="builder-header-content">
+                <h3>Builder</h3>
+                <div className="principle-tabs">
+                  <button
+                    className={`tab-btn ${principleForm.mode === "select" ? "active" : ""} ${principleForm.mode === "none" ? "disabled" : ""}`}
+                    onClick={handleSelectTab}
+                    disabled={
+                      principleForm.mode === "none" ||
+                      principleForm.mode === "edit"
+                    }
+                  >
+                    Select
+                  </button>
+                  <div className="tab-divider" />
+                  <button
+                    className={`tab-btn ${principleForm.mode === "new" ? "active" : ""} ${principleForm.mode === "none" ? "disabled" : ""}`}
+                    onClick={handleNewTab}
+                    disabled={
+                      principleForm.mode === "none" ||
+                      principleForm.mode === "edit"
+                    }
+                  >
+                    New
+                  </button>
+                  <div className="tab-divider" />
+                  <button
+                    className={`tab-btn ${principleForm.mode === "edit" ? "active" : ""} ${savedPrinciples.length === 0 || principleForm.mode === "select" || principleForm.mode === "new" ? "disabled" : ""}`}
+                    onClick={handleEditTab}
+                    disabled={
+                      savedPrinciples.length === 0 ||
+                      principleForm.mode === "select" ||
+                      principleForm.mode === "new"
+                    }
+                  >
+                    Edit
+                  </button>
+                </div>
+              </div>
+            </div>
+            <div className="column-content">
+              {principleForm.mode === "select" ? (
+                <div className="principles-list-container">
+                  <div className="principles-list">
+                    <div className="principles-list-actions">
+                      <button
+                        className="select-principle-btn"
+                        onClick={handlePrincipleChanges}
+                        disabled={!selectedRegistryPrincipleId}
+                      >
+                        Select Principle
+                      </button>
+                    </div>
+
+                    {isLoading ? (
+                      <p className="no-principles">Loading principles...</p>
+                    ) : availablePrinciples.length === 0 ? (
+                      <p className="no-principles">
+                        {allPrinciples.length === 0
+                          ? "No principles available."
+                          : "All available principles have been added."}
+                      </p>
+                    ) : (
+                      <div className="principles-grid">
+                        {availablePrinciples.map((principle) => (
+                          <div
+                            key={principle.id}
+                            className={`principle-card ${selectedRegistryPrincipleId === principle.id ? "selected" : ""}`}
+                            onClick={() =>
+                              setSelectedRegistryPrincipleId(principle.id)
+                            }
+                          >
+                            <div className="principle-card-compact-header">
+                              <FaTags className="principle-card-icon" />
+                              <span className="principle-card-compact-title">
+                                <span className="principle-card-pri">
+                                  {principle.pri}
+                                </span>{" "}
+                                - {principle.label}
+                              </span>
+                            </div>
+                            <p className="principle-card-description">
+                              {principle.description}
+                            </p>
+                          </div>
+                        ))}
+                        {hasNextPage && (
+                          <button
+                            className="btn-secondary"
+                            onClick={() => fetchNextPage()}
+                          >
+                            Load More
+                          </button>
+                        )}
+                      </div>
+                    )}
+                  </div>
+                </div>
+              ) : principleForm.mode === "new" ? (
+                <div className="principle-form">
+                  <h4>Add New Principle</h4>
+                  <div className="form-group">
+                    <label htmlFor="principle-pri">Pri (*):</label>
+                    <input
+                      id="principle-pri"
+                      type="text"
+                      className="form-control"
+                      value={principleForm.data.pri}
+                      onChange={(e) =>
+                        handlePrincipleInputChange("pri", e.target.value)
+                      }
+                      placeholder="Enter principle identifier"
+                    />
+                  </div>
+
+                  <div className="form-group">
+                    <label htmlFor="principle-label">Label (*):</label>
+                    <input
+                      id="principle-label"
+                      type="text"
+                      className="form-control"
+                      value={principleForm.data.label}
+                      onChange={(e) =>
+                        handlePrincipleInputChange("label", e.target.value)
+                      }
+                      placeholder="Enter principle label"
+                    />
+                  </div>
+
+                  <div className="form-group">
+                    <label htmlFor="principle-description">
+                      Description (*):
+                    </label>
+                    <textarea
+                      id="principle-description"
+                      className="form-control"
+                      rows={3}
+                      value={principleForm.data.description}
+                      onChange={(e) =>
+                        handlePrincipleInputChange(
+                          "description",
+                          e.target.value,
+                        )
+                      }
+                      placeholder="Enter principle description"
+                    />
+                  </div>
+
+                  <div className="form-actions">
+                    <button className="btn-secondary" onClick={handleCancel}>
+                      Cancel
+                    </button>
+                    <button
+                      className="btn-primary"
+                      onClick={handlePrincipleChanges}
+                    >
+                      Create Principle
+                    </button>
+                  </div>
+                </div>
+              ) : principleForm.mode === "edit" ? (
+                <div className="principle-form">
+                  <h4 className="edit-title">Edit Principle</h4>
+
+                  <div className="form-group">
+                    <label htmlFor="edit-principle-pri">Pri (*):</label>
+                    <input
+                      id="edit-principle-pri"
+                      type="text"
+                      className="form-control"
+                      value={principleForm.data.pri}
+                      onChange={(e) =>
+                        handlePrincipleInputChange("pri", e.target.value)
+                      }
+                      placeholder="Enter principle identifier"
+                    />
+                  </div>
+
+                  <div className="form-group">
+                    <label htmlFor="edit-principle-label">Label (*):</label>
+                    <input
+                      id="edit-principle-label"
+                      type="text"
+                      className="form-control"
+                      value={principleForm.data.label}
+                      onChange={(e) =>
+                        handlePrincipleInputChange("label", e.target.value)
+                      }
+                      placeholder="Enter principle label"
+                    />
+                  </div>
+
+                  <div className="form-group">
+                    <label htmlFor="edit-principle-description">
+                      Description (*):
+                    </label>
+                    <textarea
+                      id="edit-principle-description"
+                      className="form-control"
+                      rows={3}
+                      value={principleForm.data.description}
+                      onChange={(e) =>
+                        handlePrincipleInputChange(
+                          "description",
+                          e.target.value,
+                        )
+                      }
+                      placeholder="Enter principle description"
+                    />
+                  </div>
+
+                  <div className="form-actions">
+                    <button className="btn-secondary" onClick={handleCancel}>
+                      Cancel
+                    </button>
+                    <button
+                      className="btn-primary"
+                      onClick={handlePrincipleChanges}
+                      disabled={
+                        !hasEditPrincipleChanged() ||
+                        !principleForm.data.pri ||
+                        !principleForm.data.label ||
+                        !principleForm.data.description
+                      }
+                    >
+                      Update Principle
+                    </button>
+                  </div>
+                </div>
+              ) : null}
+            </div>
+          </div>
+        </div>
+      </div>
+      <Button
+        className="mt-5 ms-1"
+        variant="secondary"
+        onClick={() => {
+          navigate(`/admin/motivations/${mtvId || ""}`);
+        }}
+      >
+        {t("buttons.back")}
+      </Button>
+    </>
+  );
+}
+
+export default AssessmentBuilder;

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -4,6 +4,7 @@ import ProfileUpdate from "./ProfileUpdate";
 import RequestValidation from "./validations/RequestValidation";
 import ValidationDetails from "./validations/ValidationDetails";
 import ValidationList from "./validations/ValidationList";
+import AssessmentBuilder from "./assessments/AssessmentBuilder";
 
 export {
   Home,
@@ -12,4 +13,5 @@ export {
   ValidationList,
   ProfileUpdate,
   ValidationDetails,
+  AssessmentBuilder,
 };

--- a/src/pages/motivations/MotivationDetails.tsx
+++ b/src/pages/motivations/MotivationDetails.tsx
@@ -27,6 +27,7 @@ import {
   FaLock,
   FaUnlock,
   FaBorderNone,
+  FaEdit,
 } from "react-icons/fa";
 import schemesImg from "@/assets/thumb_scheme.png";
 import authImg from "@/assets/thumb_auth.png";
@@ -150,7 +151,7 @@ export default function MotivationDetails() {
       message: t("page_motivations.modal_asmt_delete_message"),
       itemId: "",
       itemName: "",
-      mtvId: params.id || "",
+      mtvId: params.mtvId || "",
     });
 
   const mutationDelete = useDeleteMotivationActor(keycloak?.token || "");
@@ -177,7 +178,7 @@ export default function MotivationDetails() {
             show: false,
             itemId: "",
             itemName: "",
-            mtvId: params.id || "",
+            mtvId: params.mtvId || "",
           });
         });
       toast.promise(promise, {
@@ -231,7 +232,7 @@ export default function MotivationDetails() {
   };
 
   const { data: motivationData } = useGetMotivation({
-    id: params.id!,
+    id: params.mtvId!,
     token: keycloak?.token || "",
     isRegistered: registered,
   });
@@ -242,6 +243,9 @@ export default function MotivationDetails() {
     <Tooltip id="tip-restore">
       {t("page_motivations.tip_manage_criteria")}
     </Tooltip>
+  );
+  const tooltipEditAssessment = (
+    <Tooltip id="tip-edit-assessment">Edit Assessment</Tooltip>
   );
 
   const {
@@ -599,12 +603,23 @@ export default function MotivationDetails() {
                                       to={buildRoute(
                                         ROUTES.ADMIN.MOTIVATIONS.TEMPLATES,
                                         {
-                                          mtvId: params.id || "",
+                                          mtvId: params.mtvId || "",
                                           actId: item.id,
                                         },
                                       )}
                                     >
                                       <FaBars />
+                                    </Link>
+                                  </OverlayTrigger>
+                                  <OverlayTrigger
+                                    placement="top"
+                                    overlay={tooltipEditAssessment}
+                                  >
+                                    <Link
+                                      className="btn btn-light btn-sm m-1"
+                                      to={`/admin/motivations/${params.mtvId}/templates/actors/${item.id}/assessment-builder`}
+                                    >
+                                      <FaEdit />
                                     </Link>
                                   </OverlayTrigger>
                                   <OverlayTrigger
@@ -623,7 +638,7 @@ export default function MotivationDetails() {
                                             ROUTES.ADMIN.MOTIVATIONS
                                               .ACTOR_CRITERIA,
                                             {
-                                              mtvId: params.id || "",
+                                              mtvId: params.mtvId || "",
                                               actId: item.id,
                                             },
                                           )}
@@ -648,7 +663,7 @@ export default function MotivationDetails() {
                                         className="btn btn-light btn-sm m-1"
                                         onClick={() => {
                                           handleUnpublish(
-                                            params.id || "",
+                                            params.mtvId || "",
                                             item.id,
                                           );
                                         }}
@@ -671,7 +686,7 @@ export default function MotivationDetails() {
                                         className="btn btn-light btn-sm m-1"
                                         onClick={() => {
                                           handlePublish(
-                                            params.id || "",
+                                            params.mtvId || "",
                                             item.id,
                                           );
                                         }}
@@ -732,7 +747,7 @@ export default function MotivationDetails() {
             }
           >
             <MotivationPrinciples
-              mtvId={params.id || ""}
+              mtvId={params.mtvId || ""}
               published={motivation?.published || false}
             />
           </Tab>
@@ -748,7 +763,7 @@ export default function MotivationDetails() {
             }
           >
             <MotivationCriteria
-              mtvId={params.id || ""}
+              mtvId={params.mtvId || ""}
               published={motivation?.published || false}
             />
           </Tab>
@@ -765,7 +780,7 @@ export default function MotivationDetails() {
             }
           >
             <MotivationMetrics
-              mtvId={params.id || ""}
+              mtvId={params.mtvId || ""}
               published={motivation?.published || false}
             />
           </Tab>

--- a/src/pages/motivations/components/MotivationActorModal.tsx
+++ b/src/pages/motivations/components/MotivationActorModal.tsx
@@ -31,6 +31,7 @@ import {
   FaTrashAlt,
   FaUser,
 } from "react-icons/fa";
+import { useNavigate } from "react-router-dom";
 
 interface MotivationActorModalProps {
   motivationActors: MotivationActor[];
@@ -54,6 +55,8 @@ export function MotivationActorModal(props: MotivationActorModalProps) {
   const [showErrors, setShowErrors] = useState(false);
   const [autoGroups, setAutoGroups] = useState<AutoGroupTest[]>([]);
   const [testMethods, setTestMethods] = useState<RegistryResource[]>([]);
+
+  const navigate = useNavigate();
 
   const {
     data: testMethodsData,
@@ -144,6 +147,10 @@ export function MotivationActorModal(props: MotivationActorModalProps) {
       })
       .then(() => {
         props.onHide();
+        navigate(
+          `/admin/motivations/${props?.id}/templates/actors/${actorId}/assessment-builder`,
+        );
+        window.scrollTo(0, 0);
         alert.current = {
           message: t("page_motivations.toast_add_actor_success"),
         };

--- a/src/pages/motivations/components/MotivationMetricModal.tsx
+++ b/src/pages/motivations/components/MotivationMetricModal.tsx
@@ -79,6 +79,7 @@ export function MotivationMetricModal(props: MetricModalProps) {
     size: 5,
     token: keycloak?.token || "",
     isRegistered: registered,
+    enabled: true,
   });
 
   const {
@@ -89,6 +90,7 @@ export function MotivationMetricModal(props: MetricModalProps) {
     size: 5,
     token: keycloak?.token || "",
     isRegistered: registered,
+    enabled: true,
   });
 
   const {
@@ -99,6 +101,7 @@ export function MotivationMetricModal(props: MetricModalProps) {
     size: 5,
     token: keycloak?.token || "",
     isRegistered: registered,
+    enabled: true,
   });
 
   useEffect(() => {

--- a/src/pages/motivations/components/MotivationMetrics.tsx
+++ b/src/pages/motivations/components/MotivationMetrics.tsx
@@ -79,6 +79,8 @@ export const MotivationMetrics = ({
     message: "",
   });
 
+  console.log("MotivationMetrics rendered with mtvId:", mtvId);
+
   const {
     data: mtrData,
     fetchNextPage: mtrFetchNextPage,

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -57,6 +57,8 @@ const ROUTES = {
       METRICS_TESTS: "/admin/motivations/:mtvId/metrics-tests/:metricId",
       ACTOR_CRITERIA: "/admin/motivations/:mtvId/actors/:actId",
       TEMPLATES: "/admin/motivations/:mtvId/templates/actors/:actId",
+      ASSESSMENT_BUILDER:
+        "/admin/motivations/:mtvId/templates/actors/:actId/assessment-builder",
     },
     CRITERIA: {
       ROOT: "/admin/criteria",

--- a/src/types/motivation.ts
+++ b/src/types/motivation.ts
@@ -155,3 +155,10 @@ export interface MetricTestInput {
   test_id: string;
   relation: string;
 }
+
+export interface PrincipleAssignmentInput {
+  principle_id: string;
+  relation: string;
+  annotation_text?: string;
+  annotation_url?: string;
+}


### PR DESCRIPTION
This PR implements a Assessment Builder interface for creating and managing assessment templates with principles functionality, displaying a three-column layout.

- Added new AssessmentBuilder component with three-column layout 
- Implemented useAssignPrinciplesToMotivation hook for POST /v1/registry/motivations/{id}/principles endpoint
- Added "Build Assessment" button to MotivationDetails with navigation to Assessment Builder
- Updated MotivationModal to redirect to motivation details page after creation
- Added assessment data loading with proper principle population from existing assessments