### PR TITLE
[CAT-965] - Add Test Deletion, Auto-select Criteria & UI Improvements for Assessment Builder

### DIFF
--- a/src/pages/assessment-builder/AssessmentBuilder.module.css
+++ b/src/pages/assessment-builder/AssessmentBuilder.module.css
@@ -1343,12 +1343,23 @@
   border-radius: 0.375rem;
 }
 
+.delete-icon {
+  z-index: 10;
+  font-size: 0.8rem;
+  color: #6c757d;
+  cursor: "pointer";
+  transition: all 0.1s ease;
+}
+
+.delete-icon:hover {
+  color: #dc3545;
+  transform: scale(1.1);
+}
+
 .test-method-item {
   padding: 0.5rem 0.75rem;
   font-weight: 500;
-  cursor: pointer;
   border-bottom: 1px solid #f3f4f6;
-  transition: all 0.2s ease;
 }
 
 .test-method-item:last-child {

--- a/src/pages/assessment-builder/AssessmentBuilder.tsx
+++ b/src/pages/assessment-builder/AssessmentBuilder.tsx
@@ -30,7 +30,7 @@ import styles from "./AssessmentBuilder.module.css";
 function AssessmentBuilder() {
   const { mtvId, actId } = useParams<{
     mtvId: string;
-    actId?: string;
+    actId: string;
   }>();
 
   const { keycloak, registered } = useContext(AuthContext)!;
@@ -327,11 +327,11 @@ function AssessmentBuilder() {
             <div className={styles["column-content"]}>
               <AssessmentBuilderStructure
                 mtvId={mtvId || ""}
+                actId={actId || ""}
                 assessment={assessment}
                 setAssessment={setAssessment}
                 setBuilderState={setBuilderState}
                 selectedId={builderState.selectedId || ""}
-                motivationCriteriaMutation={motivationCriteriaMutation}
                 allCriteria={allCriteria}
               />
             </div>
@@ -351,6 +351,18 @@ function AssessmentBuilder() {
             </div>
             <AssessmentBuilderPreview
               mtvId={mtvId || ""}
+              mtrId={(() => {
+                const metricId =
+                  assessment
+                    ?.flatMap((principle) => principle.criteria || [])
+                    ?.find(
+                      (criterion) => criterion.id === builderState.selectedId,
+                    )?.metric?.id || "";
+                const matchingMetric = motivationMetrics?.find(
+                  (metric) => metric?.metric_mtr === metricId,
+                );
+                return matchingMetric?.metric_id || "";
+              })()}
               criterionPidGraph={
                 allCriteria?.find(
                   (criterion) =>
@@ -445,6 +457,7 @@ function AssessmentBuilder() {
                   assessment={assessment}
                   allCriteria={allCriteria || []}
                   allPrinciples={allPrinciples}
+                  setBuilderState={setBuilderState}
                   criterionId={
                     builderState.selectedId
                       ? assessment

--- a/src/pages/assessment-builder/AssessmentBuilderCriteria.tsx
+++ b/src/pages/assessment-builder/AssessmentBuilderCriteria.tsx
@@ -9,6 +9,7 @@ import {
 import { AuthContext } from "@/auth";
 import {
   AlertInfo,
+  AssessmentBuilderState,
   AssessmentPrinciple,
   Criterion,
   CriterionInput,
@@ -41,12 +42,13 @@ function AssessmentBuilderCriteria({
   criterionId,
   motivationCriteriaMutation,
   refetchAssessmentData,
+  setBuilderState,
 }: {
   assessment: AssessmentPrinciple[];
   setAssessment: React.Dispatch<React.SetStateAction<AssessmentPrinciple[]>>;
   formMode: "none" | "select" | "new" | "edit";
-  mtvId?: string;
-  actId?: string;
+  mtvId: string;
+  actId: string;
   allCriteria: Criterion[];
   allPrinciples?: (PrincipleInput & { id: string })[];
   criterionId?: string;
@@ -54,6 +56,7 @@ function AssessmentBuilderCriteria({
     mutateAsync: (data: { mtvId: string }) => Promise<{ content: Criterion[] }>;
   };
   refetchAssessmentData: () => void;
+  setBuilderState: React.Dispatch<React.SetStateAction<AssessmentBuilderState>>;
 }) {
   const { keycloak, registered } = useContext(AuthContext)!;
   const alert = useRef<AlertInfo>({
@@ -599,6 +602,13 @@ function AssessmentBuilderCriteria({
           return prevAssessment;
         });
 
+        setBuilderState((prevState) => ({
+          ...prevState,
+          entityMode: "criterion",
+          formMode: "edit",
+          selectedId: criterionForm?.cri || selectedRegistryCriterionId || "",
+        }));
+
         if (formMode === "new" || formMode === "edit") {
           setShowErrors(false);
           setCriterionForm({
@@ -624,6 +634,15 @@ function AssessmentBuilderCriteria({
       success: () => alert.current.message,
       error: () => alert.current.message,
     });
+
+    if (formMode === "select") {
+      setBuilderState((prevState) => ({
+        ...prevState,
+        entityMode: "criterion",
+        formMode: "edit",
+        selectedId: criterionForm?.cri || selectedRegistryCriterionId || "",
+      }));
+    }
   };
 
   const handleCriterionHover = (

--- a/src/pages/assessment-builder/AssessmentBuilderPreview.tsx
+++ b/src/pages/assessment-builder/AssessmentBuilderPreview.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useContext, useEffect, useRef, useState } from "react";
 import { OverlayTrigger, Tooltip } from "react-bootstrap";
 import { useTranslation } from "react-i18next";
 import {
@@ -6,11 +6,22 @@ import {
   AssessmentPrinciple,
   AssessmentCriterionImperative,
   MetricFull,
+  MetricTest,
+  AlertInfo,
 } from "@/types";
-import styles from "./AssessmentBuilder.module.css";
 import { FaExclamationCircle, FaInfoCircle } from "react-icons/fa";
 import TestPreviewModal from "../tests/components/TestPreviewModal";
 import AssessmentBuilderMetric from "./AssessmentBuilderMetric";
+import {
+  useGetMotivationMetricTests,
+  useUpdateMotivationMetricTests,
+} from "@/api";
+import { AuthContext } from "@/auth";
+import { RegistryTest } from "@/types/tests";
+import { relMtvMetricTest } from "@/config";
+import toast from "react-hot-toast";
+import styles from "./AssessmentBuilder.module.css";
+import AssessmentBuilderDeleteModal from "./AssessmentBuilderDeleteModal";
 
 interface AssessmentBuilderPreviewProps {
   assessment: AssessmentPrinciple[];
@@ -18,6 +29,7 @@ interface AssessmentBuilderPreviewProps {
   setBuilderState: React.Dispatch<React.SetStateAction<AssessmentBuilderState>>;
   setAssessment: React.Dispatch<React.SetStateAction<AssessmentPrinciple[]>>;
   mtvId?: string;
+  mtrId?: string;
   criterionPidGraph?: string;
   motivationMetrics?: MetricFull[];
   refetchAssessmentData: () => void;
@@ -29,6 +41,7 @@ interface AssessmentBuilderPreviewProps {
 
 function AssessmentBuilderPreview({
   mtvId,
+  mtrId,
   criterionPidGraph,
   assessment,
   builderState,
@@ -41,9 +54,119 @@ function AssessmentBuilderPreview({
   isTestSelected,
   setIsTestSelected,
 }: AssessmentBuilderPreviewProps) {
+  const { keycloak, registered } = useContext(AuthContext)!;
   const [isConfiguring, setIsConfiguring] = useState(false);
   const [isAlgorithmConfigured, setIsAlgorithmConfigured] = useState(false);
+  const [selectedTests, setSelectedTests] = useState<RegistryTest[]>([]);
+  const [showDeleteModal, setShowDeleteModal] = useState({
+    testId: "",
+    testLabel: "",
+  });
   const { t } = useTranslation();
+
+  const alert = useRef<AlertInfo>({
+    message: "",
+  });
+
+  useEffect(() => {
+    if (builderState.selectedId) {
+      setIsPrincipleSelected(false);
+      setIsTestSelected(false);
+      setIsConfiguring(false);
+    }
+  }, [
+    builderState.selectedId,
+    setIsPrincipleSelected,
+    setIsTestSelected,
+    setIsConfiguring,
+  ]);
+
+  const mutationUpdateMetricTests = useUpdateMotivationMetricTests(
+    keycloak?.token || "",
+    mtvId || "",
+    mtrId || "",
+  );
+
+  const {
+    data: selTestData,
+    fetchNextPage: selTestFetchNextPage,
+    hasNextPage: selTestHasNextPage,
+  } = useGetMotivationMetricTests(mtvId || "", mtrId || "", {
+    size: 5,
+    token: keycloak?.token || "",
+    isRegistered: registered,
+  });
+
+  useEffect(() => {
+    let tmpSelTests: MetricTest[] = [];
+
+    if (selTestData?.pages) {
+      selTestData.pages.map((page) => {
+        if (page.metric) tmpSelTests = [...tmpSelTests, ...page.metric.tests];
+      });
+      if (selTestHasNextPage) {
+        selTestFetchNextPage();
+      }
+    }
+    setSelectedTests(
+      tmpSelTests.map((item) => {
+        return {
+          id: item.db_id,
+          tes: item.id,
+          label: item.name,
+          description: item.description,
+        };
+      }),
+    );
+  }, [selTestData, selTestHasNextPage, selTestFetchNextPage]);
+
+  const handleTestDelete = (testId: string) => {
+    if (selectedTests.length === 0) return;
+
+    const filteredTests = selectedTests.filter(
+      (test) => test.tes?.toLowerCase() !== testId?.toLowerCase(),
+    );
+
+    const metricAssignment =
+      filteredTests?.map((test) => ({
+        test_id: test.id,
+        relation: relMtvMetricTest,
+      })) || [];
+
+    setSelectedTests(filteredTests);
+
+    const assignTestsToMetricPromise = mutationUpdateMetricTests
+      .mutateAsync(metricAssignment)
+      .catch((err) => {
+        alert.current = {
+          message: t("page_motivations.toast_assign_metric_fail"),
+        };
+        throw err;
+      })
+      .then(() => {
+        refetchAssessmentData();
+        alert.current = {
+          message: t("page_motivations.toast_assign_metric_success"),
+        };
+      });
+
+    toast.promise(assignTestsToMetricPromise, {
+      loading: t("toast_assign_metric_progress"),
+      success: () => alert.current.message,
+      error: () => alert.current.message,
+    });
+  };
+
+  const confirmDeleteTest = () => {
+    if (showDeleteModal.testId) {
+      handleTestDelete(showDeleteModal.testId);
+    }
+    setShowDeleteModal({ testId: "", testLabel: "" });
+  };
+
+  const cancelDeleteTest = () => {
+    setShowDeleteModal({ testId: "", testLabel: "" });
+  };
 
   return (
     <div className={styles["column-content"]}>
@@ -347,6 +470,12 @@ function AssessmentBuilderPreview({
                               );
                             })()}
                             testMethodName={test.type}
+                            onTestDelete={() =>
+                              setShowDeleteModal({
+                                testId: test.id,
+                                testLabel: test.name,
+                              })
+                            }
                           />
                         </div>
                       ))}
@@ -367,6 +496,13 @@ function AssessmentBuilderPreview({
           )}
         </div>
       ) : null}
+      <AssessmentBuilderDeleteModal
+        isOpen={Boolean(showDeleteModal?.testId)}
+        itemName={showDeleteModal?.testLabel || ""}
+        itemType="test"
+        onConfirm={confirmDeleteTest}
+        onCancel={cancelDeleteTest}
+      />
     </div>
   );
 }

--- a/src/pages/assessment-builder/AssessmentBuilderStructure.tsx
+++ b/src/pages/assessment-builder/AssessmentBuilderStructure.tsx
@@ -13,35 +13,33 @@ import {
   FaExclamationCircle,
 } from "react-icons/fa";
 import AssessmentBuilderDeleteModal from "./AssessmentBuilderDeleteModal";
-import {
-  formatDataToAssignPrincipleToCriterion,
-  isCriterionCompleted,
-} from "./utils";
-import { useUpdateMotivationPrinciplesCriteria } from "@/api";
+import { isCriterionCompleted } from "./utils";
 import { AuthContext } from "@/auth";
 import styles from "./AssessmentBuilder.module.css";
 import { OverlayTrigger, Tooltip } from "react-bootstrap";
+import {
+  useGetMotivationActorCriteria,
+  useUpdateMotivationActorCriteria,
+} from "@/api";
 
 function AssessmentBuilderStructure({
   mtvId,
+  actId,
   setBuilderState,
   assessment,
   setAssessment,
   selectedId,
-  motivationCriteriaMutation,
   allCriteria,
 }: {
-  mtvId?: string;
+  mtvId: string;
+  actId: string;
   setBuilderState: React.Dispatch<React.SetStateAction<AssessmentBuilderState>>;
   assessment: AssessmentPrinciple[];
   setAssessment: React.Dispatch<React.SetStateAction<AssessmentPrinciple[]>>;
   selectedId?: string;
-  motivationCriteriaMutation: {
-    mutateAsync: (data: { mtvId: string }) => Promise<{ content: Criterion[] }>;
-  };
   allCriteria: Criterion[];
 }) {
-  const { keycloak } = useContext(AuthContext)!;
+  const { keycloak, registered } = useContext(AuthContext)!;
   const [collapsedPrinciples, setCollapsedPrinciples] = useState<Set<string>>(
     new Set(),
   );
@@ -53,10 +51,36 @@ function AssessmentBuilderStructure({
     criterionName: string;
   } | null>(null);
 
-  const assignPrincipleToCriterion = useUpdateMotivationPrinciplesCriteria(
+  const [selectedCriteria, setSelectedCriteria] = useState<Criterion[]>([]);
+
+  const assignCriteriaToActorMutation = useUpdateMotivationActorCriteria(
     keycloak?.token || "",
     mtvId || "",
+    actId || "",
   );
+
+  const {
+    data: motivationCriteria,
+    fetchNextPage: selCriFetchNextPage,
+    hasNextPage: selCriHasNextPage,
+  } = useGetMotivationActorCriteria(mtvId || "", actId || "", {
+    size: 5,
+    token: keycloak?.token || "",
+    isRegistered: registered,
+  });
+
+  useEffect(() => {
+    let tmpSelCri: Criterion[] = [];
+    if (motivationCriteria?.pages) {
+      motivationCriteria.pages.map((page) => {
+        tmpSelCri = [...tmpSelCri, ...page.content];
+      });
+      if (selCriHasNextPage) {
+        selCriFetchNextPage();
+      }
+    }
+    setSelectedCriteria(tmpSelCri);
+  }, [motivationCriteria, selCriHasNextPage, selCriFetchNextPage]);
 
   // Ensure untagged principle is always at the last position
   useEffect(() => {
@@ -89,7 +113,7 @@ function AssessmentBuilderStructure({
           criterionIndex,
           criterion,
         ] of principle.criteria.entries()) {
-          if (criterion.id === selectedId) {
+          if (criterion.id?.toLowerCase() === selectedId?.toLowerCase()) {
             // Update the builder state with correct indices
             setBuilderState({
               entityMode: "criterion",
@@ -103,14 +127,6 @@ function AssessmentBuilderStructure({
         }
       }
     }
-    // If selectedId is not found, reset indices
-    setBuilderState({
-      entityMode: "none",
-      formMode: "none",
-      selectedId: "",
-      selectedPrincipleIndex: -1,
-      selectedCriterionIndex: -1,
-    });
   }, [assessment, selectedId, setBuilderState]);
 
   const togglePrinciple = (principleId: string) => {
@@ -128,26 +144,9 @@ function AssessmentBuilderStructure({
     criterionIndex: number,
     criterionId: string,
   ) => {
-    const allMotivationCriteriaData =
-      await motivationCriteriaMutation.mutateAsync({
-        mtvId: mtvId || "",
-      });
-
-    const allMotivationCriteria = allMotivationCriteriaData?.content || [];
-
-    let formattedPriCri = formatDataToAssignPrincipleToCriterion({
-      allMotivationCriteria: allMotivationCriteria,
-      principleId: "",
-      criterionId: "",
-    });
-
     const selectedCriterionPidGraph = allCriteria?.find(
       (criterion) => criterion.cri === criterionId,
     )?.id;
-
-    formattedPriCri = formattedPriCri.filter(
-      (item) => item.criterion_id !== selectedCriterionPidGraph,
-    );
 
     let response;
     try {
@@ -155,8 +154,17 @@ function AssessmentBuilderStructure({
         assessment[principleIndex]?.id &&
         assessment[principleIndex].id !== "untagged"
       ) {
+        const criImp = selectedCriteria?.map((item) => ({
+          criterion_id: item.id,
+          imperative_id: item.imperative.id,
+        }));
+
+        const filteredCriImp = criImp?.filter(
+          (item) => item.criterion_id !== selectedCriterionPidGraph,
+        );
+
         response =
-          await assignPrincipleToCriterion.mutateAsync(formattedPriCri);
+          await assignCriteriaToActorMutation.mutateAsync(filteredCriImp);
       }
 
       if (
@@ -331,21 +339,9 @@ function AssessmentBuilderStructure({
                       style={{
                         marginLeft: "auto",
                         marginRight: "8px",
-                        cursor: "pointer",
-                        color: "#6c757d",
-                        fontSize: "0.8rem",
-                        transition: "all 0.2s ease",
-                      }}
-                      onMouseEnter={(e) => {
-                        e.currentTarget.style.color = "#dc3545";
-                        e.currentTarget.style.transform = "scale(1.1)";
-                      }}
-                      onMouseLeave={(e) => {
-                        e.currentTarget.style.color = "#6c757d";
-                        e.currentTarget.style.transform = "scale(1)";
                       }}
                     >
-                      <FaTrash />
+                      <FaTrash className={`${styles["delete-icon"]}`} />
                     </span>
                   </div>
                 );

--- a/src/pages/assessment-builder/AssessmentBuilderTests.tsx
+++ b/src/pages/assessment-builder/AssessmentBuilderTests.tsx
@@ -80,7 +80,7 @@ function AssessmentBuilderTests({
   };
 
   const mutateCreateTest = useCreateTest(keycloak?.token || "", test);
-  const mutationUpdate = useUpdateMotivationMetricTests(
+  const mutationUpdateMetricTests = useUpdateMotivationMetricTests(
     keycloak?.token || "",
     mtvId || "",
     mtrId || "",
@@ -246,8 +246,8 @@ function AssessmentBuilderTests({
   };
 
   const handleCancel = () => {
-    setBuilderState((prev) => ({
-      ...prev,
+    setBuilderState((prevState) => ({
+      ...prevState,
       entityMode: "none",
       formMode: "none",
     }));
@@ -299,58 +299,82 @@ function AssessmentBuilderTests({
         relation: relMtvMetricTest,
       });
     }
-    alert.current = {
-      message:
-        formMode === "new"
-          ? "Test created successfully"
-          : formMode === "edit"
-            ? "Test updated successfully"
-            : "Test selected successfully",
-    };
 
     if (formMode === "new") {
       updateParamTestDef();
 
-      await mutateCreateTest
+      const createTestPromise = mutateCreateTest
         .mutateAsync()
-        .catch((err) => {
-          alert.current = {
-            message: "Error: " + err.response.data.message,
-          };
-          throw err;
-        })
         .then((newTest) => {
           alert.current = {
             message: t("page_tests.toast_create_success"),
           };
 
+          // Add the newly created test to the metric assignment
           metricAssignment.push({
             test_id: newTest.id,
             relation: relMtvMetricTest,
           });
+
+          // Now execute the assignment to metric after successful test creation
+          const assignTestsToMetricPromise = mutationUpdateMetricTests
+            .mutateAsync(metricAssignment)
+            .catch((err) => {
+              alert.current = {
+                message: t("page_motivations.toast_assign_metric_fail"),
+              };
+              throw err;
+            })
+            .then(() => {
+              refetchAssessmentData();
+              alert.current = {
+                message: t("page_motivations.toast_assign_metric_success"),
+              };
+            });
+
+          toast.promise(assignTestsToMetricPromise, {
+            loading: t("toast_assign_metric_progress"),
+            success: () => alert.current.message,
+            error: () => alert.current.message,
+          });
+
+          return newTest;
+        })
+        .catch((err) => {
+          alert.current = {
+            message: "Error: " + err.response.data.message,
+          };
+          throw err;
         });
-    }
 
-    const promise = mutationUpdate
-      .mutateAsync(metricAssignment)
-      .catch((err) => {
-        alert.current = {
-          message: t("page_motivations.toast_assign_metric_fail"),
-        };
-        throw err;
-      })
-      .then(() => {
-        refetchAssessmentData();
-        alert.current = {
-          message: t("page_motivations.toast_assign_metric_success"),
-        };
+      toast.promise(createTestPromise, {
+        loading: t("page_tests.toast_create_progress"),
+        success: () => alert.current.message,
+        error: () => alert.current.message,
       });
+    } else if (formMode === "select") {
+      // For select mode, execute assignment directly
+      const assignTestsToMetricPromise = mutationUpdateMetricTests
+        .mutateAsync(metricAssignment)
+        .catch((err) => {
+          alert.current = {
+            message: t("page_motivations.toast_assign_metric_fail"),
+          };
+          throw err;
+        })
+        .then(() => {
+          refetchAssessmentData();
+          alert.current = {
+            message: t("page_motivations.toast_assign_metric_success"),
+          };
+        });
 
-    toast.promise(promise, {
-      loading: t("page_tests.toast_create_progress"),
-      success: () => `${alert.current.message}`,
-      error: () => `${alert.current.message}`,
-    });
+      toast.promise(assignTestsToMetricPromise, {
+        loading: t("toast_assign_metric_progress"),
+        success: () => alert.current.message,
+        error: () => alert.current.message,
+      });
+    }
 
     setIsTestSelected(false);
   };

--- a/src/pages/assessments/components/tests/TestAutoG069Form.tsx
+++ b/src/pages/assessments/components/tests/TestAutoG069Form.tsx
@@ -124,15 +124,20 @@ export const TestAutoG069Form = (props: AssessmentTestProps) => {
             <h6>
               <small
                 className="text-muted badge badge-pill border bg-light"
-                style={{ textWrap: "wrap", textAlign: "start" }}
+                style={{
+                  textWrap: "wrap",
+                  textAlign: "start",
+                  wordBreak: "break-all",
+                }}
               >
-                <span className="me-3">{props.test.id}</span>
+                <span>{props.test.id}</span>
+                {" - "}
                 {props.test.name}
               </small>
             </h6>
           )}
         </Col>
-        <Col xs={3} className="text-start"></Col>
+        <Col xs={1} className="text-start"></Col>
       </Row>
 
       <Row>

--- a/src/pages/assessments/components/tests/TestAutoValidationForm.tsx
+++ b/src/pages/assessments/components/tests/TestAutoValidationForm.tsx
@@ -12,7 +12,7 @@ import { FaGears } from "react-icons/fa6";
 import { AutoTestDetails } from "./AutoTestDetails";
 
 interface AssessmentTestProps {
-  autogroup: AutoGroupTest | undefined;
+  autogroup?: AutoGroupTest;
   test: TestAutoValidation;
   onAutoGroupTestCall(autogroup: AutoGroupTest): void;
 }
@@ -28,13 +28,21 @@ export const TestAutoValidationForm = (props: AssessmentTestProps) => {
       <Row>
         <Col>
           <h6>
-            <small className="text-muted badge badge-pill border bg-light">
-              <span className="me-4">{props.test.id}</span>
+            <small
+              className="text-muted badge badge-pill border bg-light"
+              style={{
+                textWrap: "wrap",
+                textAlign: "start",
+                wordBreak: "break-word",
+              }}
+            >
+              <span>{props.test.id}</span>
+              {" - "}
               {props.test.name}
             </small>
           </h6>
         </Col>
-        <Col xs={3} className="text-start"></Col>
+        <Col xs={1} className="text-start"></Col>
       </Row>
 
       <Row>

--- a/src/pages/motivations/MotivationActorCriteria.tsx
+++ b/src/pages/motivations/MotivationActorCriteria.tsx
@@ -147,31 +147,29 @@ export default function MotivationActorCriteria() {
   }
 
   function handleUpdate() {
-    if (selectedCriteria.length > 0) {
-      const criImp = selectedCriteria.map((item) => ({
-        criterion_id: item.id,
-        imperative_id: item.imperative.id,
-      }));
-      const promise = mutationUpdate
-        .mutateAsync(criImp)
-        .catch((err) => {
-          alert.current = {
-            message: t("page_motivations.toast_assign_cri_act_fail"),
-          };
-          throw err;
-        })
-        .then(() => {
-          alert.current = {
-            message: t("page_motivations.toast_assign_cri_act_success"),
-          };
-          navigate(-1);
-        });
-      toast.promise(promise, {
-        loading: t("page_motivations.toast_assign_cri_act_progress"),
-        success: () => `${alert.current.message}`,
-        error: () => `${alert.current.message}`,
+    const criImp = selectedCriteria?.map((item) => ({
+      criterion_id: item.id,
+      imperative_id: item.imperative.id,
+    }));
+    const promise = mutationUpdate
+      .mutateAsync(criImp)
+      .catch((err) => {
+        alert.current = {
+          message: t("page_motivations.toast_assign_cri_act_fail"),
+        };
+        throw err;
+      })
+      .then(() => {
+        alert.current = {
+          message: t("page_motivations.toast_assign_cri_act_success"),
+        };
+        navigate(-1);
       });
-    }
+    toast.promise(promise, {
+      loading: t("page_motivations.toast_assign_cri_act_progress"),
+      success: () => `${alert.current.message}`,
+      error: () => `${alert.current.message}`,
+    });
   }
 
   return (

--- a/src/pages/tests/components/TestPreviewModal.tsx
+++ b/src/pages/tests/components/TestPreviewModal.tsx
@@ -1,10 +1,12 @@
 import { TestInput, TestParam } from "@/types/tests";
 import { EvidenceURLS, TestToolTip } from "@/pages/assessments/components";
 import { TestBinaryParamForm } from "@/pages/assessments/components/tests/TestBinaryParam";
+import { FaTrash } from "react-icons/fa";
 import {
   TestAutoG069,
   TestAutoHttpsCheck,
   TestAutoMD1,
+  TestAutoValidation,
   TestBinaryParam,
   TestValueParam,
 } from "@/types";
@@ -13,12 +15,15 @@ import { TestValueFormParam } from "@/pages/assessments/components/tests/TestVal
 import { TestAutoG069Form } from "@/pages/assessments/components/tests/TestAutoG069Form";
 import { TestAutoHttpsCheckForm } from "@/pages/assessments/components/tests/TestAutoHttpsCheckForm";
 import { TestAutoMd1Form } from "@/pages/assessments/components/tests/TestAutoMd1Form";
+import { TestAutoValidationForm } from "@/pages/assessments/components/tests/TestAutoValidationForm";
+import styles from "@/pages/assessment-builder/AssessmentBuilder.module.css";
 
 interface TestPreviewProps {
   test: TestInput;
   params: TestParam[];
   testMethodName?: string;
   hasEvidenceParam?: boolean;
+  onTestDelete?: () => void;
 }
 
 const TestPreviewModal = ({
@@ -26,6 +31,7 @@ const TestPreviewModal = ({
   params,
   testMethodName,
   hasEvidenceParam,
+  onTestDelete,
 }: TestPreviewProps) => {
   const testParams: JSX.Element[] = [];
 
@@ -109,6 +115,25 @@ const TestPreviewModal = ({
         onTestChange={() => {}}
         criterionId={""}
         principleId={""}
+      />,
+    );
+  } else if (testMethodName === "Fully-Automated-Validation") {
+    const adaptedTest = {
+      id: test.tes || "",
+      name: test.label || "",
+      type: testMethodName,
+      text: params?.map((p) => p.text).join("|") || "",
+      value: "",
+      result: "",
+      params: params?.map((p) => p.name).join("|") || "",
+      evidence_url: [],
+      tool_tip: params?.map((p) => p.tooltip).join("|") || "",
+      auto_type: "g069",
+    } as unknown as TestAutoValidation;
+    testParams.push(
+      <TestAutoValidationForm
+        test={adaptedTest}
+        onAutoGroupTestCall={() => {}}
       />,
     );
   } else if (testMethodName === "Auto-Check-AARC-G069-User-Info") {
@@ -210,7 +235,23 @@ const TestPreviewModal = ({
   return (
     <>
       {testParams?.length > 0 ? (
-        <div className="border rounded cat-test-div">
+        <div className="border rounded cat-test-div position-relative">
+          {onTestDelete && (
+            <span
+              onClick={(e) => {
+                e.stopPropagation();
+                onTestDelete();
+              }}
+              style={{
+                position: "absolute",
+                top: "12px",
+                right: "12px",
+                cursor: "pointer",
+              }}
+            >
+              <FaTrash className={styles["delete-icon"]} size="16px" />
+            </span>
+          )}
           {testParams}
 
           {hasEvidenceParam && (


### PR DESCRIPTION
This PR implements test deletion functionality, auto-selection features for criteria, and some more improvements to enhance the Assessment Builder UI/UX. Also, the changes include improved state management that properly resets editing modes when switching criteria, support for additional test method types in preview mode, and bug fixes for criteria management and API endpoint usage.

- Implement "Delete" action for tests in the Preview column with confirmation dialogs
- Implement auto-select functionality for criteria when adding new items to streamline the user workflow
- Add comprehensive toast notifications for test creation operations including first POST request
- Support test method preview for "Fully-Automated-Validation"
- Resolve issue when removing all criteria from an actor in the "Manage Criteria" section of motivation tab
- Fix incorrect endpoint usage when deleting criteria in Assessment Builder
- Implement proper state reset to close "Editing" mode when selecting a different criterion
- Enhance state management for Edit/Editing and Expand/Collapse actions across principles, metrics, and tests entities