### PR TITLE
[CAT-917] - Refactor Assessment Builder to use Criteria-First Approach

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -982,3 +982,12 @@ a.plain:hover {
   background-color: #007bff;
   border-color: #007bff;
 }
+
+.no-display {
+  display: none;
+}
+
+.no-pointer {
+  pointer-events: none;
+  cursor: default;
+}

--- a/src/api/services/criteria.ts
+++ b/src/api/services/criteria.ts
@@ -8,6 +8,7 @@ import {
 } from "@tanstack/react-query";
 import { handleBackendError } from "@/utils";
 import {
+  ApiOptions,
   ApiOptionsSearch,
   CriterionInput,
   CriterionResponse,
@@ -66,11 +67,7 @@ export const useGetCriterion = ({
     enabled: !!token && isRegistered && id !== "" && id !== undefined,
   });
 
-export const useGetAllCriteria = ({
-  token,
-  isRegistered,
-  size,
-}: ApiOptionsSearch) =>
+export const useGetAllCriteria = ({ token, isRegistered, size }: ApiOptions) =>
   useInfiniteQuery({
     queryKey: ["all-criteria"],
     queryFn: async ({ pageParam = 1 }) => {
@@ -182,7 +179,7 @@ export const useGetAllCriterionTypes = ({
 export const useUpdateCriterion = (
   token: string,
   id: string,
-  { cri, label, description }: CriterionInput,
+  { cri, label, description, imperative }: CriterionInput,
 ) => {
   const queryClient = useQueryClient();
   return useMutation(
@@ -193,6 +190,7 @@ export const useUpdateCriterion = (
           cri,
           label,
           description,
+          imperative,
         },
       );
       return response.data;

--- a/src/api/services/motivations.ts
+++ b/src/api/services/motivations.ts
@@ -32,6 +32,7 @@ import {
 } from "@/types";
 import { CriterionMetricResponse, CriterionResponse } from "@/types/criterion";
 import { relMtvPrincipleId } from "@/config";
+import { CriterionInput } from "../../types/criterion";
 
 export const useGetMotivations = ({
   size,
@@ -384,6 +385,28 @@ export const useGetMotivationCriteria = (
     retry: false,
     enabled: isRegistered,
   });
+
+export const useGetMotivationCriteriaMutation = (token: string) => {
+  return useMutation({
+    mutationFn: async ({
+      mtvId,
+      size = 100,
+      page = 1,
+    }: {
+      mtvId: string;
+      size?: number;
+      page?: number;
+    }) => {
+      const response = await APIClient(token).get<CriterionResponse>(
+        `/v1/registry/motivations/${mtvId}/criteria?size=${size}&page=${page}`,
+      );
+      return response.data;
+    },
+    onError: (error: AxiosError) => {
+      return handleBackendError(error);
+    },
+  });
+};
 
 export const useGetMotivationMetricTests = (
   mtvId: string,
@@ -776,13 +799,48 @@ export const useAssignPrinciplesToMotivation = (
       );
       return response.data;
     },
-
     {
       onError: (error: AxiosError) => {
         return handleBackendError(error);
       },
       onSuccess: () => {
-        queryClient.invalidateQueries(["motivation-principles", mtvId]);
+        queryClient.invalidateQueries(["motivation-principles"]);
+        queryClient.invalidateQueries(["all-principles"]);
+      },
+    },
+  );
+};
+
+export const useCreateMotivationCriterion = (
+  token: string,
+  mtvId: string,
+  { cri, label, description }: CriterionInput,
+) => {
+  const queryClient = useQueryClient();
+  return useMutation(
+    async () => {
+      const response = await APIClient(token).post<CriterionResponse>(
+        `/v1/registry/motivations/${mtvId}/criterion`,
+        {
+          criterion_request: {
+            cri,
+            label,
+            description,
+            imperative: "must", // Default imperative
+            type_criterion_id: "1", // Default type - you may want to make this configurable
+          },
+          relation: "maintainedBy", // Default relation
+        },
+      );
+      return response.data;
+    },
+    {
+      onError: (error: AxiosError) => {
+        return handleBackendError(error);
+      },
+      onSuccess: () => {
+        queryClient.invalidateQueries(["motivation-criteria"]);
+        queryClient.invalidateQueries(["all-criteria"]);
       },
     },
   );

--- a/src/assets/locales/en.json
+++ b/src/assets/locales/en.json
@@ -560,6 +560,7 @@
     "toast_unpublish_progress": "Unpublishing motivation...",
     "toast_unpublish_fail": "Error during motivation unpublishing!",
     "toast_asmt_publish_success": "Assessment Type succesfully published!",
+    "toast_asmt_publish_fail": "Error during Assessment Type publishing!",
     "toast_asmt_publish_progress": "Publishing Assessment Type...",
     "toast_asmt_upublish_fail": "Error during Assessment Type publishing!",
     "toast_asmt_unpublish_success": "Assessment Type succesfully unpublished!",

--- a/src/pages/assessments/AssessmentBuilder.css
+++ b/src/pages/assessments/AssessmentBuilder.css
@@ -8,7 +8,6 @@
 .assessment-builder-header {
   padding: 1rem 1.5rem;
   background: white;
-  border-bottom: 1px solid #e9ecef;
 }
 
 .header-content {
@@ -20,7 +19,8 @@
 
 .builder-title {
   margin: 0;
-  font-size: 1.5rem;
+  margin-bottom: 0.5rem;
+  font-size: 1.8rem;
   font-weight: 600;
   color: #2c3e50;
 }
@@ -36,6 +36,8 @@
   gap: 1px;
   overflow: hidden;
   background: #e5e7eb;
+  border: 1px solid #e9ecef;
+  border-radius: 0.375rem;
 }
 
 /* Columns */
@@ -49,7 +51,6 @@
 .structure-column {
   flex: 0 0 340px;
   min-width: 280px;
-  border-left: 1px solid #e9ecef;
 }
 
 .preview-column {
@@ -60,7 +61,6 @@
 .editor-column {
   flex: 0 0 380px;
   min-width: 330px;
-  border-right: 1px solid #e9ecef;
 }
 
 /* Column Headers */
@@ -97,7 +97,7 @@
 
 .column-header h3 {
   margin: 0;
-  font-size: 1.1rem;
+  font-size: 1.3rem;
   font-weight: 600;
   color: #374151;
 }
@@ -111,7 +111,7 @@
 
 .column-content {
   flex: 1;
-  padding: 1rem;
+  padding: 1rem 0.5rem;
   overflow-y: auto;
 }
 
@@ -126,7 +126,7 @@
 
 .principle-form h4 {
   padding-bottom: 0.5rem;
-  margin-bottom: 1.5rem;
+  margin-bottom: 0.7rem;
   font-size: 1rem;
   font-weight: 600;
   color: #374151;
@@ -154,6 +154,13 @@
   box-shadow: 0 4px 8px rgb(59 130 246 / 30%);
 }
 
+.btn-primary:disabled {
+  pointer-events: none;
+  cursor: default;
+  background: #9ca3af;
+  box-shadow: none;
+}
+
 .btn-secondary {
   display: inline-flex;
   gap: 0.5rem;
@@ -179,8 +186,8 @@
 .form-actions {
   display: flex;
   gap: 0.75rem;
-  padding-top: 1rem;
-  margin-top: 1.5rem;
+  padding-top: 0.5rem;
+  margin-top: 0.8rem;
   border-top: 1px solid #e5e7eb;
 }
 
@@ -218,6 +225,27 @@
 .header-actions .btn-primary:hover {
   background: #2563eb;
   box-shadow: 0 4px 8px rgb(59 130 246 / 30%);
+}
+
+.btn-outline-primary {
+  padding: 0.375rem 0.75rem;
+  font-size: 1rem;
+  font-weight: 400;
+  line-height: 1.5;
+  color: #0d6efd;
+  text-align: center;
+  text-decoration: none;
+  vertical-align: middle;
+  cursor: pointer;
+  background-color: transparent;
+  border: 1px solid #0d6efd;
+  border-radius: 0.375rem;
+}
+
+.btn-outline-primary:hover {
+  color: #fff;
+  background-color: #0d6efd;
+  border-color: #0d6efd;
 }
 
 /* Structure Column Specific */
@@ -260,14 +288,6 @@
   background: #f3f4f6;
 }
 
-.tree-item.nested {
-  margin-left: 1.5rem;
-}
-
-.tree-item.nested-deeper {
-  margin-left: 3rem;
-}
-
 .tree-item.clickable {
   cursor: pointer;
 }
@@ -283,31 +303,70 @@
 .tree-item.principle-item {
   padding: 0.75rem;
   margin-bottom: 0.25rem;
-  background: #dbeafe;
-  border: 1px solid #93c5fd;
+  background: #f0f9ff;
+  border: 1px solid #38bdf8;
   border-radius: 0.375rem;
   opacity: 0.8;
 }
 
 .tree-item.principle-item.selected {
-  background: #bfdbfe;
-  border: 2px solid #1d4ed8;
+  background: #e0f2fe;
+  border: 2px solid #0369a1;
   opacity: 1;
 }
 
 .tree-item.principle-item:hover {
-  background: #bfdbfe;
+  background: #e0f2fe;
 }
 
 .principle-display {
   font-size: 0.875rem;
   font-weight: 500;
-  color: #1d4ed8;
+  color: #0369a1;
 }
 
 .tree-icon {
   font-size: 0.875rem;
-  color: #1d4ed8;
+  color: #0369a1;
+}
+
+/* Untagged criteria header styling */
+.tree-item.principle-item.untagged {
+  color: #6b7280;
+  background: #f3f4f6;
+  border: 1px solid #d1d5db;
+}
+
+.tree-item.principle-item.untagged .tree-icon {
+  color: #6b7280;
+}
+
+.tree-item.principle-item.untagged .principle-display {
+  font-style: italic;
+  color: #6b7280;
+}
+
+.tree-item.principle-item.untagged:hover {
+  background: #e5e7eb;
+}
+
+/* Principle headers when acting as group headers (assigned principles) */
+.tree-item.principle-item:not(.nested, .untagged) {
+  background: #f0fdf4;
+  border: 1px solid lightgrey;
+}
+
+.tree-item.principle-item:not(.nested, .untagged):hover {
+  background: #dcfce7;
+}
+
+.tree-item.principle-item:not(.nested, .untagged) .principle-display {
+  font-weight: 600;
+  color: #166534;
+}
+
+.tree-item.principle-item:not(.nested, .untagged) .tree-icon {
+  color: #166534;
 }
 
 .form-group {
@@ -338,6 +397,25 @@
   box-shadow: 0 0 0 3px rgb(59 130 246 / 10%);
 }
 
+/* Form validation styles */
+.form-control.is-invalid {
+  border-color: #dc3545;
+  box-shadow: 0 0 0 0.2rem rgb(220 53 69 / 25%);
+}
+
+.form-control.is-invalid:focus {
+  border-color: #dc3545;
+  box-shadow: 0 0 0 0.2rem rgb(220 53 69 / 25%);
+}
+
+.invalid-feedback {
+  display: block;
+  width: 100%;
+  margin-top: 0.25rem;
+  font-size: 0.875rem;
+  color: #dc3545;
+}
+
 .header-actions .btn-primary:disabled {
   cursor: not-allowed;
   background: #9ca3af;
@@ -349,7 +427,7 @@
   box-shadow: none;
 }
 
-.column-content .principle-preview {
+.column-content .builder-preview {
   padding: 1.5rem;
   margin: 0.5rem;
   background: #fff;
@@ -357,10 +435,17 @@
   box-shadow: 0 1px 3px rgb(0 0 0 / 10%);
 }
 
-.column-content .cat-view-heading {
+.column-content .principle-wrapper {
   display: flex;
   align-items: center;
-  margin-bottom: 1.5rem;
+  width: fit-content;
+  margin-bottom: 1rem;
+  color: grey;
+  cursor: pointer;
+}
+
+.column-content .principle-wrapper:hover {
+  background: #f3f4f6;
 }
 
 .preview-placeholder {
@@ -509,7 +594,7 @@
 
 .tab-btn {
   position: relative;
-  width: 32%;
+  flex: 1;
   padding: 0.6rem 1rem;
   font-size: 0.875rem;
   font-weight: 500;
@@ -551,6 +636,20 @@
   background: #f8f9fa;
 }
 
+/* Ensure nested criteria have proper spacing */
+.tree-item.principle-item.nested {
+  margin-bottom: 0.25rem;
+  margin-left: 1.5rem;
+}
+
+/* Horizontal separator after each principle section */
+.principle-section-separator {
+  height: 1px;
+  margin: 1rem 0 0.5rem;
+  background: #e5e7eb;
+  border: none;
+}
+
 @media (width <= 1200px) {
   .editor-column {
     flex: 0 0 300px;
@@ -560,6 +659,10 @@
 @media (width <= 768px) {
   .builder-layout {
     flex-direction: column;
+  }
+
+  .assessment-builder {
+    height: auto;
   }
 
   .structure-column,

--- a/src/pages/assessments/AssessmentBuilder.tsx
+++ b/src/pages/assessments/AssessmentBuilder.tsx
@@ -1,27 +1,28 @@
 import { useParams, useNavigate } from "react-router-dom";
 import { useTranslation } from "react-i18next";
-import { useState, useContext, useRef, useEffect } from "react";
-import { FaTags, FaInfoCircle } from "react-icons/fa";
+import { useState, useContext, useEffect, useRef } from "react";
+import { FaInfoCircle } from "react-icons/fa";
 import { OverlayTrigger, Tooltip, Button } from "react-bootstrap";
 import { AuthContext } from "@/auth";
-import {
-  useGetAllPrinciples,
-  useCreateMotivationPrinciple,
-  useAssignPrinciplesToMotivation,
-} from "@/api";
+import { useGetAllPrinciples } from "@/api";
 import { useGetMotivationAssessmentType } from "@/api/services/templates";
-import { Principle, AlertInfo, PrincipleInput } from "@/types";
-import toast from "react-hot-toast";
+import {
+  usePublishMotivationActor,
+  useUnpublishMotivationActor,
+  useGetMotivation,
+} from "@/api/services/motivations";
+import {
+  Principle,
+  AssessmentBuilderState,
+  AssessmentCriterionImperative,
+  AlertInfo,
+} from "@/types";
+import AssessmentBuilderPrinciples from "./AssessmentBuilderPrinciples";
 import "./AssessmentBuilder.css";
-
-// Form modes for principle management
-type PrincipleFormMode = "none" | "select" | "new" | "edit";
-
-interface PrincipleFormState {
-  mode: PrincipleFormMode;
-  data: PrincipleInput;
-  selectedIndex: number;
-}
+import AssessmentBuilderStructure from "./AssessmentBuilderStructure";
+import AssessmentBuilderCriteria from "./AssessmentBuilderCriteria";
+import { useGetAllCriteria } from "../../api/services/criteria";
+import toast from "react-hot-toast";
 
 function AssessmentBuilder() {
   const { mtvId, actId } = useParams<{
@@ -31,345 +32,127 @@ function AssessmentBuilder() {
 
   const { t } = useTranslation();
   const { keycloak, registered } = useContext(AuthContext)!;
+  const navigate = useNavigate();
+
   const alert = useRef<AlertInfo>({
     message: "",
   });
-  const navigate = useNavigate();
 
-  const { data: assessmentData } = useGetMotivationAssessmentType(
-    mtvId || "",
-    actId || "",
-    keycloak?.token || "",
-    registered,
-  );
+  const { data: assessmentData, refetch: refetchAssessmentData } =
+    useGetMotivationAssessmentType(
+      mtvId || "",
+      actId || "",
+      keycloak?.token || "",
+      registered,
+    );
 
-  const {
-    data: principlesData,
-    isLoading,
-    fetchNextPage,
-    hasNextPage,
-  } = useGetAllPrinciples({
+  const { data: motivationData } = useGetMotivation({
+    id: mtvId || "",
     token: keycloak?.token || "",
     isRegistered: registered,
-    size: 50,
   });
 
-  const [savedPrinciples, setSavedPrinciples] = useState<PrincipleInput[]>([]);
-  const [principleForm, setPrincipleForm] = useState<PrincipleFormState>({
-    mode: "none",
-    data: { pri: "", label: "", description: "" },
-    selectedIndex: -1,
+  const isPublished =
+    motivationData?.actors?.find((actor) => actor.id === actId)?.published ||
+    false;
+
+  const mutationPublish = usePublishMotivationActor(keycloak?.token || "");
+  const mutationUnpublish = useUnpublishMotivationActor(keycloak?.token || "");
+
+  const handlePublish = () => {
+    if (!mtvId || !actId) return;
+
+    const promise = mutationPublish
+      .mutateAsync({ mtvId, actId })
+      .catch((err) => {
+        alert.current = {
+          message: t("page_motivations.toast_asmt_publish_fail"),
+        };
+        throw err;
+      })
+      .then(() => {
+        alert.current = {
+          message: t("page_motivations.toast_asmt_publish_success"),
+        };
+        refetchAssessmentData();
+      });
+
+    toast.promise(promise, {
+      loading: t("page_motivations.toast_asmt_publish_progress"),
+      success: () => `${alert.current.message}`,
+      error: () => `${alert.current.message}`,
+    });
+  };
+
+  const handleUnpublish = () => {
+    if (!mtvId || !actId) return;
+
+    const promise = mutationUnpublish
+      .mutateAsync({ mtvId, actId })
+      .catch((err) => {
+        alert.current = {
+          message: t("page_motivations.toast_asmt_unpublish_fail"),
+        };
+        throw err;
+      })
+      .then(() => {
+        alert.current = {
+          message: t("page_motivations.toast_asmt_unpublish_success"),
+        };
+        refetchAssessmentData();
+      });
+
+    toast.promise(promise, {
+      loading: t("page_motivations.toast_asmt_unpublish_progress"),
+      success: () => `${alert.current.message}`,
+      error: () => `${alert.current.message}`,
+    });
+  };
+
+  const [assessment, setAssessment] = useState(
+    assessmentData?.principles || [],
+  );
+  const [builderState, setBuilderState] = useState<AssessmentBuilderState>({
+    formMode: "none",
+    entityMode: "none",
+    selectedId: "",
+    selectedPrincipleIndex: -1,
+    selectedCriterionIndex: -1,
   });
-  const [selectedRegistryPrincipleId, setSelectedRegistryPrincipleId] =
-    useState<string | null>(null);
 
-  const mutateCreateMotivationPrinciple = useCreateMotivationPrinciple(
-    keycloak?.token || "",
-    mtvId || "",
-    principleForm.data,
-  );
+  useEffect(() => {
+    if (assessmentData) {
+      setAssessment(assessmentData?.principles || []);
+    }
+  }, [assessmentData]);
 
-  const mutateAssignPrinciplesToMotivation = useAssignPrinciplesToMotivation(
-    keycloak?.token || "",
-    mtvId || "",
-  );
+  const { data: principlesData, refetch: refetchPrinciples } =
+    useGetAllPrinciples({
+      token: keycloak?.token || "",
+      isRegistered: registered,
+      size: 100,
+    });
 
   const allPrinciples: Principle[] =
     principlesData?.pages?.flatMap((page) => page.content) || [];
 
-  const availablePrinciples = allPrinciples.filter(
-    (principle) =>
-      !savedPrinciples.some(
-        (savedPrinciple) => savedPrinciple.pri === principle.pri,
-      ),
-  );
+  const { data: criteriaData } = useGetAllCriteria({
+    size: 100,
+    token: keycloak?.token || "",
+    isRegistered: registered,
+  });
+  const allCriteria =
+    criteriaData?.pages?.flatMap((page) => page.content) || [];
 
-  const selectedRegistryPrinciple = availablePrinciples.find(
-    (p) => p.id === selectedRegistryPrincipleId,
-  );
-
-  // Load existing assessment data and populate saved principles
-  useEffect(() => {
-    if (assessmentData?.principles) {
-      const loadedPrinciples: PrincipleInput[] = assessmentData.principles.map(
-        (principle) => ({
-          pri: principle.id,
-          label: principle.name,
-          description: principle.description,
-        }),
-      );
-      setSavedPrinciples(loadedPrinciples);
-    }
-  }, [assessmentData]);
-
-  const handleAddPrinciple = () => {
-    setPrincipleForm({
-      mode: "select",
-      data: { pri: "", label: "", description: "" },
-      selectedIndex: -1,
-    });
-    setSelectedRegistryPrincipleId(null);
-  };
-
-  const handleSelectTab = () => {
-    setPrincipleForm({
-      ...principleForm,
-      mode: "select",
-      data: { pri: "", label: "", description: "" },
-    });
-  };
-
-  const handleNewTab = () => {
-    setPrincipleForm({
-      ...principleForm,
-      mode: "new",
-      data: { pri: "", label: "", description: "" },
-    });
-  };
-
-  const handleEditTab = () => {
-    // If there are saved principles, automatically select the first one for editing
-    if (savedPrinciples.length > 0) {
-      const firstPrinciple = savedPrinciples[0];
-      setPrincipleForm({
-        mode: "edit",
-        data: {
-          pri: firstPrinciple.pri,
-          label: firstPrinciple.label,
-          description: firstPrinciple.description,
-        },
-        selectedIndex: 0,
-      });
-    }
-  };
-
-  const handleEditPrinciple = (principleIndex: number) => {
-    const principle = savedPrinciples[principleIndex];
-    setPrincipleForm({
-      mode: "edit",
-      data: {
-        pri: principle.pri,
-        label: principle.label,
-        description: principle.description,
-      },
-      selectedIndex: principleIndex,
-    });
-  };
-
-  const hasEditPrincipleChanged = () => {
-    if (principleForm.mode !== "edit" || principleForm.selectedIndex < 0) {
-      return false;
-    }
-    const originalPrinciple = savedPrinciples[principleForm.selectedIndex];
-    if (!originalPrinciple) {
-      return false;
-    }
-    return (
-      principleForm.data.pri !== originalPrinciple.pri ||
-      principleForm.data.label !== originalPrinciple.label ||
-      principleForm.data.description !== originalPrinciple.description
-    );
-  };
-
-  const handlePrincipleInputChange = (
-    field: keyof PrincipleInput,
-    value: string,
-  ) => {
-    setPrincipleForm({
-      ...principleForm,
-      data: {
-        ...principleForm.data,
-        [field]: value,
-      },
-    });
-  };
-
-  const assignPrincipleToMotivationRequest = ({
-    pri,
-    label,
-    description,
-  }: PrincipleInput) => {
-    const promise = mutateCreateMotivationPrinciple
-      .mutateAsync()
-      .catch((err) => {
-        alert.current = {
-          message: "Error: " + (err.response?.data?.message || err.message),
-        };
-        throw err;
-      })
-      .then(() => {
-        alert.current = {
-          message: "Principle added to motivation successfully",
-        };
-
-        const newPrinciple: PrincipleInput = {
-          pri: pri,
-          label: label,
-          description: description,
-        };
-        const updatedPrinciples = [...savedPrinciples, newPrinciple];
-        setSavedPrinciples(updatedPrinciples);
-
-        const newPrincipleIndex = updatedPrinciples.length - 1;
-        setPrincipleForm({
-          mode: "edit",
-          data: {
-            pri: newPrinciple.pri,
-            label: newPrinciple.label,
-            description: newPrinciple.description,
-          },
-          selectedIndex: newPrincipleIndex,
-        });
-      });
-
-    toast.promise(promise, {
-      loading: "Adding principle to motivation...",
-      success: () => `${alert.current.message}`,
-      error: () => `${alert.current.message}`,
-    });
-  };
-
-  const assignSelectedPrincipleToMotivation = () => {
-    if (!selectedRegistryPrinciple || !mtvId) return;
-
-    const principleAssignments = [
-      {
-        principle_id: selectedRegistryPrinciple.id,
-        relation: "maintainedBy", // You can make this configurable if needed
-        annotation_text: "",
-        annotation_url: "",
-      },
-    ];
-
-    const promise = mutateAssignPrinciplesToMotivation
-      .mutateAsync(principleAssignments)
-      .catch((err) => {
-        alert.current = {
-          message: "Error: " + (err.response?.data?.message || err.message),
-        };
-        throw err;
-      })
-      .then(() => {
-        alert.current = {
-          message: "Principle assigned to motivation successfully",
-        };
-
-        const newPrinciple: PrincipleInput = {
-          pri: selectedRegistryPrinciple.pri,
-          label: selectedRegistryPrinciple.label,
-          description: selectedRegistryPrinciple.description,
-        };
-        const updatedPrinciples = [...savedPrinciples, newPrinciple];
-        setSavedPrinciples(updatedPrinciples);
-
-        const newPrincipleIndex = updatedPrinciples.length - 1;
-        setPrincipleForm({
-          mode: "edit",
-          data: {
-            pri: newPrinciple.pri,
-            label: newPrinciple.label,
-            description: newPrinciple.description,
-          },
-          selectedIndex: newPrincipleIndex,
-        });
-
-        // Clear the selected registry principle
-        setSelectedRegistryPrincipleId(null);
-      });
-
-    toast.promise(promise, {
-      loading: "Assigning principle to motivation...",
-      success: () => `${alert.current.message}`,
-      error: () => `${alert.current.message}`,
-    });
-  };
-
-  const handlePrincipleChanges = () => {
-    if (principleForm.mode === "select") {
-      // Assign selected principle from registry to motivation
-      if (selectedRegistryPrincipleId && mtvId) {
-        assignSelectedPrincipleToMotivation();
-      } else if (!mtvId) {
-        if (selectedRegistryPrinciple) {
-          const newPrinciple: PrincipleInput = {
-            pri: selectedRegistryPrinciple.pri,
-            label: selectedRegistryPrinciple.label,
-            description: selectedRegistryPrinciple.description,
-          };
-          const updatedPrinciples = [...savedPrinciples, newPrinciple];
-          setSavedPrinciples(updatedPrinciples);
-
-          // Automatically select the newly added principle for preview
-          const newPrincipleIndex = updatedPrinciples.length - 1;
-          setPrincipleForm({
-            mode: "edit",
-            data: {
-              pri: newPrinciple.pri,
-              label: newPrinciple.label,
-              description: newPrinciple.description,
-            },
-            selectedIndex: newPrincipleIndex,
-          });
-          setSelectedRegistryPrincipleId(null);
-        }
-      }
-    } else if (principleForm.mode === "new") {
-      if (
-        principleForm.data.pri &&
-        principleForm.data.label &&
-        principleForm.data.description
-      ) {
-        if (mtvId) {
-          assignPrincipleToMotivationRequest({
-            pri: principleForm.data.pri,
-            label: principleForm.data.label,
-            description: principleForm.data.description,
-          });
-        } else {
-          const newPrinciple: PrincipleInput = {
-            ...principleForm.data,
-          };
-          const updatedPrinciples = [...savedPrinciples, newPrinciple];
-          setSavedPrinciples(updatedPrinciples);
-
-          // Automatically select the newly created principle for preview
-          const newPrincipleIndex = updatedPrinciples.length - 1;
-          setPrincipleForm({
-            mode: "edit",
-            data: {
-              pri: newPrinciple.pri,
-              label: newPrinciple.label,
-              description: newPrinciple.description,
-            },
-            selectedIndex: newPrincipleIndex,
-          });
-        }
-      }
-    } else if (principleForm.mode === "edit") {
-      if (
-        principleForm.data.pri &&
-        principleForm.data.label &&
-        principleForm.data.description &&
-        principleForm.selectedIndex >= 0
-      ) {
-        const updatedPrinciples = [...savedPrinciples];
-        updatedPrinciples[principleForm.selectedIndex] = {
-          ...updatedPrinciples[principleForm.selectedIndex],
-          pri: principleForm.data.pri,
-          label: principleForm.data.label,
-          description: principleForm.data.description,
-        };
-        setSavedPrinciples(updatedPrinciples);
-      }
-    }
-  };
-
-  const handleCancel = () => {
-    setPrincipleForm({
-      mode: "none",
-      data: { pri: "", label: "", description: "" },
-      selectedIndex: -1,
-    });
+  const handleAddCriterion = () => {
+    setBuilderState((prevState) => ({
+      ...prevState,
+      formMode: "select",
+      entityMode: "criterion",
+      selectedId: "",
+      selectedPrincipleIndex: -1,
+      selectedCriterionIndex: -1,
+    }));
   };
 
   return (
@@ -380,7 +163,18 @@ function AssessmentBuilder() {
             <h1 className="builder-title">Assessment Builder</h1>
             <div className="header-actions">
               <button className="btn-secondary">Preview</button>
-              <button className="btn-primary">Publish</button>
+              {isPublished ? (
+                <button
+                  className="btn-outline-primary"
+                  onClick={handleUnpublish}
+                >
+                  Unpublish
+                </button>
+              ) : (
+                <button className="btn-primary" onClick={handlePublish}>
+                  Publish
+                </button>
+              )}
             </div>
           </div>
         </div>
@@ -390,80 +184,129 @@ function AssessmentBuilder() {
           {/* Left Column - Assessment Structure */}
           <div className="builder-column structure-column">
             <div className="column-header">
-              <h3>Assessment Structure</h3>
+              <h3>Structure</h3>
               <button
                 className="add-principle-btn"
-                onClick={handleAddPrinciple}
+                onClick={handleAddCriterion}
               >
-                + Add Principle
+                + Add Criterion
               </button>
             </div>
             <div className="column-content">
-              <div className="structure-tree">
-                {savedPrinciples.map((principle, principleIndex) => (
-                  <div key={principleIndex}>
-                    <div
-                      className={`tree-item principle-item clickable ${
-                        principleForm.selectedIndex === principleIndex
-                          ? "selected"
-                          : ""
-                      }`}
-                      onClick={() => handleEditPrinciple(principleIndex)}
-                    >
-                      <span className="tree-icon">
-                        <FaTags />
-                      </span>
-                      <span className="principle-display">
-                        {principle.pri} - {principle.label}
-                      </span>
-                    </div>
-                  </div>
-                ))}
-              </div>
+              <AssessmentBuilderStructure
+                assessment={assessment}
+                setBuilderState={setBuilderState}
+                selectedId={builderState.selectedId || ""}
+              />
             </div>
           </div>
 
-          {/* Center Column - Live Preview */}
+          {/* Center Column - Preview */}
           <div className="builder-column preview-column">
             <div className="column-header">
               <div>
-                <h3>Live Preview</h3>
+                <h3>Preview</h3>
                 <p className="column-description">
                   Preview how users will see this assessment
                 </p>
               </div>
             </div>
             <div className="column-content">
-              {principleForm.selectedIndex >= 0 ? (
-                <div className="principle-preview">
-                  <div className="cat-view-heading">
-                    <span className="h5 align-middle">
-                      Part of Principle{" "}
-                      {savedPrinciples[principleForm.selectedIndex]?.pri}:{" "}
-                      {savedPrinciples[principleForm.selectedIndex]?.label}
-                    </span>
-                    <OverlayTrigger
-                      placement="top"
-                      overlay={
-                        <Tooltip
-                          id={`tip-pri-${savedPrinciples[principleForm.selectedIndex]?.pri}`}
-                        >
-                          {
-                            savedPrinciples[principleForm.selectedIndex]
-                              ?.description
-                          }
-                        </Tooltip>
+              {assessment?.length > 0 ? (
+                <div className="builder-preview">
+                  {builderState.selectedPrincipleIndex != null &&
+                  builderState.selectedPrincipleIndex > -1 ? (
+                    <div
+                      className="principle-wrapper"
+                      onClick={() =>
+                        setBuilderState((prevState) => ({
+                          ...prevState,
+                          entityMode: "principle",
+                          formMode: "select",
+                        }))
                       }
                     >
-                      <span className="ms-2 mb-2">
-                        <FaInfoCircle className="text-secondary opacity-50 align-middle" />
+                      <span className="h5 align-middle">
+                        Part of Principle{" "}
+                        {assessment[builderState.selectedPrincipleIndex]?.id}:{" "}
+                        {assessment[builderState.selectedPrincipleIndex]?.name}
                       </span>
-                    </OverlayTrigger>
-                  </div>
+                      <OverlayTrigger
+                        placement="top"
+                        overlay={
+                          <Tooltip
+                            id={`tip-pri-${
+                              builderState.selectedPrincipleIndex &&
+                              builderState.selectedPrincipleIndex > -1 &&
+                              assessment[builderState.selectedPrincipleIndex]
+                                ?.id
+                            }`}
+                          >
+                            {
+                              assessment[builderState.selectedPrincipleIndex]
+                                ?.description
+                            }
+                          </Tooltip>
+                        }
+                      >
+                        <span className="ms-2 mb-2">
+                          <FaInfoCircle className="text-secondary opacity-50 align-middle" />
+                        </span>
+                      </OverlayTrigger>
+                    </div>
+                  ) : builderState.selectedCriterionIndex == null ||
+                    builderState.selectedCriterionIndex < 0 ? (
+                    <div className="empty-preview">
+                      <p className="text-muted">
+                        Please select a criterion from the structure list to see
+                        its details here.
+                      </p>
+                    </div>
+                  ) : null}
+
+                  {builderState.selectedCriterionIndex != null &&
+                  builderState.selectedCriterionIndex > -1 ? (
+                    <div>
+                      <span className="h5 align-middle">
+                        {
+                          assessment[builderState.selectedPrincipleIndex || 0]
+                            ?.criteria[builderState.selectedCriterionIndex]?.id
+                        }
+                        :{" "}
+                        {
+                          assessment[builderState.selectedPrincipleIndex || 0]
+                            ?.criteria[builderState.selectedCriterionIndex]
+                            ?.name
+                        }
+                      </span>
+
+                      {assessment[builderState.selectedPrincipleIndex || 0]
+                        ?.criteria[builderState.selectedCriterionIndex]
+                        ?.imperative === AssessmentCriterionImperative.MUST ? (
+                        <span className="badge bg-success bg-small ms-4 align-middle">
+                          {t("required")}
+                        </span>
+                      ) : (
+                        <span className="badge bg-warning bg-small ms-4 align-middle">
+                          {t("optional")}
+                        </span>
+                      )}
+                      <p className="text-muted lh-sm mt-2 mb-2">
+                        {
+                          assessment[builderState.selectedPrincipleIndex || 0]
+                            ?.criteria[builderState.selectedCriterionIndex]
+                            ?.description
+                        }
+                      </p>
+                    </div>
+                  ) : null}
                 </div>
               ) : (
-                <div className="preview-placeholder">
-                  <p>Select a principle to see the live preview</p>
+                <div className="empty-preview">
+                  <p className="text-muted">
+                    No assessment structure defined yet. Please add or select a
+                    criterion to start building your assessment.
+                  </p>
                 </div>
               )}
             </div>
@@ -476,231 +319,107 @@ function AssessmentBuilder() {
                 <h3>Builder</h3>
                 <div className="principle-tabs">
                   <button
-                    className={`tab-btn ${principleForm.mode === "select" ? "active" : ""} ${principleForm.mode === "none" ? "disabled" : ""}`}
-                    onClick={handleSelectTab}
+                    className={`tab-btn ${builderState.formMode === "select" ? "active" : ""} ${builderState.formMode === "none" ? "disabled" : ""}`}
+                    onClick={() => {
+                      setBuilderState((prevState) => ({
+                        ...prevState,
+                        formMode: "select",
+                      }));
+                    }}
                     disabled={
-                      principleForm.mode === "none" ||
-                      principleForm.mode === "edit"
+                      builderState.formMode === "none" ||
+                      builderState.formMode === "edit"
                     }
                   >
                     Select
                   </button>
                   <div className="tab-divider" />
                   <button
-                    className={`tab-btn ${principleForm.mode === "new" ? "active" : ""} ${principleForm.mode === "none" ? "disabled" : ""}`}
-                    onClick={handleNewTab}
+                    className={`tab-btn ${builderState.formMode === "new" ? "active" : ""} ${builderState.formMode === "none" ? "disabled" : ""}`}
+                    onClick={() => {
+                      setBuilderState((prevState) => ({
+                        ...prevState,
+                        formMode: "new",
+                      }));
+                    }}
                     disabled={
-                      principleForm.mode === "none" ||
-                      principleForm.mode === "edit"
+                      builderState.formMode === "none" ||
+                      builderState.formMode === "edit"
                     }
                   >
                     New
                   </button>
-                  <div className="tab-divider" />
-                  <button
-                    className={`tab-btn ${principleForm.mode === "edit" ? "active" : ""} ${savedPrinciples.length === 0 || principleForm.mode === "select" || principleForm.mode === "new" ? "disabled" : ""}`}
-                    onClick={handleEditTab}
-                    disabled={
-                      savedPrinciples.length === 0 ||
-                      principleForm.mode === "select" ||
-                      principleForm.mode === "new"
-                    }
-                  >
-                    Edit
-                  </button>
+                  {(builderState.entityMode === "criterion" ||
+                    builderState.entityMode === "none") && (
+                    <>
+                      <div className="tab-divider" />
+                      <button
+                        className={`tab-btn ${builderState.formMode === "edit" ? "active" : ""} ${builderState.formMode === "select" || builderState.formMode === "new" ? "disabled" : ""}`}
+                        onClick={() => {
+                          setBuilderState((prevState) => ({
+                            ...prevState,
+                            formMode: "edit",
+                          }));
+                        }}
+                        disabled={
+                          builderState.formMode === "select" ||
+                          builderState.formMode === "new" ||
+                          builderState.formMode === "none"
+                        }
+                      >
+                        Edit
+                      </button>
+                    </>
+                  )}
                 </div>
               </div>
             </div>
             <div className="column-content">
-              {principleForm.mode === "select" ? (
-                <div className="principles-list-container">
-                  <div className="principles-list">
-                    <div className="principles-list-actions">
-                      <button
-                        className="select-principle-btn"
-                        onClick={handlePrincipleChanges}
-                        disabled={!selectedRegistryPrincipleId}
-                      >
-                        Select Principle
-                      </button>
-                    </div>
-
-                    {isLoading ? (
-                      <p className="no-principles">Loading principles...</p>
-                    ) : availablePrinciples.length === 0 ? (
-                      <p className="no-principles">
-                        {allPrinciples.length === 0
-                          ? "No principles available."
-                          : "All available principles have been added."}
-                      </p>
-                    ) : (
-                      <div className="principles-grid">
-                        {availablePrinciples.map((principle) => (
-                          <div
-                            key={principle.id}
-                            className={`principle-card ${selectedRegistryPrincipleId === principle.id ? "selected" : ""}`}
-                            onClick={() =>
-                              setSelectedRegistryPrincipleId(principle.id)
-                            }
-                          >
-                            <div className="principle-card-compact-header">
-                              <FaTags className="principle-card-icon" />
-                              <span className="principle-card-compact-title">
-                                <span className="principle-card-pri">
-                                  {principle.pri}
-                                </span>{" "}
-                                - {principle.label}
-                              </span>
-                            </div>
-                            <p className="principle-card-description">
-                              {principle.description}
-                            </p>
-                          </div>
-                        ))}
-                        {hasNextPage && (
-                          <button
-                            className="btn-secondary"
-                            onClick={() => fetchNextPage()}
-                          >
-                            Load More
-                          </button>
-                        )}
-                      </div>
-                    )}
-                  </div>
-                </div>
-              ) : principleForm.mode === "new" ? (
-                <div className="principle-form">
-                  <h4>Add New Principle</h4>
-                  <div className="form-group">
-                    <label htmlFor="principle-pri">Pri (*):</label>
-                    <input
-                      id="principle-pri"
-                      type="text"
-                      className="form-control"
-                      value={principleForm.data.pri}
-                      onChange={(e) =>
-                        handlePrincipleInputChange("pri", e.target.value)
-                      }
-                      placeholder="Enter principle identifier"
-                    />
-                  </div>
-
-                  <div className="form-group">
-                    <label htmlFor="principle-label">Label (*):</label>
-                    <input
-                      id="principle-label"
-                      type="text"
-                      className="form-control"
-                      value={principleForm.data.label}
-                      onChange={(e) =>
-                        handlePrincipleInputChange("label", e.target.value)
-                      }
-                      placeholder="Enter principle label"
-                    />
-                  </div>
-
-                  <div className="form-group">
-                    <label htmlFor="principle-description">
-                      Description (*):
-                    </label>
-                    <textarea
-                      id="principle-description"
-                      className="form-control"
-                      rows={3}
-                      value={principleForm.data.description}
-                      onChange={(e) =>
-                        handlePrincipleInputChange(
-                          "description",
-                          e.target.value,
-                        )
-                      }
-                      placeholder="Enter principle description"
-                    />
-                  </div>
-
-                  <div className="form-actions">
-                    <button className="btn-secondary" onClick={handleCancel}>
-                      Cancel
-                    </button>
-                    <button
-                      className="btn-primary"
-                      onClick={handlePrincipleChanges}
-                    >
-                      Create Principle
-                    </button>
-                  </div>
-                </div>
-              ) : principleForm.mode === "edit" ? (
-                <div className="principle-form">
-                  <h4 className="edit-title">Edit Principle</h4>
-
-                  <div className="form-group">
-                    <label htmlFor="edit-principle-pri">Pri (*):</label>
-                    <input
-                      id="edit-principle-pri"
-                      type="text"
-                      className="form-control"
-                      value={principleForm.data.pri}
-                      onChange={(e) =>
-                        handlePrincipleInputChange("pri", e.target.value)
-                      }
-                      placeholder="Enter principle identifier"
-                    />
-                  </div>
-
-                  <div className="form-group">
-                    <label htmlFor="edit-principle-label">Label (*):</label>
-                    <input
-                      id="edit-principle-label"
-                      type="text"
-                      className="form-control"
-                      value={principleForm.data.label}
-                      onChange={(e) =>
-                        handlePrincipleInputChange("label", e.target.value)
-                      }
-                      placeholder="Enter principle label"
-                    />
-                  </div>
-
-                  <div className="form-group">
-                    <label htmlFor="edit-principle-description">
-                      Description (*):
-                    </label>
-                    <textarea
-                      id="edit-principle-description"
-                      className="form-control"
-                      rows={3}
-                      value={principleForm.data.description}
-                      onChange={(e) =>
-                        handlePrincipleInputChange(
-                          "description",
-                          e.target.value,
-                        )
-                      }
-                      placeholder="Enter principle description"
-                    />
-                  </div>
-
-                  <div className="form-actions">
-                    <button className="btn-secondary" onClick={handleCancel}>
-                      Cancel
-                    </button>
-                    <button
-                      className="btn-primary"
-                      onClick={handlePrincipleChanges}
-                      disabled={
-                        !hasEditPrincipleChanged() ||
-                        !principleForm.data.pri ||
-                        !principleForm.data.label ||
-                        !principleForm.data.description
-                      }
-                    >
-                      Update Principle
-                    </button>
-                  </div>
-                </div>
-              ) : null}
+              {builderState.entityMode === "criterion" && (
+                <AssessmentBuilderCriteria
+                  mtvId={mtvId || ""}
+                  actId={actId || ""}
+                  formMode={builderState.formMode}
+                  setAssessment={setAssessment}
+                  assessment={assessment}
+                  allCriteria={allCriteria || []}
+                  allPrinciples={allPrinciples}
+                  criterionId={
+                    builderState.selectedId
+                      ? assessment
+                          ?.flatMap((principle) => principle.criteria || [])
+                          .find(
+                            (criterion) =>
+                              criterion.id === builderState.selectedId,
+                          )?.id
+                      : ""
+                  }
+                  setBuilderState={setBuilderState}
+                />
+              )}
+              {builderState.entityMode === "principle" && (
+                <AssessmentBuilderPrinciples
+                  mtvId={mtvId || ""}
+                  formMode={builderState.formMode}
+                  setAssessment={setAssessment}
+                  assessment={assessment}
+                  allPrinciples={allPrinciples}
+                  allCriteria={allCriteria}
+                  principleId={
+                    builderState.selectedId
+                      ? assessment.find((principle) =>
+                          principle.criteria?.some(
+                            (criterion) =>
+                              criterion.id === builderState.selectedId,
+                          ),
+                        )?.id || ""
+                      : ""
+                  }
+                  builderState={builderState}
+                  setBuilderState={setBuilderState}
+                  refetchPrinciples={refetchPrinciples}
+                />
+              )}
             </div>
           </div>
         </div>

--- a/src/pages/assessments/AssessmentBuilderCriteria.tsx
+++ b/src/pages/assessments/AssessmentBuilderCriteria.tsx
@@ -1,0 +1,691 @@
+import {
+  useCreateCriterion,
+  useUpdateMotivationPrinciplesCriteria,
+  useGetAllImperatives,
+  useGetMotivationActorCriteria,
+  useUpdateCriterion,
+  useUpdateMotivationActorCriteria,
+  useGetMotivationCriteriaMutation,
+} from "@/api";
+import { AuthContext } from "@/auth";
+import {
+  AlertInfo,
+  AssessmentBuilderState,
+  AssessmentPrinciple,
+  Criterion,
+  CriterionInput,
+  Imperative,
+  PrincipleInput,
+} from "@/types";
+import { useContext, useEffect, useRef, useState } from "react";
+import { Form } from "react-bootstrap";
+import toast from "react-hot-toast";
+import { useTranslation } from "react-i18next";
+import { FaTags } from "react-icons/fa";
+import {
+  assessmentCriterionToForm,
+  handleSelectCriterion,
+  handleNewCriterion,
+  formatDataToAssignPrincipleToCriterion,
+  handleEditCriterion,
+} from "./utils";
+
+function AssessmentBuilderCriteria({
+  assessment,
+  setAssessment,
+  formMode,
+  mtvId,
+  actId,
+  allCriteria,
+  allPrinciples,
+  setBuilderState,
+  criterionId,
+}: {
+  assessment: AssessmentPrinciple[];
+  setAssessment: React.Dispatch<React.SetStateAction<AssessmentPrinciple[]>>;
+  formMode: "none" | "select" | "new" | "edit";
+  mtvId?: string;
+  actId?: string;
+  allCriteria: Criterion[];
+  allPrinciples?: (PrincipleInput & { id: string })[];
+  setBuilderState: (builderState: AssessmentBuilderState) => void;
+  criterionId?: string;
+}) {
+  const { keycloak, registered } = useContext(AuthContext)!;
+  const alert = useRef<AlertInfo>({
+    message: "",
+  });
+  const { t } = useTranslation();
+
+  const [selectedCriteria, setSelectedCriteria] = useState<Criterion[]>([]);
+  const [principleTag, setPrincipleTag] = useState<string | null>(null);
+
+  const [criterionForm, setCriterionForm] = useState<CriterionInput | null>(
+    assessmentCriterionToForm(criterionId || "", assessment, formMode),
+  );
+
+  const [showErrors, setShowErrors] = useState(false);
+  const [searchTerm, setSearchTerm] = useState("");
+
+  function handleValidate() {
+    setShowErrors(true);
+    return (
+      criterionForm?.cri !== "" &&
+      criterionForm?.label !== "" &&
+      criterionForm?.description !== "" &&
+      criterionForm?.imperative !== ""
+    );
+  }
+
+  const filteredCriteria = allCriteria.filter((criterion) => {
+    // Check if criterion exists in any principle (including untagged)
+    const existsInAssessment = assessment.some((principle) =>
+      principle.criteria?.some(
+        (assessmentCriterion) =>
+          assessmentCriterion.id?.toLowerCase() ===
+          criterion.cri?.toLowerCase(),
+      ),
+    );
+
+    if (!searchTerm) {
+      return !existsInAssessment;
+    }
+
+    const term = searchTerm.toLowerCase();
+    const matchesSearch =
+      criterion.cri?.toLowerCase().includes(term) ||
+      criterion.label?.toLowerCase().includes(term) ||
+      criterion.description?.toLowerCase().includes(term);
+
+    // For search results, also filter out existing criteria
+    return matchesSearch && !existsInAssessment;
+  });
+
+  const mutateCreateNewCriterion = useCreateCriterion(keycloak?.token || "", {
+    cri: criterionForm?.cri || "",
+    label: criterionForm?.label || "",
+    description: criterionForm?.description || "",
+    imperative: criterionForm?.imperative || "",
+    type_criterion_id: "pid_graph:4A47BB1A",
+  });
+
+  const selectedCriterionPidGraph = allCriteria?.find(
+    (criterion) => criterion?.cri?.toLowerCase() === criterionId?.toLowerCase(),
+  )?.id;
+
+  const selectedPrincipleLabel = assessment.find((item) =>
+    item.criteria.some(
+      (c) => c.id?.toLowerCase() === criterionId?.toLowerCase(),
+    ),
+  )?.id;
+
+  const selectedPrinciplePidGraph = allPrinciples?.find(
+    (principle) =>
+      principle?.pri?.toLowerCase() === selectedPrincipleLabel?.toLowerCase(),
+  )?.id;
+
+  const mutateUpdateCriterion = useUpdateCriterion(
+    keycloak?.token || "",
+    selectedCriterionPidGraph || "",
+    {
+      cri: criterionForm?.cri || "",
+      label: criterionForm?.label || "",
+      description: criterionForm?.description || "",
+      imperative: criterionForm?.imperative || "",
+    },
+  );
+
+  const getMotivationCriteriaMutation = useGetMotivationCriteriaMutation(
+    keycloak?.token || "",
+  );
+
+  const assignPrincipleToCriterion = useUpdateMotivationPrinciplesCriteria(
+    keycloak?.token || "",
+    mtvId || "",
+  );
+
+  const assignCriteriaToActorMutation = useUpdateMotivationActorCriteria(
+    keycloak?.token || "",
+    mtvId || "",
+    actId || "",
+  );
+
+  const [imperatives, setImperatives] = useState<Imperative[]>([]);
+
+  const [selectedRegistryCriterionId, setSelectedRegistryCriterionId] =
+    useState<string | null>(criterionId || null);
+
+  const {
+    data: impData,
+    fetchNextPage: impFetchNextPage,
+    hasNextPage: impHasNextPage,
+  } = useGetAllImperatives({
+    size: 20,
+    token: keycloak?.token || "",
+    isRegistered: registered,
+    search: "",
+  });
+
+  const {
+    data: selCriData,
+    fetchNextPage: selCriFetchNextPage,
+    hasNextPage: selCriHasNextPage,
+  } = useGetMotivationActorCriteria(mtvId || "", actId || "", {
+    size: 5,
+    token: keycloak?.token || "",
+    isRegistered: registered,
+  });
+
+  useEffect(() => {
+    let tmpImp: Imperative[] = [];
+    if (impData?.pages) {
+      impData.pages.map((page) => {
+        tmpImp = [...tmpImp, ...page.content];
+      });
+      if (impHasNextPage) {
+        impFetchNextPage();
+      }
+    }
+
+    setImperatives(tmpImp);
+  }, [impData, impHasNextPage, impFetchNextPage]);
+
+  useEffect(() => {
+    // gather all motivation actor criteria in one array
+    let tmpSelCri: Criterion[] = [];
+
+    // iterate over backend pages and gather all items in the mtv array
+    if (selCriData?.pages) {
+      selCriData.pages.map((page) => {
+        tmpSelCri = [...tmpSelCri, ...page.content];
+      });
+      if (selCriHasNextPage) {
+        selCriFetchNextPage();
+      }
+    }
+    setSelectedCriteria(tmpSelCri);
+  }, [selCriData, selCriHasNextPage, selCriFetchNextPage]);
+
+  // Handle edit mode form population
+  useEffect(() => {
+    // initial form for new or select mode
+    if (formMode !== "edit") {
+      const formData = assessmentCriterionToForm(
+        "",
+        assessment,
+        formMode,
+        setPrincipleTag,
+      );
+
+      setCriterionForm(formData);
+      return;
+    }
+
+    if (formMode === "edit" && criterionId) {
+      const formData = assessmentCriterionToForm(
+        criterionId,
+        assessment,
+        formMode,
+        setPrincipleTag,
+      );
+
+      setCriterionForm(formData);
+
+      if (
+        selectedPrinciplePidGraph &&
+        selectedPrinciplePidGraph !== "untagged"
+      ) {
+        setPrincipleTag(selectedPrinciplePidGraph);
+      } else {
+        setPrincipleTag(null);
+      }
+
+      // Find and set the imperative ID from the imperatives list
+      if (formData?.imperative && imperatives.length > 0) {
+        const matchingImperative = imperatives.find(
+          (imp) =>
+            imp.label.toLowerCase() === formData.imperative.toLowerCase() ||
+            imp.id === formData.imperative,
+        );
+        if (matchingImperative && formData) {
+          setCriterionForm({
+            ...formData,
+            imperative: matchingImperative.id,
+          });
+        }
+      }
+    }
+  }, [
+    formMode,
+    criterionId,
+    assessment,
+    imperatives,
+    selectedCriterionPidGraph,
+    selectedPrinciplePidGraph,
+  ]);
+
+  const handleCancel = () => {
+    setCriterionForm({ cri: "", label: "", description: "", imperative: "" });
+    setPrincipleTag("");
+    setBuilderState({
+      formMode: "none",
+      entityMode: "none",
+      selectedId: "",
+      selectedPrincipleIndex: -1,
+      selectedCriterionIndex: -1,
+    });
+  };
+
+  const handleCriterionInputChange = (
+    field: keyof CriterionInput,
+    value: string,
+  ) => {
+    if (!criterionForm) return;
+    setCriterionForm({
+      ...criterionForm,
+      [field]: value,
+    });
+  };
+
+  const assignCriteriaToActor = async () => {
+    const criImp = selectedCriteria?.map((item) => ({
+      criterion_id: item.id,
+      imperative_id: item.imperative.id,
+    }));
+
+    let newCriterionId: string | null = null;
+    let formattedPriCri: ReturnType<
+      typeof formatDataToAssignPrincipleToCriterion
+    > = [];
+
+    const allMotivationCriteriaData =
+      await getMotivationCriteriaMutation.mutateAsync({
+        mtvId: mtvId || "",
+      });
+
+    const allMotivationCriteria = allMotivationCriteriaData?.content || [];
+
+    if (formMode === "new") {
+      // First API call - Create new criterion
+      try {
+        const createResponse = await mutateCreateNewCriterion.mutateAsync();
+        // Extract id from response object
+        newCriterionId = (createResponse as { id?: string }).id || null;
+
+        if (newCriterionId) {
+          criImp.push({
+            criterion_id: newCriterionId,
+            imperative_id:
+              criterionForm?.imperative ||
+              (imperatives.length > 0 ? imperatives[0].id : ""),
+          });
+        }
+      } catch (error) {
+        console.error("Create criterion failed:", error);
+        throw error;
+      }
+
+      if (principleTag && newCriterionId) {
+        formattedPriCri = formatDataToAssignPrincipleToCriterion({
+          principleId: principleTag,
+          criterionId: newCriterionId,
+          allMotivationCriteria: allMotivationCriteria,
+        });
+
+        try {
+          await assignPrincipleToCriterion.mutateAsync(formattedPriCri);
+        } catch (error) {
+          console.error(error);
+          throw error;
+        }
+      }
+    }
+
+    if (formMode === "select" && selectedRegistryCriterionId) {
+      const selectedCriterionPid = allCriteria.find(
+        (criterion) => criterion.cri === selectedRegistryCriterionId,
+      )?.id;
+
+      if (principleTag) {
+        formattedPriCri = formatDataToAssignPrincipleToCriterion({
+          principleId: principleTag || "",
+          criterionId: selectedCriterionPid || "",
+          allMotivationCriteria: allMotivationCriteria,
+        });
+
+        try {
+          await assignPrincipleToCriterion.mutateAsync(formattedPriCri);
+        } catch (error) {
+          console.error("Assign principle to criterion failed:", error);
+          throw error;
+        }
+      }
+
+      criImp.push({
+        criterion_id: selectedCriterionPid || "",
+        imperative_id:
+          criterionForm?.imperative ||
+          (imperatives.length > 0 ? imperatives[0].id : ""),
+      });
+    }
+
+    if (formMode === "edit" && criterionForm?.cri) {
+      await mutateUpdateCriterion.mutateAsync();
+
+      if (
+        principleTag &&
+        principleTag !== "untagged" &&
+        principleTag !== selectedPrinciplePidGraph
+      ) {
+        formattedPriCri = formatDataToAssignPrincipleToCriterion({
+          principleId: principleTag || "",
+          criterionId: selectedCriterionPidGraph || "",
+          allMotivationCriteria: allMotivationCriteria,
+        });
+
+        try {
+          await assignPrincipleToCriterion.mutateAsync(formattedPriCri);
+        } catch (error) {
+          console.error("Assign principle to criterion failed:", error);
+          throw error;
+        }
+      }
+
+      if (selectedCriterionPidGraph) {
+        criImp.push({
+          criterion_id: selectedCriterionPidGraph,
+          imperative_id:
+            criterionForm?.imperative ||
+            (imperatives.length > 0 ? imperatives[0].id : ""),
+        });
+      }
+    }
+
+    if (formMode !== "edit") {
+      try {
+        await assignCriteriaToActorMutation.mutateAsync(criImp);
+      } catch (error) {
+        console.error("Assign criteria to actor failed:", error);
+        throw error;
+      }
+    }
+  };
+
+  const handleSubmit = async () => {
+    if (!registered) {
+      alert.current = {
+        message: "You must be registered to perform this action.",
+      };
+      toast.error(alert.current.message);
+      return;
+    }
+
+    if ((formMode === "new" || formMode === "edit") && !handleValidate()) {
+      return;
+    }
+
+    const promise = assignCriteriaToActor()
+      .catch((err) => {
+        alert.current = {
+          message: "Error: " + (err.response?.data?.message || err.message),
+        };
+        throw err;
+      })
+      .then(() => {
+        alert.current = {
+          message:
+            formMode === "new"
+              ? "Criterion created successfully"
+              : formMode === "edit"
+                ? "Criterion updated successfully"
+                : "Criterion selected successfully",
+        };
+
+        setAssessment((prevAssessment) => {
+          if (formMode === "new") {
+            return handleNewCriterion(
+              criterionForm || {
+                cri: "",
+                label: "",
+                description: "",
+                imperative: "",
+              },
+              principleTag,
+              allPrinciples || [],
+              prevAssessment,
+              imperatives,
+            );
+          } else if (formMode === "select" && selectedRegistryCriterionId) {
+            return handleSelectCriterion(
+              selectedRegistryCriterionId,
+              allCriteria,
+              principleTag,
+              allPrinciples || [],
+              prevAssessment,
+              imperatives,
+            );
+          } else if (formMode === "edit" && criterionForm?.cri) {
+            return handleEditCriterion(
+              criterionId || "",
+              criterionForm,
+              principleTag,
+              allPrinciples || [],
+              prevAssessment,
+            );
+          }
+          return prevAssessment;
+        });
+
+        if (formMode === "new" || formMode === "edit") {
+          setShowErrors(false);
+          setCriterionForm({
+            cri: "",
+            label: "",
+            description: "",
+            imperative: "",
+          });
+          setPrincipleTag("");
+        }
+      });
+
+    toast.promise(promise, {
+      loading:
+        formMode === "new"
+          ? "Creating criterion..."
+          : formMode === "edit"
+            ? "Updating criterion..."
+            : "Selecting criterion...",
+      success: () => `${alert.current.message}`,
+      error: () => `${alert.current.message}`,
+    });
+  };
+
+  return (
+    <>
+      {formMode === "select" ? (
+        <div className="principles-list-container">
+          <div className="principles-list">
+            <div className="principles-list-actions">
+              <button
+                className="select-principle-btn"
+                onClick={handleSubmit}
+                disabled={!selectedRegistryCriterionId}
+              >
+                Select Criterion
+              </button>
+            </div>
+
+            <div className="form-group">
+              <input
+                type="text"
+                className="form-control mb-1"
+                style={{ width: "98%", margin: "0 auto" }}
+                placeholder="Search criteria by ID, label or description..."
+                value={searchTerm}
+                onChange={(e) => setSearchTerm(e.target.value)}
+              />
+            </div>
+
+            {filteredCriteria.length === 0 ? (
+              <p className="no-principles">
+                {searchTerm
+                  ? "No criteria found matching your search"
+                  : allCriteria.length === 0
+                    ? "No criteria available"
+                    : "All available criteria have been added"}
+              </p>
+            ) : (
+              <div className="principles-grid">
+                {filteredCriteria?.map((criterion) => (
+                  <div
+                    key={criterion.cri}
+                    className={`principle-card ${selectedRegistryCriterionId === criterion.cri ? "selected" : ""}`}
+                    onClick={() =>
+                      setSelectedRegistryCriterionId(criterion.cri)
+                    }
+                  >
+                    <div className="principle-card-compact-header">
+                      <FaTags className="principle-card-icon" />
+                      <span className="principle-card-compact-title">
+                        <span className="principle-card-pri">
+                          {criterion.cri}
+                        </span>{" "}
+                        - {criterion.label}
+                      </span>
+                    </div>
+                    <p className="principle-card-description">
+                      {criterion.description}
+                    </p>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+      ) : (
+        <div className="principle-form">
+          <h4>Add New Criterion</h4>
+          <div className="form-group">
+            <label htmlFor="principle-pri">Cri (*):</label>
+            <input
+              id="principle-pri"
+              type="text"
+              className="form-control"
+              value={criterionForm?.cri}
+              onChange={(e) =>
+                handleCriterionInputChange("cri", e.target.value)
+              }
+              placeholder="Enter criterion identifier"
+              disabled={formMode === "edit"}
+            />
+            {showErrors && !criterionForm?.cri && (
+              <span className="text-danger">{t("required")}</span>
+            )}
+          </div>
+
+          <div className="form-group">
+            <label htmlFor="criterion-label">Label (*):</label>
+            <input
+              id="criterion-label"
+              type="text"
+              className="form-control"
+              value={criterionForm?.label}
+              onChange={(e) =>
+                handleCriterionInputChange("label", e.target.value)
+              }
+              placeholder="Enter criterion label"
+            />
+            {showErrors && !criterionForm?.label && (
+              <span className="text-danger">{t("required")}</span>
+            )}
+          </div>
+
+          <div className="form-group">
+            <label htmlFor="criterion-description">Description (*):</label>
+            <textarea
+              id="criterion-description"
+              className="form-control"
+              rows={3}
+              value={criterionForm?.description}
+              onChange={(e) =>
+                handleCriterionInputChange("description", e.target.value)
+              }
+              placeholder="Enter criterion description"
+            />
+            {showErrors && !criterionForm?.description && (
+              <span className="text-danger">{t("required")}</span>
+            )}
+          </div>
+
+          <div className="form-group">
+            <label htmlFor="new-criterion-description">Imperative (*):</label>
+            <Form.Select
+              id="input-motivation-type"
+              aria-describedby="label-motivation-type"
+              placeholder={t("page_criteria.select_imperative")}
+              value={criterionForm?.imperative || ""}
+              onChange={(e) => {
+                if (!criterionForm) return;
+                setCriterionForm({
+                  ...criterionForm,
+                  imperative: e.target.value,
+                });
+              }}
+            >
+              <>
+                <option value="" disabled>
+                  {t("fields.select_imperative")}
+                </option>
+                {imperatives.map((item) => (
+                  <option key={item.id} value={item.id}>
+                    {item.label}
+                  </option>
+                ))}
+              </>
+            </Form.Select>
+            {showErrors && !criterionForm?.imperative && (
+              <span className="text-danger">{t("required")}</span>
+            )}
+          </div>
+
+          <div className="form-group">
+            <label htmlFor="criterion-principle">Tag with Principle:</label>
+            <Form.Select
+              id="criterion-principle"
+              aria-describedby="label-criterion-principle"
+              value={principleTag || ""}
+              onChange={(e) => setPrincipleTag(e.target.value || null)}
+            >
+              <option value="">No principle (Untagged)</option>
+              {allPrinciples?.map((principle) => (
+                <option key={principle.pri} value={principle.id}>
+                  {principle.label}
+                </option>
+              ))}
+            </Form.Select>
+          </div>
+
+          <div className="form-actions">
+            <button className="btn-secondary" onClick={handleCancel}>
+              Cancel
+            </button>
+            <button
+              className="btn-primary"
+              onClick={handleSubmit}
+              disabled={
+                formMode === "edit" &&
+                (!criterionForm?.cri ||
+                  !criterionForm?.label ||
+                  !criterionForm?.description)
+              }
+            >
+              {formMode === "edit" ? "Update Criterion" : "Create Criterion"}
+            </button>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}
+
+export default AssessmentBuilderCriteria;

--- a/src/pages/assessments/AssessmentBuilderPrinciples.tsx
+++ b/src/pages/assessments/AssessmentBuilderPrinciples.tsx
@@ -1,0 +1,415 @@
+import {
+  useCreateMotivationPrinciple,
+  useGetMotivationCriteriaMutation,
+  useUpdateMotivationPrinciplesCriteria,
+} from "@/api";
+import {
+  AlertInfo,
+  AssessmentBuilderState,
+  AssessmentPrinciple,
+  Criterion,
+  FormMode,
+  Principle,
+  PrincipleInput,
+} from "@/types";
+import { useContext, useEffect, useRef, useState } from "react";
+import { FaTags } from "react-icons/fa";
+import { AuthContext } from "@/auth";
+import toast from "react-hot-toast";
+import "./AssessmentBuilder.css";
+import { useTranslation } from "react-i18next";
+import {
+  assessmentPrincipleToForm,
+  formatDataToAssignPrincipleToCriterion,
+  handleEditCriterion,
+} from "./utils";
+import { relMtvPrincpleCriterion } from "@/config";
+
+const getPrincipleFromAssessment = (
+  principleId: string,
+  assessment: AssessmentPrinciple[],
+): PrincipleInput | null => {
+  return assessmentPrincipleToForm(principleId, assessment);
+};
+
+function AssessmentBuilderPrinciples({
+  mtvId,
+  principleId,
+  assessment,
+  setAssessment,
+  allPrinciples,
+  allCriteria,
+  formMode,
+  builderState,
+  setBuilderState,
+  refetchPrinciples,
+}: {
+  mtvId?: string;
+  principleId?: string;
+  assessment: AssessmentPrinciple[];
+  setAssessment: (assessment: AssessmentPrinciple[]) => void;
+  allPrinciples: Principle[];
+  allCriteria: Criterion[];
+  formMode: FormMode;
+  builderState: AssessmentBuilderState;
+  setBuilderState: (builderState: AssessmentBuilderState) => void;
+  refetchPrinciples?: () => void;
+}) {
+  const { keycloak, registered } = useContext(AuthContext)!;
+  const alert = useRef<AlertInfo>({
+    message: "",
+  });
+
+  const [principleForm, setPrincipleForm] = useState<PrincipleInput>(
+    getPrincipleFromAssessment(principleId || "", assessment) || {
+      pri: "",
+      label: "",
+      description: "",
+    },
+  );
+
+  const [showErrors, setShowErrors] = useState(false);
+  const [searchTerm, setSearchTerm] = useState("");
+
+  useEffect(() => {
+    if (formMode !== "edit") {
+      setPrincipleForm({
+        pri: "",
+        label: "",
+        description: "",
+      });
+      setSelectedRegistryPrincipleId(null);
+    }
+  }, [formMode, principleId, assessment, builderState.selectedId]);
+
+  function handleValidate() {
+    setShowErrors(true);
+    return (
+      principleForm?.pri !== "" &&
+      principleForm?.label !== "" &&
+      principleForm?.description !== ""
+    );
+  }
+
+  const filteredPrinciples = allPrinciples.filter((principle) => {
+    if (!searchTerm) return true;
+    const term = searchTerm.toLowerCase();
+    return (
+      principle.pri?.toLowerCase().includes(term) ||
+      principle.label?.toLowerCase().includes(term) ||
+      principle.description?.toLowerCase().includes(term)
+    );
+  });
+
+  const { t } = useTranslation();
+
+  const selectedPrinciplePidGraph = allPrinciples?.find(
+    (principle) => principle?.pri?.toLowerCase() === principleId?.toLowerCase(),
+  )?.id;
+
+  const selectedCriterionPidGraph = allCriteria?.find(
+    (criterion) =>
+      criterion?.cri?.toLowerCase() === builderState?.selectedId?.toLowerCase(),
+  )?.id;
+
+  const [selectedRegistryPrincipleId, setSelectedRegistryPrincipleId] =
+    useState<string | null>(selectedPrinciplePidGraph || null);
+
+  const mutateCreateMotivationPrinciple = useCreateMotivationPrinciple(
+    keycloak?.token || "",
+    mtvId || "",
+    principleForm || { pri: "", label: "", description: "" },
+  );
+
+  const assignPrincipleToCriterion = useUpdateMotivationPrinciplesCriteria(
+    keycloak?.token || "",
+    mtvId || "",
+  );
+
+  const getMotivationCriteriaMutation = useGetMotivationCriteriaMutation(
+    keycloak?.token || "",
+  );
+
+  const createPrincipleToMotivation = () => {
+    const promise = mutateCreateMotivationPrinciple
+      .mutateAsync()
+      .catch((err) => {
+        alert.current = {
+          message: "Error: " + (err.response?.data?.message || err.message),
+        };
+        throw err;
+      })
+      .then(() => {
+        alert.current = {
+          message: "Principle added to motivation successfully",
+        };
+        setShowErrors(false);
+        setPrincipleForm({
+          pri: "",
+          label: "",
+          description: "",
+        });
+        if (refetchPrinciples) {
+          refetchPrinciples();
+        }
+      });
+
+    toast.promise(promise, {
+      loading: "Adding principle to motivation...",
+      success: () => `${alert.current.message}`,
+      error: () => `${alert.current.message}`,
+    });
+  };
+
+  const handleSubmit = async () => {
+    if (!registered) {
+      alert.current = {
+        message: "You must be registered to perform this action.",
+      };
+      toast.error(alert.current.message);
+      return;
+    }
+
+    if ((formMode === "new" || formMode === "edit") && !handleValidate()) {
+      return;
+    }
+
+    if (formMode === "new") {
+      if (
+        principleForm?.pri &&
+        principleForm.label &&
+        principleForm.description
+      ) {
+        createPrincipleToMotivation();
+      }
+    } else if (formMode === "select") {
+      const allMotivationCriteriaContent =
+        await getMotivationCriteriaMutation.mutateAsync({
+          mtvId: mtvId || "",
+        });
+
+      const allMotivationCriteria = allMotivationCriteriaContent?.content || [];
+
+      const formattedPriCri = formatDataToAssignPrincipleToCriterion({
+        principleId: selectedRegistryPrincipleId || "",
+        criterionId: selectedCriterionPidGraph || "",
+        allMotivationCriteria: allMotivationCriteria,
+      }) || [
+        {
+          principleId: "",
+          criterionId: "",
+          relation: relMtvPrincpleCriterion,
+          annotation_text: "",
+          annotation_url: "",
+        },
+      ];
+
+      const promise = assignPrincipleToCriterion
+        .mutateAsync(formattedPriCri)
+        .catch((err) => {
+          alert.current = {
+            message: t("page_motivations.toast_manage_cri_fail"),
+          };
+          throw err;
+        })
+        .then(() => {
+          alert.current = {
+            message: t("page_motivations.toast_manage_cri_success"),
+          };
+
+          const selectedCriterion = allCriteria?.find(
+            (criterion) =>
+              criterion?.cri?.toLowerCase() ===
+              builderState?.selectedId?.toLowerCase(),
+          );
+
+          const updatedAssessment = handleEditCriterion(
+            builderState?.selectedId || "",
+            {
+              cri: selectedCriterion?.cri || "",
+              label: selectedCriterion?.label || "",
+              description: selectedCriterion?.description || "",
+              imperative: String(selectedCriterion?.imperative || ""),
+            },
+            selectedRegistryPrincipleId,
+            allPrinciples,
+            assessment,
+          );
+
+          if (updatedAssessment.length > 0) {
+            setAssessment(updatedAssessment);
+          }
+        });
+
+      toast.promise(promise, {
+        loading: t("page_motivations.toast_manage_cri_progress"),
+        success: () => `${alert.current.message}`,
+        error: () => `${alert.current.message}`,
+      });
+    }
+    // else if (formMode === "edit") {
+    //   if (
+    //     principleForm?.pri &&
+    //     principleForm?.label &&
+    //     principleForm?.description
+    //   ) {
+    //   }
+    // }
+  };
+
+  const handleCancel = () => {
+    setPrincipleForm({ pri: "", label: "", description: "" });
+    setBuilderState({
+      formMode: "none",
+      entityMode: "none",
+      selectedId: "",
+      selectedPrincipleIndex: -1,
+      selectedCriterionIndex: -1,
+    });
+  };
+
+  const handlePrincipleInputChange = (
+    field: keyof PrincipleInput,
+    value: string,
+  ) => {
+    if (!principleForm) return;
+    setPrincipleForm((principleForm) => ({
+      ...principleForm,
+      [field]: value,
+    }));
+  };
+
+  return (
+    <>
+      {formMode === "select" ? (
+        <div className="principles-list-container">
+          <div className="principles-list">
+            <div className="principles-list-actions">
+              <button
+                className="select-principle-btn"
+                onClick={handleSubmit}
+                disabled={
+                  !selectedRegistryPrincipleId ||
+                  selectedPrinciplePidGraph === selectedRegistryPrincipleId
+                }
+              >
+                Select Principle
+              </button>
+            </div>
+
+            <div className="form-group">
+              <input
+                type="text"
+                className="form-control mb-1"
+                style={{ width: "98%", margin: "0 auto" }}
+                placeholder="Search principles by ID, label or description..."
+                value={searchTerm}
+                onChange={(e) => setSearchTerm(e.target.value)}
+              />
+            </div>
+
+            {filteredPrinciples.length === 0 ? (
+              <p className="no-principles">
+                {searchTerm
+                  ? "No principles found matching your search"
+                  : allPrinciples.length === 0
+                    ? "No principles available"
+                    : "All available principles have been added"}
+              </p>
+            ) : (
+              <div className="principles-grid">
+                {filteredPrinciples?.map((principle) => (
+                  <div
+                    key={principle.id}
+                    className={`principle-card ${selectedRegistryPrincipleId === principle.id ? "selected" : ""}`}
+                    onClick={() => setSelectedRegistryPrincipleId(principle.id)}
+                  >
+                    <div className="principle-card-compact-header">
+                      <FaTags className="principle-card-icon" />
+                      <span className="principle-card-compact-title">
+                        <span className="principle-card-pri">
+                          {principle.pri}
+                        </span>{" "}
+                        - {principle.label}
+                      </span>
+                    </div>
+                    <p className="principle-card-description">
+                      {principle.description}
+                    </p>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+      ) : (
+        formMode === "new" && (
+          <div className="principle-form">
+            <h4>Add New Principle</h4>
+            <div className="form-group">
+              <label htmlFor="principle-pri">Pri (*):</label>
+              <input
+                id="principle-pri"
+                type="text"
+                className="form-control"
+                value={principleForm?.pri}
+                onChange={(e) =>
+                  handlePrincipleInputChange("pri", e.target.value)
+                }
+                placeholder="Enter principle identifier"
+              />
+              {showErrors && !principleForm?.pri && (
+                <span className="text-danger">{t("required")}</span>
+              )}
+            </div>
+
+            <div className="form-group">
+              <label htmlFor="principle-label">Label (*):</label>
+              <input
+                id="principle-label"
+                type="text"
+                className="form-control"
+                value={principleForm?.label}
+                onChange={(e) =>
+                  handlePrincipleInputChange("label", e.target.value)
+                }
+                placeholder="Enter principle label"
+              />
+              {showErrors && !principleForm?.label && (
+                <span className="text-danger">{t("required")}</span>
+              )}
+            </div>
+
+            <div className="form-group">
+              <label htmlFor="principle-description">Description (*):</label>
+              <textarea
+                id="principle-description"
+                className="form-control"
+                rows={3}
+                value={principleForm?.description}
+                onChange={(e) =>
+                  handlePrincipleInputChange("description", e.target.value)
+                }
+                placeholder="Enter principle description"
+              />
+              {showErrors && !principleForm?.description && (
+                <span className="text-danger">{t("required")}</span>
+              )}
+            </div>
+
+            <div className="form-actions">
+              <button className="btn-secondary" onClick={handleCancel}>
+                Cancel
+              </button>
+              <button className="btn-primary" onClick={handleSubmit}>
+                Create Principle
+              </button>
+            </div>
+          </div>
+        )
+      )}
+    </>
+  );
+}
+
+export default AssessmentBuilderPrinciples;

--- a/src/pages/assessments/AssessmentBuilderStructure.tsx
+++ b/src/pages/assessments/AssessmentBuilderStructure.tsx
@@ -1,0 +1,176 @@
+import { useState } from "react";
+import { AssessmentBuilderState, AssessmentPrinciple } from "@/types";
+import {
+  FaFileAlt,
+  FaFolder,
+  FaChevronDown,
+  FaChevronUp,
+} from "react-icons/fa";
+
+function AssessmentBuilderStructure({
+  setBuilderState,
+  assessment,
+  selectedId,
+}: {
+  setBuilderState: (state: AssessmentBuilderState) => void;
+  assessment: AssessmentPrinciple[];
+  selectedId?: string;
+}) {
+  const [collapsedPrinciples, setCollapsedPrinciples] = useState<Set<string>>(
+    new Set(),
+  );
+
+  const togglePrinciple = (principleId: string) => {
+    const newCollapsed = new Set(collapsedPrinciples);
+    if (newCollapsed.has(principleId)) {
+      newCollapsed.delete(principleId);
+    } else {
+      newCollapsed.add(principleId);
+    }
+    setCollapsedPrinciples(newCollapsed);
+  };
+
+  return (
+    <div className="structure-tree ">
+      {assessment?.map((principle: AssessmentPrinciple, principleIndex) => {
+        if (!principle.id || principle.id === "untagged") return null;
+
+        return (
+          <div key={principleIndex} className="principle-group">
+            <div
+              className="tree-item principle-item cat-cursor-pointer"
+              onClick={() => togglePrinciple(principle.id)}
+            >
+              <span className="tree-icon">
+                <FaFolder />
+              </span>
+              <span className="principle-display">
+                {principle.id} - {principle.name}
+              </span>
+              <span style={{ marginLeft: "auto", marginRight: "8px" }}>
+                {collapsedPrinciples.has(principle.id) ? (
+                  <FaChevronUp />
+                ) : (
+                  <FaChevronDown />
+                )}
+              </span>
+            </div>
+            <div
+              className={
+                collapsedPrinciples.has(principle.id) ? "no-display" : ""
+              }
+            >
+              {principle?.criteria?.map((criterion, criterionIndex: number) => {
+                return (
+                  <div
+                    key={criterionIndex}
+                    className={`tree-item principle-item clickable nested ${
+                      selectedId === criterion.id ? "selected" : ""
+                    }`}
+                    onClick={() =>
+                      setBuilderState({
+                        entityMode: "criterion",
+                        formMode: "edit",
+                        selectedId: criterion.id,
+                        selectedPrincipleIndex: principleIndex,
+                        selectedCriterionIndex: criterionIndex,
+                      })
+                    }
+                  >
+                    <span className="tree-icon">
+                      <FaFileAlt />
+                    </span>
+                    <span className="principle-display">
+                      {criterion.id} - {criterion.name}
+                    </span>
+                  </div>
+                );
+              })}
+            </div>
+            {principleIndex < assessment.length - 1 && (
+              <div className="principle-section-separator" />
+            )}
+          </div>
+        );
+      })}
+
+      {/* Untagged Criteria */}
+      {(() => {
+        const untaggedCriteria = assessment
+          ?.filter((principle) => {
+            if (principle.id === "untagged") {
+              return principle;
+            }
+          })
+          ?.flatMap((principle) => {
+            return principle?.criteria?.filter((criterion) => {
+              return !criterion.principle_id ? criterion : null;
+            });
+          });
+
+        if (untaggedCriteria?.length > 0) {
+          return (
+            <div className="principle-group">
+              <div
+                className="tree-item principle-item untagged cat-cursor-pointer"
+                onClick={() => togglePrinciple("untagged")}
+              >
+                <span className="tree-icon">
+                  <FaFolder />
+                </span>
+                <span className="principle-display">Untagged Criteria</span>
+                <span style={{ marginLeft: "auto", marginRight: "8px" }}>
+                  {collapsedPrinciples.has("untagged") ? (
+                    <FaChevronUp />
+                  ) : (
+                    <FaChevronDown />
+                  )}
+                </span>
+              </div>
+
+              <div
+                className={
+                  collapsedPrinciples.has("untagged") ? "no-display" : ""
+                }
+              >
+                {untaggedCriteria.map(
+                  (criterion, untaggedCriteriaIndex: number) => {
+                    return (
+                      <div
+                        key={untaggedCriteriaIndex}
+                        className={`tree-item principle-item clickable nested ${
+                          selectedId === criterion.id ? "selected" : ""
+                        }`}
+                        onClick={() =>
+                          setBuilderState({
+                            entityMode: "criterion",
+                            formMode: "edit",
+                            selectedId: criterion.id,
+                            selectedPrincipleIndex: assessment.findIndex(
+                              (p) => p.id === "untagged",
+                            ),
+                            selectedCriterionIndex: untaggedCriteriaIndex,
+                          })
+                        }
+                      >
+                        <span className="tree-icon">
+                          <FaFileAlt />
+                        </span>
+                        <span className="principle-display">
+                          {criterion.id} - {criterion.name}
+                        </span>
+                      </div>
+                    );
+                  },
+                )}
+              </div>
+            </div>
+          );
+        }
+        return null;
+      })()}
+    </div>
+  );
+}
+
+export default AssessmentBuilderStructure;

--- a/src/pages/assessments/utils/assessmentBuilderUtils.ts
+++ b/src/pages/assessments/utils/assessmentBuilderUtils.ts
@@ -1,0 +1,610 @@
+import { relMtvPrincpleCriterion } from "@/config";
+import {
+  AssessmentPrinciple,
+  AssessmentCriterion,
+  CriterionInput,
+  PrincipleInput,
+  Criterion,
+  Metric,
+  FormMode,
+  Imperative,
+} from "@/types";
+
+// Finds a principle in the assessment by its ID
+export const findPrincipleInAssessment = (
+  principleId: string,
+  assessment: AssessmentPrinciple[],
+): AssessmentPrinciple | undefined => {
+  return assessment.find((p) => p.id === principleId);
+};
+
+// Finds a criterion within all principles in the assessment
+export const findCriterionInAssessment = (
+  criterionId: string,
+  assessment: AssessmentPrinciple[],
+): { criterion: AssessmentCriterion; principleId: string } | null => {
+  for (const principle of assessment) {
+    const criterion = principle.criteria?.find((c) => c.id === criterionId);
+    if (criterion) {
+      return { criterion, principleId: principle.id };
+    }
+  }
+  return null;
+};
+
+// Creates a new principle structure
+export const createPrincipleStructure = (
+  id: string,
+  name: string,
+  description: string,
+): AssessmentPrinciple => ({
+  id,
+  name,
+  description,
+  criteria: [],
+});
+
+export const createCriterionStructure = (
+  id: string,
+  name: string,
+  description: string,
+  imperative: string,
+) => ({
+  id,
+  name,
+  description,
+  imperative,
+  metric: {
+    type: "",
+    label_algorithm_type: "",
+  } as Metric,
+});
+
+// Creates an "Untagged" principle for criteria without a selected principle
+export const createUntaggedPrinciple = (): AssessmentPrinciple => ({
+  id: "untagged",
+  name: "",
+  description: "",
+  criteria: [],
+});
+
+// Gets principle information from allPrinciples by pri
+export const getPrincipleInfoById = (
+  id: string | null,
+  allPrinciples: (PrincipleInput & { id: string })[],
+): PrincipleInput | undefined => {
+  if (!id) return undefined;
+  return allPrinciples.find((p) => p?.id === id);
+};
+
+// Gets criterion information from allCriteria by cri
+export const getCriterionInfoByCri = (
+  cri: string,
+  allCriteria: Criterion[],
+): Criterion | undefined => {
+  return allCriteria.find((c) => c.cri === cri);
+};
+
+// Gets the principle ID that contains a specific criterion
+export const getPrincipleIdForCriterion = (
+  criterionId: string,
+  assessment: AssessmentPrinciple[],
+): string | null => {
+  const criterionLocation = findCriterionInAssessment(criterionId, assessment);
+  return criterionLocation ? criterionLocation.principleId : null;
+};
+
+// Handles selecting an existing criterion from registry
+export const handleSelectCriterion = (
+  selectedCriterionId: string,
+  allCriteria: Criterion[],
+  principleTag: string | null,
+  allPrinciples: (PrincipleInput & { id: string })[],
+  assessment: AssessmentPrinciple[],
+  imperatives: Imperative[],
+): AssessmentPrinciple[] => {
+  const selectedCriterion = getCriterionInfoByCri(
+    selectedCriterionId,
+    allCriteria,
+  );
+
+  if (!selectedCriterion) {
+    return assessment; // No criterion found, return unchanged
+  }
+
+  const updatedAssessment = [...assessment];
+
+  // Determine target principle
+  const targetPrincipleId = principleTag;
+  let targetPrinciple = findPrincipleInAssessment(
+    targetPrincipleId || "",
+    updatedAssessment,
+  );
+
+  if (!targetPrinciple) {
+    // Create new principle
+    if (principleTag && allPrinciples.length > 0) {
+      const principleInfo = getPrincipleInfoById(principleTag, allPrinciples);
+      targetPrinciple = createPrincipleStructure(
+        principleTag,
+        principleInfo?.label || principleTag,
+        principleInfo?.description || "",
+      );
+      updatedAssessment.push(targetPrinciple);
+    } else {
+      // find or create "Untagged" principle
+      targetPrinciple = findPrincipleInAssessment(
+        "untagged",
+        updatedAssessment,
+      );
+      if (targetPrinciple == null) {
+        targetPrinciple = createUntaggedPrinciple();
+        updatedAssessment.push(targetPrinciple);
+      }
+    }
+  }
+
+  const imperativeLabel =
+    imperatives?.find(
+      (imperative) => imperative.id === String(selectedCriterion.imperative),
+    )?.label || String(selectedCriterion.imperative);
+
+  // Create and add the criterion
+  const newCriterion = createCriterionStructure(
+    selectedCriterion.cri,
+    selectedCriterion.label,
+    selectedCriterion.description || "",
+    imperativeLabel,
+  );
+
+  if (targetPrinciple) {
+    targetPrinciple.criteria = [
+      ...(targetPrinciple.criteria || []),
+      newCriterion,
+    ];
+  }
+
+  return updatedAssessment;
+};
+
+// Handles creating a new criterion
+export const handleNewCriterion = (
+  criterionForm: CriterionInput,
+  principleTag: string | null,
+  allPrinciples: (PrincipleInput & { id: string })[],
+  assessment: AssessmentPrinciple[],
+  imperatives: Imperative[],
+): AssessmentPrinciple[] => {
+  if (!criterionForm.cri) {
+    return assessment; // Invalid state, return unchanged
+  }
+
+  const updatedAssessment = [...assessment];
+  const principleInfo = getPrincipleInfoById(principleTag, allPrinciples);
+  let targetPrinciple = findPrincipleInAssessment(
+    principleInfo?.pri || "",
+    updatedAssessment,
+  );
+
+  if (!targetPrinciple) {
+    // Create new principle
+    if (principleTag && allPrinciples.length > 0) {
+      if (principleInfo) {
+        targetPrinciple = {
+          id: principleInfo.pri,
+          name: principleInfo.label,
+          description: principleInfo.description,
+          criteria: [],
+        };
+      } else {
+        // Fallback if principle not found in allPrinciples
+        targetPrinciple = createPrincipleStructure(
+          principleTag,
+          principleTag,
+          "",
+        );
+      }
+      updatedAssessment.push(targetPrinciple);
+    } else {
+      // find or create "Untagged" principle
+      targetPrinciple = findPrincipleInAssessment(
+        "untagged",
+        updatedAssessment,
+      );
+      if (targetPrinciple == null) {
+        targetPrinciple = createUntaggedPrinciple();
+        updatedAssessment.push(targetPrinciple);
+      }
+    }
+  }
+
+  criterionForm.imperative =
+    imperatives?.find(
+      (imperative) => imperative.id === criterionForm.imperative,
+    )?.label || "";
+
+  // Create and add the criterion
+  const newCriterion = createCriterionStructure(
+    criterionForm.cri,
+    criterionForm.label || "",
+    criterionForm.description || "",
+    criterionForm.imperative || "",
+  );
+
+  if (targetPrinciple) {
+    targetPrinciple.criteria = [
+      ...(targetPrinciple.criteria || []),
+      newCriterion,
+    ];
+  }
+
+  return updatedAssessment;
+};
+
+export const findPidGraphOfPrinciple = (
+  criterionId: string,
+  allPrinciples: (PrincipleInput & { id: string })[],
+  assessment: AssessmentPrinciple[],
+): string | null => {
+  // First find which principle contains this criterion in the assessment
+  for (const principle of assessment) {
+    const criterion = principle.criteria?.find((c) => c.id === criterionId);
+    if (criterion) {
+      // Now find the corresponding pid_graph from allPrinciples
+      const principleInfo = allPrinciples.find((p) => p.pri === principle.id);
+      return principleInfo?.id || null;
+    }
+  }
+  return null;
+};
+
+export const findCriterionWithPrinciple = (
+  criterionId: string,
+  assessment: AssessmentPrinciple[],
+): {
+  criterion: AssessmentCriterion;
+  principle: AssessmentPrinciple;
+  criterionIndex: number;
+  principleIndex: number;
+} | null => {
+  for (
+    let principleIndex = 0;
+    principleIndex < assessment.length;
+    principleIndex++
+  ) {
+    const principle = assessment[principleIndex];
+    const criterionIndex =
+      principle.criteria?.findIndex((c) => c.id === criterionId) ?? -1;
+    if (criterionIndex !== -1) {
+      const criterion = principle.criteria![criterionIndex];
+      return { criterion, principle, criterionIndex, principleIndex };
+    }
+  }
+  return null;
+};
+
+export const handleEditCriterion = (
+  criterionCri: string,
+  updatedCriterion: CriterionInput,
+  principleTag: string | null,
+  allPrinciples: (PrincipleInput & { id: string })[],
+  assessment: AssessmentPrinciple[],
+): AssessmentPrinciple[] => {
+  const updatedAssessment = [...assessment];
+
+  // Find the existing principle and criterion that belongs to in the assessment
+  const criterionInfo = findCriterionWithPrinciple(
+    criterionCri,
+    updatedAssessment,
+  );
+
+  if (!criterionInfo) {
+    return assessment; // Criterion not found, return unchanged
+  }
+
+  const { criterion, criterionIndex, principleIndex } = criterionInfo;
+
+  // Check if this criterion has the same principle as before
+  const actualPidGraphOfPrinciple = findPidGraphOfPrinciple(
+    criterionCri,
+    allPrinciples,
+    assessment,
+  );
+
+  // Check if the principle is the same with the previous one
+  if (actualPidGraphOfPrinciple === principleTag) {
+    updatedAssessment[principleIndex].criteria![criterionIndex] = {
+      ...criterion,
+      id: updatedCriterion.cri,
+      name: updatedCriterion.label || "",
+      description: updatedCriterion.description || "",
+      imperative: updatedCriterion.imperative || "",
+    };
+  } else {
+    updatedAssessment[principleIndex].criteria!.splice(criterionIndex, 1);
+
+    const newCriterion = {
+      id: updatedCriterion.cri,
+      name: updatedCriterion.label || "",
+      description: updatedCriterion.description || "",
+      imperative: updatedCriterion.imperative || "",
+      metric: criterion.metric, // Preserve existing metric
+    };
+
+    // Determine the target principle
+    let targetPrinciple: AssessmentPrinciple | undefined;
+
+    if (!principleTag || principleTag === "untagged") {
+      targetPrinciple = findPrincipleInAssessment(
+        "untagged",
+        updatedAssessment,
+      );
+      if (!targetPrinciple) {
+        targetPrinciple = {
+          id: "untagged",
+          name: "Untagged Criteria",
+          description: "Criteria not assigned to any principle",
+          criteria: [],
+        };
+        updatedAssessment.push(targetPrinciple);
+      }
+    } else {
+      const newPrincipleInfo = allPrinciples.find((p) => p.id === principleTag);
+
+      if (newPrincipleInfo) {
+        // Check if principle already exists in assessment
+        targetPrinciple = findPrincipleInAssessment(
+          newPrincipleInfo.pri,
+          updatedAssessment,
+        );
+
+        if (!targetPrinciple) {
+          targetPrinciple = {
+            id: newPrincipleInfo.pri,
+            name: newPrincipleInfo.label,
+            description: newPrincipleInfo.description,
+            criteria: [],
+          };
+          updatedAssessment.push(targetPrinciple);
+        }
+      }
+    }
+
+    if (targetPrinciple) {
+      targetPrinciple.criteria = [
+        ...(targetPrinciple.criteria || []),
+        newCriterion,
+      ];
+    }
+
+    // Clean up empty principles (except untagged)
+    const filteredAssessment = updatedAssessment.filter(
+      (p) => p.id === "untagged" || (p.criteria && p.criteria.length > 0),
+    );
+
+    return filteredAssessment;
+  }
+
+  return updatedAssessment;
+};
+
+// Handles selecting an existing principle from registry
+export const handleSelectPrinciple = (
+  selectedPrincipleId: string,
+  allPrinciples: (PrincipleInput & { id: string })[],
+  assessment: AssessmentPrinciple[],
+): AssessmentPrinciple[] => {
+  const selectedPrinciple = getPrincipleInfoById(
+    selectedPrincipleId,
+    allPrinciples,
+  );
+  if (!selectedPrinciple) {
+    return assessment; // No principle found, return unchanged
+  }
+
+  const updatedAssessment = [...assessment];
+
+  // Check if principle already exists
+  const existingPrinciple = findPrincipleInAssessment(
+    selectedPrinciple.pri,
+    updatedAssessment,
+  );
+  if (existingPrinciple) {
+    return assessment; // Principle already exists, return unchanged
+  }
+
+  // Create and add the principle
+  const newPrinciple = createPrincipleStructure(
+    selectedPrinciple.pri,
+    selectedPrinciple.label,
+    selectedPrinciple.description,
+  );
+
+  updatedAssessment.push(newPrinciple);
+  return updatedAssessment;
+};
+
+export const handleNewPrinciple = (
+  principleForm: PrincipleInput,
+  assessment: AssessmentPrinciple[],
+): AssessmentPrinciple[] => {
+  if (!principleForm.pri || !principleForm.label) {
+    return assessment; // Invalid state, return unchanged
+  }
+
+  const updatedAssessment = [...assessment];
+
+  // Check if principle already exists
+  const existingPrinciple = findPrincipleInAssessment(
+    principleForm.pri,
+    updatedAssessment,
+  );
+  if (existingPrinciple) {
+    return assessment; // Principle already exists, return unchanged
+  }
+
+  // Create and add the principle
+  const newPrinciple = createPrincipleStructure(
+    principleForm.pri,
+    principleForm.label,
+    principleForm.description,
+  );
+
+  updatedAssessment.push(newPrinciple);
+  return updatedAssessment;
+};
+
+export const handleEditPrinciple = (
+  principleId: string,
+  updatedPrinciple: PrincipleInput,
+  assessment: AssessmentPrinciple[],
+): AssessmentPrinciple[] => {
+  const updatedAssessment = [...assessment];
+
+  const targetPrinciple = findPrincipleInAssessment(
+    principleId,
+    updatedAssessment,
+  );
+  if (!targetPrinciple) {
+    return assessment; // Principle not found, return unchanged
+  }
+
+  // Update the principle
+  targetPrinciple.id = updatedPrinciple.pri;
+  targetPrinciple.name = updatedPrinciple.label;
+  targetPrinciple.description = updatedPrinciple.description;
+
+  return updatedAssessment;
+};
+
+// Converts AssessmentPrinciple to PrincipleInput for form editing
+export const assessmentPrincipleToForm = (
+  principleId: string,
+  assessment: AssessmentPrinciple[],
+): PrincipleInput | null => {
+  const principle = findPrincipleInAssessment(principleId, assessment);
+  if (!principle) {
+    return { pri: "", label: "", description: "" };
+  }
+
+  return {
+    pri: principle.id,
+    label: principle.name,
+    description: principle.description,
+  };
+};
+
+// Converts AssessmentCriterion to CriterionInput for form editing
+export const assessmentCriterionToForm = (
+  criterionId: string,
+  assessment: AssessmentPrinciple[],
+  formMode: FormMode,
+  setPrincipleTag?: (tag: string) => void,
+): CriterionInput | null => {
+  const criterionLocation = findCriterionInAssessment(criterionId, assessment);
+  if (!criterionLocation || formMode !== "edit") {
+    setPrincipleTag?.("");
+    return { cri: "", label: "", description: "", imperative: "" };
+  }
+
+  const { criterion } = criterionLocation;
+  return {
+    cri: criterion.id,
+    label: criterion.name,
+    description: criterion.description || "",
+    imperative: criterion.imperative.toString(),
+  };
+};
+
+// Checks if principle form has changes compared to original
+export const hasPrincipleFormChanged = (
+  formData: PrincipleInput | null,
+  originalPrinciple: PrincipleInput | undefined,
+): boolean => {
+  if (!formData || !originalPrinciple) return false;
+
+  return (
+    formData.pri !== originalPrinciple.pri ||
+    formData.label !== originalPrinciple.label ||
+    formData.description !== originalPrinciple.description
+  );
+};
+
+// Checks if criterion form has changes compared to original
+export const hasCriterionFormChanged = (
+  formData: CriterionInput | null,
+  originalCriterion: Criterion | undefined,
+): boolean => {
+  if (!formData || !originalCriterion) return false;
+
+  return (
+    formData.cri !== originalCriterion.cri ||
+    formData.label !== originalCriterion.label ||
+    formData.description !== originalCriterion.description ||
+    formData.imperative !== String(originalCriterion.imperative)
+  );
+};
+
+interface MotivationCriterion {
+  id: string;
+  principles?: Array<{ id: string }>;
+}
+
+interface PrincipleCriterionRelation {
+  criterion_id: string;
+  principle_id: string;
+  annotation_url: string;
+  annotation_text: string;
+  relation: string;
+}
+
+export const formatDataToAssignPrincipleToCriterion = ({
+  allMotivationCriteria,
+  criterionId,
+  principleId,
+}: {
+  allMotivationCriteria: MotivationCriterion[] | undefined;
+  criterionId: string;
+  principleId?: string;
+}): PrincipleCriterionRelation[] => {
+  let priCri =
+    allMotivationCriteria?.flatMap(
+      (cri) =>
+        cri?.principles?.map((pri) => ({
+          criterion_id: cri.id,
+          principle_id: pri.id,
+          annotation_url: "",
+          annotation_text: "",
+          relation: relMtvPrincpleCriterion,
+        })) || [],
+    ) || [];
+
+  const existingCriterionInPriCri = priCri.find(
+    (item) => item.criterion_id === criterionId,
+  );
+
+  if (existingCriterionInPriCri) {
+    priCri = priCri.map((item) => {
+      if (item.criterion_id === criterionId) {
+        return {
+          ...item,
+          principle_id: principleId || "",
+          annotation_url: "",
+          annotation_text: "",
+          relation: relMtvPrincpleCriterion,
+        };
+      }
+      return item;
+    });
+  } else {
+    priCri.push({
+      criterion_id: criterionId || "",
+      principle_id: principleId || "",
+      annotation_url: "",
+      annotation_text: "",
+      relation: relMtvPrincpleCriterion,
+    });
+  }
+
+  return priCri;
+};

--- a/src/pages/assessments/utils/index.ts
+++ b/src/pages/assessments/utils/index.ts
@@ -1,0 +1,1 @@
+export * from "./assessmentBuilderUtils";

--- a/src/pages/metrics/components/MetricEditModal.tsx
+++ b/src/pages/metrics/components/MetricEditModal.tsx
@@ -73,6 +73,7 @@ export function MetricEditModal(props: MetricEditModalProps) {
     size: 50,
     token: keycloak?.token || "",
     isRegistered: registered,
+    enabled: true,
   });
 
   const {
@@ -83,6 +84,7 @@ export function MetricEditModal(props: MetricEditModalProps) {
     size: 50,
     token: keycloak?.token || "",
     isRegistered: registered,
+    enabled: true,
   });
 
   const {
@@ -93,6 +95,7 @@ export function MetricEditModal(props: MetricEditModalProps) {
     size: 50,
     token: keycloak?.token || "",
     isRegistered: registered,
+    enabled: true,
   });
 
   useEffect(() => {

--- a/src/pages/motivations/MotivationCriteriaPrinciples.tsx
+++ b/src/pages/motivations/MotivationCriteriaPrinciples.tsx
@@ -107,7 +107,7 @@ export default function MotivationCriteriaPrinciples() {
     fetchNextPage: selCriFetchNextPage,
     hasNextPage: selCriHasNextPage,
   } = useGetMotivationCriteria(params.mtvId || "", {
-    size: 5,
+    size: 100,
     token: keycloak?.token || "",
     isRegistered: registered,
   });

--- a/src/pages/motivations/MotivationDetails.tsx
+++ b/src/pages/motivations/MotivationDetails.tsx
@@ -615,12 +615,18 @@ export default function MotivationDetails() {
                                     placement="top"
                                     overlay={tooltipEditAssessment}
                                   >
-                                    <Link
-                                      className="btn btn-light btn-sm m-1"
-                                      to={`/admin/motivations/${params.mtvId}/templates/actors/${item.id}/assessment-builder`}
-                                    >
-                                      <FaEdit />
-                                    </Link>
+                                    {item.published ? (
+                                      <span className="btn btn-light btn-sm m-1 disabled">
+                                        <FaEdit />
+                                      </span>
+                                    ) : (
+                                      <Link
+                                        className="btn btn-light btn-sm m-1"
+                                        to={`/admin/motivations/${params.mtvId}/templates/actors/${item.id}/assessment-builder`}
+                                      >
+                                        <FaEdit />
+                                      </Link>
+                                    )}
                                   </OverlayTrigger>
                                   <OverlayTrigger
                                     placement="top"

--- a/src/pages/motivations/components/MotivationMetrics.tsx
+++ b/src/pages/motivations/components/MotivationMetrics.tsx
@@ -78,8 +78,6 @@ export const MotivationMetrics = ({
     message: "",
   });
 
-  console.log("MotivationMetrics rendered with mtvId:", mtvId);
-
   const {
     data: mtrData,
     fetchNextPage: mtrFetchNextPage,

--- a/src/types/assessment.ts
+++ b/src/types/assessment.ts
@@ -95,15 +95,18 @@ export interface AssessmentPrinciple {
   name: string;
   criteria: AssessmentCriterion[];
   description: string;
+  imperative?: string;
+  principle_id?: string;
 }
 
 /** Each principle contains a list of criteria */
 export interface AssessmentCriterion {
   id: string;
   name: string;
-  imperative: AssessmentCriterionImperative;
+  imperative: AssessmentCriterionImperative | string;
   metric: Metric;
   description?: string;
+  principle_id?: string;
 }
 
 /** Each criterion can be either mandatory (must) or optional (should) */
@@ -258,7 +261,7 @@ export interface TestAutoResponse {
 export interface GroupTestRef {
   criterionId: string;
   criterionName: string;
-  criterionImperative: AssessmentCriterionImperative;
+  criterionImperative: AssessmentCriterionImperative | string;
   testId: string;
   testName: string;
   result: number | null;

--- a/src/types/criterion.ts
+++ b/src/types/criterion.ts
@@ -53,7 +53,7 @@ export interface CriterionInput {
   label: string;
   description: string;
   imperative: string;
-  type_criterion_id: string;
+  type_criterion_id?: string;
 }
 
 export interface CriterionMetric {
@@ -64,6 +64,17 @@ export interface CriterionMetric {
   label_algorithm_type: string;
   label_type_metric: string;
   tests: AssessmentTest[];
+}
+
+export interface CriterionAssessmentTemplate {
+  id: string;
+  cri?: string;
+  pri?: string;
+  description: string;
+  name: string;
+  used_by_motivations?: MotivationReference[];
+  principle_id?: string;
+  criteria?: CriterionAssessmentTemplate[];
 }
 
 export type CriterionMetricResponse = {

--- a/src/types/motivation.ts
+++ b/src/types/motivation.ts
@@ -162,3 +162,28 @@ export interface PrincipleAssignmentInput {
   annotation_text?: string;
   annotation_url?: string;
 }
+
+export interface CriterionAssignmentInput {
+  criterion_id: string;
+  relation: string;
+  annotation_text?: string;
+  annotation_url?: string;
+}
+
+export interface CriterionBuilderInput {
+  cri: string;
+  label: string;
+  description: string;
+  imperative?: string;
+  principleTag?: string;
+}
+
+export type FormMode = "none" | "select" | "new" | "edit";
+export type EntityMode = "none" | "principle" | "criterion";
+export interface AssessmentBuilderState {
+  formMode: FormMode;
+  entityMode: EntityMode;
+  selectedId?: string;
+  selectedPrincipleIndex?: number;
+  selectedCriterionIndex?: number;
+}


### PR DESCRIPTION
This PR refactors the Assessment Builder to use a criteria-first approach with API integration for Criteria-Principles-Motivation. Also, includes state management for assessment, search functionality, accordion navigation, and implemented publish/unpublish workflow.

- Integrated API requests to connect principles with criteria and motivation
- Implemented state management with proper assessment structure updates for select, create, and edit operations for both Criteria and Principles
- Pre-populated assessment data and initialized state with proper principles-criteria structure
- Split AssessmentBuilder into focused components for Structure, Preview, and Builder columns
- Added functionality for publish/unpublish the assessment type in the Assessment Builder page
- Added client-side search functionality to both Principles and Criteria components
- Added toast notifications for all API operations with error states
- Implemented filtering, in criteria selection to exclude already-added criteria
- Added generic UI improvements including three-column layout with proper spacing, responsive design breakpoints, improved gaps and column headers.
