### PR TITLE
CAT-932 Implement minimal theme/branding options

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -52,6 +52,7 @@ import TestMethodsSettings from "./pages/admin/settings/TestMethodsSettings";
 import MetricTypesSettings from "./pages/admin/settings/MetricTypesSettings";
 import AlgorithmsSettings from "./pages/admin/settings/AlgorithmsSettings";
 import BenchmarkTypesSettings from "./pages/admin/settings/BenchmarkTypesSettings";
+import { pidSelectionView, themeAbout } from "./config";
 
 const queryClient = new QueryClient();
 
@@ -92,23 +93,33 @@ function App() {
             <main className="cat-main-view">
               <Routes>
                 <Route path={ROUTES.HOME} element={<Home />} />
-                <Route path={ROUTES.ABOUT.CAT} element={<AboutCat />} />
-                <Route
-                  path={ROUTES.ABOUT.INTEROPERABILITY}
-                  element={<Interoperability />}
-                />
-                <Route
-                  path={ROUTES.ABOUT.ACCEPTABLE_USE}
-                  element={<AcceptableUse />}
-                />
-                <Route path={ROUTES.ABOUT.PRIVACY} element={<Privacy />} />
-                <Route
-                  path={ROUTES.ABOUT.DISCLAIMER}
-                  element={<Disclaimer />}
-                />
-                <Route path={ROUTES.PID_SELECTION} element={<PidSelection />} />
-                <Route path={ROUTES.ABOUT.COOKIES} element={<Cookies />} />
-                <Route path={ROUTES.ABOUT.TERMS} element={<Terms />} />
+                {themeAbout && (
+                  <>
+                    <Route path={ROUTES.ABOUT.CAT} element={<AboutCat />} />
+                    <Route
+                      path={ROUTES.ABOUT.INTEROPERABILITY}
+                      element={<Interoperability />}
+                    />
+                    <Route
+                      path={ROUTES.ABOUT.ACCEPTABLE_USE}
+                      element={<AcceptableUse />}
+                    />
+                    <Route path={ROUTES.ABOUT.PRIVACY} element={<Privacy />} />
+                    <Route
+                      path={ROUTES.ABOUT.DISCLAIMER}
+                      element={<Disclaimer />}
+                    />
+
+                    <Route path={ROUTES.ABOUT.COOKIES} element={<Cookies />} />
+                    <Route path={ROUTES.ABOUT.TERMS} element={<Terms />} />
+                  </>
+                )}
+                {pidSelectionView && (
+                  <Route
+                    path={ROUTES.PID_SELECTION}
+                    element={<PidSelection />}
+                  />
+                )}
                 <Route
                   path={ROUTES.ASSESSMENTS.CREATE_WITH_VALIDATION}
                   element={<ProtectedRoute />}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -7,7 +7,7 @@ import logoGwdg from "@/assets/logo-gwdg.svg";
 import { Link } from "react-router-dom";
 import packageJson from "@/../package.json";
 import { useTranslation } from "react-i18next";
-import { linksDocs, linksGithub } from "@/config";
+import { linksDocs, linksGithub, themeFooterDisplay } from "@/config";
 import ROUTES from "../routes";
 
 function Footer() {
@@ -21,74 +21,96 @@ function Footer() {
   return (
     <footer className="border-top">
       <Container className="text-left">
-        <Row className="mt-4">
-          <Col sm>
-            <h6>{t("footer.about_category")}</h6>
-            <ul className="list-unstyled">
-              <li>
-                <Link to={ROUTES.ABOUT.CAT}>{t("footer.about_cat")}</Link>
-              </li>
-              <li>
-                <Link to={ROUTES.ABOUT.INTEROPERABILITY}>
-                  {t("interoperability_guidelines")}
-                </Link>
-              </li>
-              <li>
-                <Link to={ROUTES.ABOUT.ACCEPTABLE_USE}>
-                  {t("acceptable_use_policy")}
-                </Link>
-              </li>
-              <li>
-                <Link to={ROUTES.ABOUT.TERMS}>{t("page_terms.title")}</Link>
-              </li>
-              <li>
-                <Link to={ROUTES.ABOUT.COOKIES}>{t("page_cookies.title")}</Link>
-              </li>
-              <li>
-                <Link to={ROUTES.ABOUT.PRIVACY}>{t("privacy_statement")}</Link>
-              </li>
-              <li>
-                <Link to={ROUTES.ABOUT.DISCLAIMER}>{t("disclaimer")}</Link>
-              </li>
-            </ul>
-          </Col>
-          <Col sm>
-            <h6>{t("footer.development_category")}</h6>
-            <ul className="list-unstyled">
-              {linksGithub && (
+        {themeFooterDisplay && (
+          <Row className="mt-4">
+            <Col sm>
+              <h6>{t("footer.about_category")}</h6>
+              <ul className="list-unstyled">
                 <li>
-                  <FaGithub color="grey" className="me-2" />
-                  <a href={linksGithub} target="_blank" rel="noreferrer">
-                    {t("github")}
-                  </a>
+                  <Link to={ROUTES.ABOUT.CAT}>{t("footer.about_cat")}</Link>
                 </li>
-              )}
-              {linksDocs && (
                 <li>
-                  <FaBook color="grey" className="me-2" />
-                  <a href={linksDocs} target="_blank" rel="noreferrer">
-                    {t("documentation")}
-                  </a>
+                  <Link to={ROUTES.ABOUT.INTEROPERABILITY}>
+                    {t("interoperability_guidelines")}
+                  </Link>
                 </li>
-              )}
-            </ul>
-          </Col>
-          <Col sm>
-            <h6>{t("footer.partners_category")}</h6>
-            <a href="https://dans.knaw.nl/en" target="_blank" rel="noreferrer">
-              <img className="cat-logo-sm" src={logoDans} alt="DANS" />
-            </a>
-            <a href="https://www.grnet.gr/en" target="_blank" rel="noreferrer">
-              <img className="cat-logo-sm" src={logoGrnet} alt="GRNET" />
-            </a>
-            <a href="https://www.datacite.org" target="_blank" rel="noreferrer">
-              <img className="cat-logo-sm" src={logoDatacite} alt="DATACITE" />
-            </a>
-            <a href="https://www.gwdg.de/" target="_blank" rel="noreferrer">
-              <img className="cat-logo-sm" src={logoGwdg} alt="GWDG" />
-            </a>
-          </Col>
-        </Row>
+                <li>
+                  <Link to={ROUTES.ABOUT.ACCEPTABLE_USE}>
+                    {t("acceptable_use_policy")}
+                  </Link>
+                </li>
+                <li>
+                  <Link to={ROUTES.ABOUT.TERMS}>{t("page_terms.title")}</Link>
+                </li>
+                <li>
+                  <Link to={ROUTES.ABOUT.COOKIES}>
+                    {t("page_cookies.title")}
+                  </Link>
+                </li>
+                <li>
+                  <Link to={ROUTES.ABOUT.PRIVACY}>
+                    {t("privacy_statement")}
+                  </Link>
+                </li>
+                <li>
+                  <Link to={ROUTES.ABOUT.DISCLAIMER}>{t("disclaimer")}</Link>
+                </li>
+              </ul>
+            </Col>
+            <Col sm>
+              <h6>{t("footer.development_category")}</h6>
+              <ul className="list-unstyled">
+                {linksGithub && (
+                  <li>
+                    <FaGithub color="grey" className="me-2" />
+                    <a href={linksGithub} target="_blank" rel="noreferrer">
+                      {t("github")}
+                    </a>
+                  </li>
+                )}
+                {linksDocs && (
+                  <li>
+                    <FaBook color="grey" className="me-2" />
+                    <a href={linksDocs} target="_blank" rel="noreferrer">
+                      {t("documentation")}
+                    </a>
+                  </li>
+                )}
+              </ul>
+            </Col>
+            <Col sm>
+              <h6>{t("footer.partners_category")}</h6>
+              <a
+                href="https://dans.knaw.nl/en"
+                target="_blank"
+                rel="noreferrer"
+              >
+                <img className="cat-logo-sm" src={logoDans} alt="DANS" />
+              </a>
+              <a
+                href="https://www.grnet.gr/en"
+                target="_blank"
+                rel="noreferrer"
+              >
+                <img className="cat-logo-sm" src={logoGrnet} alt="GRNET" />
+              </a>
+              <a
+                href="https://www.datacite.org"
+                target="_blank"
+                rel="noreferrer"
+              >
+                <img
+                  className="cat-logo-sm"
+                  src={logoDatacite}
+                  alt="DATACITE"
+                />
+              </a>
+              <a href="https://www.gwdg.de/" target="_blank" rel="noreferrer">
+                <img className="cat-logo-sm" src={logoGwdg} alt="GWDG" />
+              </a>
+            </Col>
+          </Row>
+        )}
         <div className="text-left">
           <small className="text-muted">
             <span>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -9,6 +9,7 @@ import { FaUser, FaShieldAlt } from "react-icons/fa";
 import { UserProfile } from "@/types";
 import { useTranslation } from "react-i18next";
 import ROUTES from "../routes";
+import { pidSelectionView, themeAppTitle } from "@/config";
 
 function Header() {
   const { authenticated, keycloak, registered } = useContext(AuthContext)!;
@@ -37,7 +38,7 @@ function Header() {
                 src={logo}
                 height="46"
                 className="d-inline-block align-top"
-                alt="FAIRCORE4EOSC CAT"
+                alt={themeAppTitle}
               />
             </Link>
           </Navbar.Brand>
@@ -62,11 +63,13 @@ function Header() {
                   {t("assessments").toUpperCase()}
                 </Link>
               </NavItem>
-              <NavItem>
-                <Link to={ROUTES.PID_SELECTION} className="cat-nav-link">
-                  {t("pid_selection").toUpperCase()}
-                </Link>
-              </NavItem>
+              {pidSelectionView && (
+                <NavItem>
+                  <Link to={ROUTES.PID_SELECTION} className="cat-nav-link">
+                    {t("pid_selection").toUpperCase()}
+                  </Link>
+                </NavItem>
+              )}
             </Nav>
 
             <Nav>

--- a/src/config.tsx
+++ b/src/config.tsx
@@ -1,7 +1,9 @@
-import config from "./config.json";
-import { ApiT } from "./types";
+import configJSON from "./config.json";
+import { Config } from "./types";
 
-const API: ApiT = config.api;
+const config: Config = configJSON;
+
+const API = config.api;
 
 const relMtvActorId = config.relation_ids.motivation_actor;
 const relMtvPrincipleId = config.relation_ids.motivation_principle;
@@ -21,12 +23,23 @@ const defaultMotivationMetricAlgorithm =
 const defaultG069userInfo = config.default_values?.g069_param_user_info || "";
 const defaultG069tokenIntrospection =
   config.default_values?.g069_param_token_introspection || "";
+const defaultPublicMotivationId =
+  config.default_values?.public_motivation_id || "pid_graph:3E109BBA";
 
 const linksGithub = config.links?.github || "";
 
 const linksDocs = config.links?.docs || "";
 
 const g069Providers: Record<string, string> = config.g069_providers;
+const themeAppTitle = config.theme?.app_title ?? "CAT";
+
+const pidSelectionView = config.embedded_views?.pid_selection_view || "";
+
+// some minimal theme configs
+const themeFooterDisplay = config.theme?.footer?.display ?? true;
+const themeHomeBenefits = config.theme?.home?.display_benefits ?? true;
+const themeActorArt = config.theme?.actor_art;
+const themeAbout = config.theme?.about?.display ?? true;
 
 export {
   API,
@@ -41,7 +54,14 @@ export {
   defaultMotivationMetricBenchmarkType,
   defaultG069userInfo,
   defaultG069tokenIntrospection,
+  defaultPublicMotivationId,
   linksGithub,
   linksDocs,
   g069Providers,
+  themeFooterDisplay,
+  themeAppTitle,
+  themeHomeBenefits,
+  themeActorArt,
+  themeAbout,
+  pidSelectionView,
 };

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -7,6 +7,7 @@ import serviceImg from "@/assets/thumb_service.png";
 import manageImg from "@/assets/thumb_manage.png";
 import ownersImg from "@/assets/thumb_user.png";
 import ROUTES from "../routes";
+import { themeHomeBenefits } from "@/config";
 
 function Home() {
   const { data } = useGetStatistics();
@@ -70,69 +71,71 @@ function Home() {
           </div>
         </div>
       </div>
-      <div className="row bg-light p-4">
-        <h2>{t("page_home.benefits")}</h2>
-        <div className="row">
-          <div className="col">
-            <Card className="p-2 border-grey shadow-sm mb-2">
-              <Card.Img
-                className="mx-auto p-2"
-                src={manageImg}
-                alt={t("page_home.managers")}
-                style={{ maxWidth: "80px" }}
-              />
+      {themeHomeBenefits && (
+        <div className="row bg-light p-4">
+          <h2>{t("page_home.benefits")}</h2>
+          <div className="row">
+            <div className="col">
+              <Card className="p-2 border-grey shadow-sm mb-2">
+                <Card.Img
+                  className="mx-auto p-2"
+                  src={manageImg}
+                  alt={t("page_home.managers")}
+                  style={{ maxWidth: "80px" }}
+                />
 
-              <Card.Body>
-                <Card.Title className="d-flex justify-content-between">
-                  {t("page_home.managers")}
-                </Card.Title>
-                <span className="lead cat-home-lead">
-                  <small>{t("page_home.managers_description")}</small>
-                </span>
-              </Card.Body>
-              <Card.Footer className="bg-transparent border-0"></Card.Footer>
-            </Card>
-          </div>
-          <div className="col">
-            <Card className="p-2 border-grey shadow-sm mb-2">
-              <Card.Img
-                className="mx-auto p-2"
-                src={ownersImg}
-                alt={t("page_home.owners")}
-                style={{ maxWidth: "80px" }}
-              />
-              <Card.Body>
-                <Card.Title className="d-flex justify-content-between">
-                  {t("page_home.owners")}
-                </Card.Title>
-                <span className="lead cat-home-lead">
-                  <small>{t("page_home.owners_description")}</small>
-                </span>
-              </Card.Body>
-              <Card.Footer className="bg-transparent border-0"></Card.Footer>
-            </Card>
-          </div>
-          <div className="col cat-heading-right">
-            <Card className="p-2 border-grey shadow-sm mb-2">
-              <Card.Img
-                className="mx-auto p-2"
-                src={serviceImg}
-                alt={t("page_home.providers")}
-                style={{ maxWidth: "80px" }}
-              />
-              <Card.Body>
-                <Card.Title className="d-flex justify-content-between">
-                  {t("page_home.providers")}
-                </Card.Title>
-                <span className="lead cat-home-lead">
-                  <small>{t("page_home.providers_description")}</small>
-                </span>
-              </Card.Body>
-              <Card.Footer className="bg-transparent border-0"></Card.Footer>
-            </Card>
+                <Card.Body>
+                  <Card.Title className="d-flex justify-content-between">
+                    {t("page_home.managers")}
+                  </Card.Title>
+                  <span className="lead cat-home-lead">
+                    <small>{t("page_home.managers_description")}</small>
+                  </span>
+                </Card.Body>
+                <Card.Footer className="bg-transparent border-0"></Card.Footer>
+              </Card>
+            </div>
+            <div className="col">
+              <Card className="p-2 border-grey shadow-sm mb-2">
+                <Card.Img
+                  className="mx-auto p-2"
+                  src={ownersImg}
+                  alt={t("page_home.owners")}
+                  style={{ maxWidth: "80px" }}
+                />
+                <Card.Body>
+                  <Card.Title className="d-flex justify-content-between">
+                    {t("page_home.owners")}
+                  </Card.Title>
+                  <span className="lead cat-home-lead">
+                    <small>{t("page_home.owners_description")}</small>
+                  </span>
+                </Card.Body>
+                <Card.Footer className="bg-transparent border-0"></Card.Footer>
+              </Card>
+            </div>
+            <div className="col cat-heading-right">
+              <Card className="p-2 border-grey shadow-sm mb-2">
+                <Card.Img
+                  className="mx-auto p-2"
+                  src={serviceImg}
+                  alt={t("page_home.providers")}
+                  style={{ maxWidth: "80px" }}
+                />
+                <Card.Body>
+                  <Card.Title className="d-flex justify-content-between">
+                    {t("page_home.providers")}
+                  </Card.Title>
+                  <span className="lead cat-home-lead">
+                    <small>{t("page_home.providers_description")}</small>
+                  </span>
+                </Card.Body>
+                <Card.Footer className="bg-transparent border-0"></Card.Footer>
+              </Card>
+            </div>
           </div>
         </div>
-      </div>
+      )}
       <div className="row p-4"></div>
     </div>
   );

--- a/src/pages/PidSelection.tsx
+++ b/src/pages/PidSelection.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from "react";
-import config from "@/config.json";
+import { pidSelectionView } from "@/config";
 
 function PidSelection() {
   const iframeRef = useRef<HTMLIFrameElement>(null);
@@ -7,7 +7,7 @@ function PidSelection() {
 
   useEffect(() => {
     const handleResize = (event: MessageEvent) => {
-      if (event.origin === config?.embedded_views?.pid_selection_view) {
+      if (event.origin === pidSelectionView) {
         // Replace with the actual domain of pageB
         console.log("received size from child:", event.data);
         if (iframeRef.current)
@@ -26,7 +26,7 @@ function PidSelection() {
   return (
     <div>
       <iframe
-        src={config?.embedded_views?.pid_selection_view}
+        src={pidSelectionView}
         style={{ width: "100%", height: "800px" }}
         ref={iframeRef}
       ></iframe>

--- a/src/pages/assessments/Assessments.tsx
+++ b/src/pages/assessments/Assessments.tsx
@@ -12,6 +12,7 @@ import { ActorCard } from "./components/ActorCard";
 import { AuthContext } from "@/auth";
 import { useContext } from "react";
 import { useTranslation } from "react-i18next";
+import { defaultPublicMotivationId, themeActorArt } from "@/config";
 
 interface CardProps {
   id: number;
@@ -36,19 +37,27 @@ function Assessments() {
 
   const { t } = useTranslation();
 
+  const actorArt: Record<string, string> = themeActorArt ?? {
+    "PID Scheme (Component)": "scheme_art",
+    "PID Manager (Role)": "manager_art",
+    "PID Service Provider (Role)": "service_art",
+    "PID Owner (Role)": "owner_art",
+    "PID Authority (Role)": "authority_art",
+  };
+
   const cardImgs: Record<string, string> = {
-    "PID Scheme (Component)": schemesImg,
-    "PID Manager (Role)": manageImg,
-    "PID Service Provider (Role)": serviceImg,
-    "PID Owner (Role)": ownersImg,
-    "PID Authority (Role)": authImg,
+    scheme_art: schemesImg,
+    manager_art: manageImg,
+    service_art: serviceImg,
+    owner_art: ownersImg,
+    authority_art: authImg,
   };
 
   // generate the cards when actor data is loaded
   if (!actorsData.isLoading && actorsData.data) {
     actorsData.data.content.forEach((actorItem) => {
       // get the image
-      const cardImg = cardImgs[actorItem.label] || null;
+      const cardImg = cardImgs[actorArt[actorItem.label]] || null;
       if (cardImg) {
         cardProps.push({
           id: parseInt(actorItem.id),
@@ -58,7 +67,7 @@ function Assessments() {
           linkText: t("page_assessments.public_view"),
           link: `/public-assessments?actor-id=${
             actorItem.id
-          }&motivation-id=${"pid_graph:3E109BBA"}&actor-name=${actorItem.label}`,
+          }&motivation-id=${defaultPublicMotivationId}&actor-name=${actorItem.label}`,
         });
       }
     });

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -2,11 +2,6 @@
 
 import { MotivationMetric } from "./motivation";
 
-export type ApiT = {
-  base_url: string;
-  version: string;
-};
-
 export interface ResponsePage<T> {
   size_of_page: number;
   number_of_page: number;

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -1,0 +1,61 @@
+export interface Config {
+  api: ConfigApi;
+  relation_ids: ConfigRelationIds;
+  default_values?: ConfigDefaultValues;
+  embedded_views?: ConfigEmbeddedViews;
+  theme?: ConfigTheme;
+  links?: ConfigLinks;
+  g069_providers: Record<string, string>;
+}
+
+export type ConfigRelationIds = {
+  motivation_principle: string;
+  motivation_actor: string;
+  motivation_principle_criterion: string;
+  motivation_metric_test: string;
+};
+
+export type ConfigDefaultValues = {
+  criterion_type: string;
+  criterion_imperative: string;
+  motivation_metric_type: string;
+  motivation_metric_algorithm: string;
+  motivation_metric_benchmark_type: string;
+  g069_param_user_info: string;
+  g069_param_token_introspection: string;
+  public_motivation_id?: string;
+};
+
+export type ConfigLinks = {
+  github: string;
+  docs: string;
+};
+
+export type ConfigApi = {
+  base_url: string;
+  version: string;
+};
+
+export type ConfigEmbeddedViews = {
+  pid_selection_view?: string;
+};
+
+export type ConfigTheme = {
+  app_title?: string;
+  actor_art?: Record<string, string>;
+  home?: ConfigThemeHome;
+  footer?: ConfigThemeFooter;
+  about?: ConfigAbout;
+};
+
+export type ConfigThemeHome = {
+  display_benefits: boolean;
+};
+
+export type ConfigThemeFooter = {
+  display?: boolean;
+};
+
+export type ConfigAbout = {
+  display: true;
+};

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -6,3 +6,4 @@ export * from "./motivation";
 export * from "./principle";
 export * from "./criterion";
 export * from "./registry";
+export * from "./config";


### PR DESCRIPTION
### Goal
Give the ability with the minimum amount of config parameters to deploy CAT for another use case (different logos, welcome messages, public assessment actor cards etc)

### Things that can already be configured through deployment recipes:
- logo: replace `/src/logo.svg` with the appropriate log
- favicon: replace `/public/favicon.ico`
- fcat list image (if needed): replace `/public/fclogo.png`
- welcome message: replace `page_home.description` string in i18n file in `/src/assests/locales/en.json`


### Things that need to be configured with extra params
- `app_title` to use it as alternative text in logo image and in other cases
- `display footer` to be able to hide footer when we don't have any meaningful content to display (app version will still be displayed for ops observability)
- `display benefits` to be able to hide benefits section from the home page if we don't have any meaningful content to display
- `display about pages` to be able to hide about pages when we don't have content (also disable routes)
- `pid selection` view and header navigation will be hidden when no meaningful embedded url has been established (also disable route)
- `actor_art` will be a small dictionary that can map specific user roles to a list of specific clipart used in the cards such as `manager_art`, `owner_art`, `provider_art`. The user can specify which roles will map to which card art assets and only those roles will be visible in the public assessment page info 
- `default public motivation id` will be used to reference the default motivation that will be used to display public assessments 

The above parameters are expressed in the following json structure placed in `/config.json`

```
 "theme": {
    "app_title": "CAT",
    "actor_art": {
      "PID Service Provider (Role)": "service_art"
    },
    "home": {
      "display_benefits": false
    },
    "footer": {
      "display": false
    }
    "about:" {
     "display": false
     }
  }
```

### Implementation
- [x] Establish config types to handle configuration more easily 
- [x] Add app_title as alternative text to logo image
- [x] Hide/remove footer content based on `footer.display` parameter
- [x] Hide/remove benefits from home page based on `home.display_benefits`
- [x] Configure routes conditionally if `about.display` is configured or no embedded view for pid_selection is defined
- [x] Create a mapping of generic labels to clip art used for cards (use `manager_art`, `owner_art` etc as default mappings). Map specific roles to these labels so as to automatically receive the correct art in the public assessments info view page. Roles that aren't specified will be skipped from card list
- [x] Add a default public motivation id parameter so as cat to know which motivation will use for the public assessment type views (only one can be used as it is right now per cat installation) 

