### PR TITLE
[CAT-929] - Fix metric creation and assignment within motivation

### DIFF
--- a/src/api/services/registry.ts
+++ b/src/api/services/registry.ts
@@ -361,6 +361,29 @@ export function useCreateTestVersion({
   });
 }
 
+export const useGetAllMetrics = ({ token, isRegistered, size }: ApiOptions) =>
+  useInfiniteQuery({
+    queryKey: ["all-metrics"],
+    queryFn: async ({ pageParam = 1 }) => {
+      const response = await APIClient(token).get<RegistryMetricResponse>(
+        `/v1/registry/metrics?size=${size}&page=${pageParam}`,
+      );
+      return response.data;
+    },
+    getNextPageParam: (lastPage) => {
+      if (lastPage.number_of_page < lastPage.total_pages) {
+        return lastPage.number_of_page + 1;
+      } else {
+        return undefined;
+      }
+    },
+    onError: (error: AxiosError) => {
+      return handleBackendError(error);
+    },
+    retry: false,
+    enabled: isRegistered,
+  });
+
 export const useGetRegistryMetrics = ({
   size,
   page,

--- a/src/pages/motivations/components/MotivationMetricAssignModal.tsx
+++ b/src/pages/motivations/components/MotivationMetricAssignModal.tsx
@@ -1,16 +1,14 @@
 import { Modal, Button, Alert } from "react-bootstrap";
-import { AlertInfo, MotivationMetric } from "@/types";
+import { AlertInfo, RegistryMetric } from "@/types";
 import { useContext, useEffect, useMemo, useRef, useState } from "react";
 import { FaBorderNone, FaInfoCircle } from "react-icons/fa";
-import {
-  useGetAllMotivationMetrics,
-  useUpdateMotivationAssignMetric,
-} from "@/api";
+import { useUpdateMotivationAssignMetric } from "@/api";
 import { AuthContext } from "@/auth";
 import { relMtvPrincpleCriterion } from "@/config";
 import toast from "react-hot-toast";
 import { useTranslation } from "react-i18next";
 import { SearchBox } from "@/components/SearchBox";
+import { useGetAllMetrics } from "@/api/services/registry";
 
 interface MotivationMetricAssignProps {
   mtvId: string;
@@ -26,7 +24,9 @@ export function MotivationMetricAssignModal(
 ) {
   const { t } = useTranslation();
   const { keycloak, registered } = useContext(AuthContext)!;
-  const [mtvMetrics, setMtvMetrics] = useState<MotivationMetric[]>([]);
+  const [availableMetrics, setAvailableMetrics] = useState<RegistryMetric[]>(
+    [],
+  );
   const [selMetricId, setSelMetricId] = useState("");
 
   const [searchInput, setSearchInput] = useState("");
@@ -79,17 +79,17 @@ export function MotivationMetricAssignModal(
     data: mtrData,
     fetchNextPage: mtrFetchNextPage,
     hasNextPage: mtrHasNextPage,
-  } = useGetAllMotivationMetrics(props.mtvId, {
+  } = useGetAllMetrics({
     size: 20,
     token: keycloak?.token || "",
     isRegistered: registered,
   });
 
   useEffect(() => {
-    // gather all mtv metrics in one array
-    let tmpMtr: MotivationMetric[] = [];
+    // gather all registry metrics in one array
+    let tmpMtr: RegistryMetric[] = [];
 
-    // iterate over backend pages and gather all items in the motivation metrics array
+    // iterate over backend pages and gather all items in the metrics array
     if (mtrData?.pages) {
       mtrData.pages.map((page) => {
         tmpMtr = [...tmpMtr, ...page.content];
@@ -98,22 +98,23 @@ export function MotivationMetricAssignModal(
         mtrFetchNextPage();
       }
     }
-    setMtvMetrics(tmpMtr);
-  }, [mtrData, mtrHasNextPage, mtrFetchNextPage]);
+
+    setAvailableMetrics(tmpMtr);
+  }, [mtrData, mtrHasNextPage, mtrFetchNextPage, props.mtvId]);
 
   useEffect(() => {
     setSelMetricId("");
   }, [props.show]);
 
   const filteredMetrics = useMemo(() => {
-    return mtvMetrics.filter((item) => {
+    return availableMetrics.filter((item) => {
       const query = searchInput.toLowerCase();
       return (
         item.metric_label.toLowerCase().includes(query) ||
         item.metric_description.toLowerCase().includes(query)
       );
     });
-  }, [searchInput, mtvMetrics]);
+  }, [searchInput, availableMetrics]);
 
   return (
     <Modal
@@ -137,7 +138,7 @@ export function MotivationMetricAssignModal(
             {t("page_motivations.available_metrics")}
           </strong>
           <span className="ms-1 badge bg-primary rounded-pill fs-6">
-            {mtvMetrics.length}
+            {availableMetrics.length}
           </span>
         </div>
 
@@ -181,8 +182,9 @@ export function MotivationMetricAssignModal(
               <FaBorderNone className="me-2" />
               <strong>
                 {
-                  mtvMetrics.filter((item) => item.metric_id === selMetricId)[0]
-                    .metric_label
+                  availableMetrics?.filter(
+                    (item) => item.metric_id === selMetricId,
+                  )[0].metric_label
                 }
               </strong>
               <small className="ms-2 text-muted">{selMetricId}</small>

--- a/src/pages/motivations/components/MotivationMetrics.tsx
+++ b/src/pages/motivations/components/MotivationMetrics.tsx
@@ -20,15 +20,14 @@ import {
 import notavailImg from "@/assets/thumb_notavail.png";
 import {
   FaBars,
-  FaCodeBranch,
   FaCog,
   FaEdit,
-  FaTrash,
   FaChevronDown,
   FaChevronRight,
+  FaPlus,
 } from "react-icons/fa";
 import { MotivationMetricModal } from "./MotivationMetricModal";
-import { useDeleteMotivationMetric, useGetAllMotivationMetrics } from "@/api";
+import { useDeleteMotivationMetric } from "@/api";
 import { Link } from "react-router-dom";
 import ROUTES, { buildRoute } from "../../../routes";
 import { useTranslation } from "react-i18next";
@@ -36,6 +35,7 @@ import { MotivationMetricDetailsModal } from "./MotivationMetricDetailsModal";
 import toast from "react-hot-toast";
 import { DeleteModal } from "@/components/DeleteModal";
 import { SearchBox } from "@/components/SearchBox";
+import { useGetAllMetrics } from "@/api/services/registry";
 
 interface MetricModalConfig {
   show: boolean;
@@ -82,11 +82,35 @@ export const MotivationMetrics = ({
     data: mtrData,
     fetchNextPage: mtrFetchNextPage,
     hasNextPage: mtrHasNextPage,
-  } = useGetAllMotivationMetrics(mtvId, {
+  } = useGetAllMetrics({
     size: 20,
     token: keycloak?.token || "",
     isRegistered: registered,
   });
+
+  useEffect(() => {
+    // gather all registry metrics in one array
+    let tmpMtr: RegistryMetric[] = [];
+
+    // iterate over backend pages and gather all items in the metrics array
+    if (mtrData?.pages) {
+      mtrData.pages.map((page) => {
+        tmpMtr = [...tmpMtr, ...page.content];
+      });
+      if (mtrHasNextPage) {
+        mtrFetchNextPage();
+      }
+    }
+
+    const availableMetricsForMotivation = tmpMtr.filter((metric) => {
+      if (!metric.motivation_id || metric.motivation_id === "") {
+        return true;
+      }
+      return metric.motivation_id === mtvId;
+    });
+
+    setMtvMetrics(availableMetricsForMotivation);
+  }, [mtrData, mtrHasNextPage, mtrFetchNextPage, mtvId]);
 
   const mutationDelete = useDeleteMotivationMetric(keycloak?.token || "");
 
@@ -130,24 +154,6 @@ export const MotivationMetrics = ({
     }
   };
 
-  useEffect(() => {
-    let result: RegistryMetric[] = [];
-
-    // iterate over backend pages and gather all items in the motivation metrics array
-    if (mtrData?.pages) {
-      mtrData.pages.forEach((page) => {
-        const contentDetails = page.content as RegistryMetric[];
-        result = [...result, ...contentDetails];
-      });
-
-      if (mtrHasNextPage) {
-        mtrFetchNextPage();
-      }
-    }
-
-    setMtvMetrics(result);
-  }, [mtrData, mtrHasNextPage, mtrFetchNextPage]);
-
   const [searchInput, setSearchInput] = useState("");
 
   const handleSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -183,6 +189,9 @@ export const MotivationMetrics = ({
       }),
     [searchInput, mtvMetrics],
   );
+
+  console.log("mtvMetrics - Metric Tab", mtvMetrics);
+  console.log("filteredMetrics", filteredMetrics);
 
   const handleMetricMetadata = () => {
     // Find the metric that matches the current modal itemId
@@ -267,8 +276,8 @@ export const MotivationMetrics = ({
         <div>
           {published ? (
             <span className="btn btn-warning disabled">
-              <FaEdit className="me-2" />
-              {t("page_motivations.manage_metrics")}
+              <FaPlus className="me-2" />
+              {t("page_motivations.create_metric")}
             </span>
           ) : (
             <Button
@@ -282,8 +291,8 @@ export const MotivationMetrics = ({
               }}
               disabled={published}
             >
-              <FaEdit className="me-2" />
-              {t("page_motivations.manage_metrics")}
+              <FaPlus className="me-2" />
+              {t("page_motivations.create_metric")}
             </Button>
           )}
         </div>
@@ -372,27 +381,6 @@ export const MotivationMetrics = ({
                         placement="top"
                         overlay={
                           <Tooltip>
-                            {t("page_motivations.tip_edit_metric")}
-                          </Tooltip>
-                        }
-                      >
-                        <Button
-                          variant="light"
-                          onClick={() => {
-                            setModalCreateEdit({
-                              itemId: item.metric_id,
-                              show: true,
-                              isVersioning: false,
-                            });
-                          }}
-                        >
-                          <FaEdit />
-                        </Button>
-                      </OverlayTrigger>
-                      <OverlayTrigger
-                        placement="top"
-                        overlay={
-                          <Tooltip>
                             {t("page_motivations.tip_view_metric_tests")}
                           </Tooltip>
                         }
@@ -421,50 +409,11 @@ export const MotivationMetrics = ({
                           className="btn btn-light"
                           to={buildRoute(
                             ROUTES.ADMIN.MOTIVATIONS.METRICS_TESTS,
-                            { mtvId: mtvId, metricId: item.metric_id },
+                            { mtvId: mtvId, mtrId: item.metric_id },
                           )}
                         >
                           <FaCog />
                         </Link>
-                      </OverlayTrigger>
-                      <OverlayTrigger
-                        placement="top"
-                        overlay={<Tooltip>Create New Version</Tooltip>}
-                      >
-                        <Button
-                          className="btn btn-light"
-                          onClick={() => {
-                            setModalCreateEdit({
-                              itemId: item.metric_id,
-                              show: true,
-                              isVersioning: true,
-                            });
-                          }}
-                        >
-                          <FaCodeBranch />
-                        </Button>
-                      </OverlayTrigger>
-                      <OverlayTrigger
-                        placement="top"
-                        overlay={
-                          <Tooltip id="tip-delete">
-                            {t("page_motivations.tip_delete_metric")}
-                          </Tooltip>
-                        }
-                      >
-                        <Button
-                          className="btn btn-light btn-sm m-1"
-                          onClick={() => {
-                            setDeleteMetricModalConfig({
-                              ...deleteMetricModalConfig,
-                              show: true,
-                              itemId: item.metric_id,
-                              itemName: item.metric_label,
-                            });
-                          }}
-                        >
-                          <FaTrash />
-                        </Button>
                       </OverlayTrigger>
                     </Col>
                   </Row>
@@ -561,7 +510,7 @@ export const MotivationMetrics = ({
                               className="btn btn-light"
                               to={buildRoute(
                                 ROUTES.ADMIN.MOTIVATIONS.METRICS_TESTS,
-                                { mtvId: mtvId, metricId: version.metric_id },
+                                { mtvId: mtvId, mtrId: version.metric_id },
                               )}
                             >
                               <FaCog />

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -54,7 +54,7 @@ const ROUTES = {
       ROOT: "/admin/motivations",
       VIEW: "/admin/motivations/:mtvId",
       MANAGE_CRITERIA: "/admin/motivations/:mtvId/manage-criteria-principles",
-      METRICS_TESTS: "/admin/motivations/:mtvId/metrics-tests/:metricId",
+      METRICS_TESTS: "/admin/motivations/:mtvId/metrics-tests/:mtrId",
       ACTOR_CRITERIA: "/admin/motivations/:mtvId/actors/:actId",
       TEMPLATES: "/admin/motivations/:mtvId/templates/actors/:actId",
       ASSESSMENT_BUILDER:


### PR DESCRIPTION
This PR refactors the metric functionality for creation and assignment a new metric in a motivation.

- Updated MotivationMetricAssignModal to properly fetch and filter metrics available for the current motivation
- Updated metric filtering logic to use simple motivation_id string field
- Refactored MotivationMetrics component to use infinite query pattern for fetching all metric pages from registry
- Improved metric creation workflow within motivation context using updated endpoints