### PR TITLE
Fix Assessment Builder API Error, Enhance Untagged Criteria Management, and some UI/UX improvements for Builder

### DIFF
--- a/src/api/services/motivations.ts
+++ b/src/api/services/motivations.ts
@@ -429,7 +429,7 @@ export const useGetMotivationMetricTests = (
       return handleBackendError(error);
     },
     retry: false,
-    enabled: isRegistered,
+    enabled: isRegistered && !!mtvId && !!mtrId,
   });
 
 export const useGetMotivationActorCriteria = (

--- a/src/pages/assessment-builder/AssessmentBuilder.module.css
+++ b/src/pages/assessment-builder/AssessmentBuilder.module.css
@@ -637,7 +637,7 @@
 /* Horizontal separator after each principle section */
 .principle-section-separator {
   height: 1px;
-  margin: 0.7rem 0 0.2rem;
+  margin-top: 0.5rem;
   background: #e5e7eb;
 }
 
@@ -787,6 +787,12 @@
     max-width: calc(100vw - 16px);
     margin-right: 0;
     transform: none;
+  }
+
+  .form-actions-tests {
+    position: static;
+    width: 100%;
+    margin-top: 0.5rem;
   }
 }
 

--- a/src/pages/assessment-builder/AssessmentBuilder.tsx
+++ b/src/pages/assessment-builder/AssessmentBuilder.tsx
@@ -1,6 +1,6 @@
 import { useParams, useNavigate } from "react-router-dom";
 import { useTranslation } from "react-i18next";
-import { useState, useContext, useEffect, useRef } from "react";
+import { useState, useContext, useEffect, useRef, useCallback } from "react";
 import toast from "react-hot-toast";
 import { Button, Container, Spinner } from "react-bootstrap";
 import { AuthContext } from "@/auth";
@@ -259,6 +259,18 @@ function AssessmentBuilder() {
     }));
   };
 
+  const getMetricId = useCallback(() => {
+    const metricId =
+      assessment
+        ?.flatMap((principle) => principle.criteria || [])
+        ?.find((criterion) => criterion.id === builderState.selectedId)?.metric
+        ?.id || "";
+    const matchingMetric = motivationMetrics?.find(
+      (metric) => metric?.metric_mtr === metricId,
+    );
+    return matchingMetric?.metric_id || "";
+  }, [assessment, builderState.selectedId, motivationMetrics]);
+
   if (isLoading) {
     return (
       <Container fluid className="py-4">
@@ -351,18 +363,7 @@ function AssessmentBuilder() {
             </div>
             <AssessmentBuilderPreview
               mtvId={mtvId || ""}
-              mtrId={(() => {
-                const metricId =
-                  assessment
-                    ?.flatMap((principle) => principle.criteria || [])
-                    ?.find(
-                      (criterion) => criterion.id === builderState.selectedId,
-                    )?.metric?.id || "";
-                const matchingMetric = motivationMetrics?.find(
-                  (metric) => metric?.metric_mtr === metricId,
-                );
-                return matchingMetric?.metric_id || "";
-              })()}
+              mtrId={getMetricId()}
               criterionPidGraph={
                 allCriteria?.find(
                   (criterion) =>
@@ -495,29 +496,19 @@ function AssessmentBuilder() {
                   refetchPrinciples={refetchPrinciples}
                   motivationCriteriaMutation={motivationCriteriaMutation}
                   setIsPrincipleSelected={setIsPrincipleSelected}
+                  setBuilderState={setBuilderState}
                 />
               )}
               {builderState.entityMode === "tests" && (
                 <AssessmentBuilderTests
                   assessment={assessment}
                   builderState={builderState}
+                  setAssessment={setAssessment}
                   setBuilderState={setBuilderState}
                   setIsTestSelected={setIsTestSelected}
                   refetchAssessmentData={refetchAssessmentData}
                   mtvId={mtvId || ""}
-                  mtrId={(() => {
-                    const metricId =
-                      assessment
-                        ?.flatMap((principle) => principle.criteria || [])
-                        ?.find(
-                          (criterion) =>
-                            criterion.id === builderState.selectedId,
-                        )?.metric?.id || "";
-                    const matchingMetric = motivationMetrics?.find(
-                      (metric) => metric?.metric_mtr === metricId,
-                    );
-                    return matchingMetric?.metric_id || "";
-                  })()}
+                  mtrId={getMetricId()}
                 />
               )}
             </div>

--- a/src/pages/assessment-builder/AssessmentBuilderPreview.tsx
+++ b/src/pages/assessment-builder/AssessmentBuilderPreview.tsx
@@ -6,7 +6,6 @@ import {
   AssessmentPrinciple,
   AssessmentCriterionImperative,
   MetricFull,
-  MetricTest,
   AlertInfo,
 } from "@/types";
 import { FaExclamationCircle, FaInfoCircle } from "react-icons/fa";
@@ -22,6 +21,7 @@ import { relMtvMetricTest } from "@/config";
 import toast from "react-hot-toast";
 import styles from "./AssessmentBuilder.module.css";
 import AssessmentBuilderDeleteModal from "./AssessmentBuilderDeleteModal";
+import { removeTestFromUntaggedCriterion } from "./utils/assessmentBuilderUtils";
 
 interface AssessmentBuilderPreviewProps {
   assessment: AssessmentPrinciple[];
@@ -87,38 +87,27 @@ function AssessmentBuilderPreview({
     mtrId || "",
   );
 
-  const {
-    data: selTestData,
-    fetchNextPage: selTestFetchNextPage,
-    hasNextPage: selTestHasNextPage,
-  } = useGetMotivationMetricTests(mtvId || "", mtrId || "", {
-    size: 5,
-    token: keycloak?.token || "",
-    isRegistered: registered,
-  });
+  const { data: metricTestsData } = useGetMotivationMetricTests(
+    mtvId || "",
+    mtrId || "",
+    {
+      token: keycloak?.token || "",
+      isRegistered: showDeleteModal?.testId && registered ? registered : false,
+    },
+  );
 
   useEffect(() => {
-    let tmpSelTests: MetricTest[] = [];
-
-    if (selTestData?.pages) {
-      selTestData.pages.map((page) => {
-        if (page.metric) tmpSelTests = [...tmpSelTests, ...page.metric.tests];
-      });
-      if (selTestHasNextPage) {
-        selTestFetchNextPage();
-      }
-    }
     setSelectedTests(
-      tmpSelTests.map((item) => {
-        return {
+      metricTestsData?.pages
+        .flatMap((page) => page?.metric.tests || [])
+        .map((item) => ({
           id: item.db_id,
           tes: item.id,
           label: item.name,
           description: item.description,
-        };
-      }),
+        })) || [],
     );
-  }, [selTestData, selTestHasNextPage, selTestFetchNextPage]);
+  }, [metricTestsData]);
 
   const handleTestDelete = (testId: string) => {
     if (selectedTests.length === 0) return;
@@ -145,6 +134,14 @@ function AssessmentBuilderPreview({
       })
       .then(() => {
         refetchAssessmentData();
+
+        removeTestFromUntaggedCriterion({
+          testId,
+          selectedCriterionId: builderState.selectedId || "",
+          assessment,
+          setAssessment,
+        });
+
         alert.current = {
           message: t("page_motivations.toast_assign_metric_success"),
         };

--- a/src/pages/assessment-builder/AssessmentBuilderPrinciples.tsx
+++ b/src/pages/assessment-builder/AssessmentBuilderPrinciples.tsx
@@ -13,7 +13,7 @@ import {
   Principle,
   PrincipleInput,
 } from "@/types";
-import { useContext, useEffect, useRef, useState } from "react";
+import { useContext, useEffect, useMemo, useRef, useState } from "react";
 import { FaTags } from "react-icons/fa";
 import { AuthContext } from "@/auth";
 import toast from "react-hot-toast";
@@ -38,7 +38,6 @@ function AssessmentBuilderPrinciples({
   actId,
   principleId,
   assessment,
-  setAssessment,
   allPrinciples,
   allCriteria,
   formMode,
@@ -46,12 +45,13 @@ function AssessmentBuilderPrinciples({
   refetchPrinciples,
   motivationCriteriaMutation,
   setIsPrincipleSelected,
+  setAssessment,
+  setBuilderState,
 }: {
   mtvId?: string;
   actId?: string;
   principleId?: string;
   assessment: AssessmentPrinciple[];
-  setAssessment: (assessment: AssessmentPrinciple[]) => void;
   allPrinciples: Principle[];
   allCriteria: Criterion[];
   formMode: FormMode;
@@ -61,6 +61,8 @@ function AssessmentBuilderPrinciples({
     mutateAsync: (data: { mtvId: string }) => Promise<{ content: Criterion[] }>;
   };
   setIsPrincipleSelected: React.Dispatch<React.SetStateAction<boolean>>;
+  setAssessment: (assessment: AssessmentPrinciple[]) => void;
+  setBuilderState: React.Dispatch<React.SetStateAction<AssessmentBuilderState>>;
 }) {
   const { keycloak, registered } = useContext(AuthContext)!;
   const alert = useRef<AlertInfo>({
@@ -127,7 +129,26 @@ function AssessmentBuilderPrinciples({
     );
   };
 
+  const currentPrincipleOfCriterion = useMemo(
+    () =>
+      assessment.find((assessmentPrinciple) =>
+        assessmentPrinciple.criteria?.some(
+          (criterion) => criterion.id === builderState.selectedId,
+        ),
+      ),
+    [assessment, builderState.selectedId],
+  );
+
   const filteredPrinciples = allPrinciples.filter((principle) => {
+    // Exclude the current principle if it exists and is not "untagged"
+    if (
+      currentPrincipleOfCriterion &&
+      currentPrincipleOfCriterion.id !== "untagged" &&
+      principle.pri === currentPrincipleOfCriterion.id
+    ) {
+      return false;
+    }
+
     if (!searchTerm) return true;
     const term = searchTerm.toLowerCase();
     return (
@@ -206,6 +227,8 @@ function AssessmentBuilderPrinciples({
       return;
     }
 
+    let selectedCriterion: Criterion | undefined;
+
     if (formMode === "new") {
       if (
         principleForm?.pri &&
@@ -213,6 +236,12 @@ function AssessmentBuilderPrinciples({
         principleForm.description
       ) {
         createPrincipleToMotivation();
+        setBuilderState((prevState) => ({
+          ...prevState,
+          entityMode: "criterion",
+          formMode: "edit",
+          selectedId: selectedCriterion?.cri || builderState.selectedId || "",
+        }));
       }
     } else if (formMode === "select") {
       const allMotivationCriteriaData =
@@ -275,7 +304,7 @@ function AssessmentBuilderPrinciples({
             }
           }
 
-          const selectedCriterion = allCriteria?.find(
+          selectedCriterion = allCriteria?.find(
             (criterion) =>
               criterion?.cri?.toLowerCase() ===
               builderState?.selectedId?.toLowerCase(),
@@ -297,6 +326,13 @@ function AssessmentBuilderPrinciples({
           if (updatedAssessment.length > 0) {
             setAssessment(updatedAssessment);
           }
+
+          setBuilderState((prevState) => ({
+            ...prevState,
+            entityMode: "criterion",
+            formMode: "edit",
+            selectedId: selectedCriterion?.cri || builderState.selectedId || "",
+          }));
         });
 
       toast.promise(promise, {
@@ -305,14 +341,7 @@ function AssessmentBuilderPrinciples({
         error: () => `${alert.current.message}`,
       });
     }
-    // else if (formMode === "edit") {
-    //   if (
-    //     principleForm?.pri &&
-    //     principleForm?.label &&
-    //     principleForm?.description
-    //   ) {
-    //   }
-    // }
+
     setIsPrincipleSelected(false);
     setSelectedRegistryPrincipleId(null);
   };

--- a/src/pages/assessment-builder/AssessmentBuilderTests.tsx
+++ b/src/pages/assessment-builder/AssessmentBuilderTests.tsx
@@ -27,12 +27,14 @@ import { FaClipboardQuestion } from "react-icons/fa6";
 import { useUpdateMotivationMetricTests } from "@/api";
 import { relMtvMetricTest } from "@/config";
 import toast from "react-hot-toast";
+import { addTestToUntaggedCriterion } from "./utils/assessmentBuilderUtils";
 
 interface AssessmentBuilderTestsProps {
   mtvId: string;
   mtrId: string;
   assessment: AssessmentPrinciple[];
   builderState: AssessmentBuilderState;
+  setAssessment: React.Dispatch<React.SetStateAction<AssessmentPrinciple[]>>;
   setBuilderState: React.Dispatch<React.SetStateAction<AssessmentBuilderState>>;
   refetchAssessmentData: () => void;
   setIsTestSelected: React.Dispatch<React.SetStateAction<boolean>>;
@@ -44,6 +46,7 @@ function AssessmentBuilderTests({
   assessment,
   builderState,
   refetchAssessmentData,
+  setAssessment,
   setBuilderState,
   setIsTestSelected,
 }: AssessmentBuilderTestsProps) {
@@ -327,6 +330,14 @@ function AssessmentBuilderTests({
             })
             .then(() => {
               refetchAssessmentData();
+              // Add test to untagged criterion if needed
+              addTestToUntaggedCriterion({
+                testData: newTest,
+                selectedCriterionId: builderState.selectedId || "",
+                assessment,
+                testMethods,
+                setAssessment,
+              });
               alert.current = {
                 message: t("page_motivations.toast_assign_metric_success"),
               };
@@ -364,6 +375,19 @@ function AssessmentBuilderTests({
         })
         .then(() => {
           refetchAssessmentData();
+          // Add test to untagged criterion if needed
+          const selectedTest = allTests.find(
+            (test) => test.id === selectedTestId,
+          );
+          if (selectedTest) {
+            addTestToUntaggedCriterion({
+              testData: selectedTest,
+              selectedCriterionId: builderState.selectedId || "",
+              assessment,
+              testMethods,
+              setAssessment,
+            });
+          }
           alert.current = {
             message: t("page_motivations.toast_assign_metric_success"),
           };

--- a/src/pages/assessment-builder/utils/assessmentBuilderUtils.ts
+++ b/src/pages/assessment-builder/utils/assessmentBuilderUtils.ts
@@ -8,6 +8,7 @@ import {
   Metric,
   FormMode,
   Imperative,
+  RegistryResource,
 } from "@/types";
 
 // Finds a principle in the assessment by its ID
@@ -293,8 +294,6 @@ export const isCriterionCompleted = (
   if (!criterionInfo) {
     return false;
   }
-
-  console.log("criterionInfo:", criterionInfo);
 
   const { criterion, principle } = criterionInfo;
   const hasPrinciple = principle.id && principle.id !== "untagged";
@@ -643,4 +642,139 @@ export const formatDataToAssignPrincipleToCriterion = ({
   }
 
   return priCri;
+};
+
+interface AddTestToUntaggedCriterionParams {
+  testData: {
+    tes?: string;
+    id?: string;
+    label?: string;
+    name?: string;
+    description?: string;
+    test_method_id?: string;
+    test_params?: string;
+    test_question?: string;
+    tool_tip?: string;
+  };
+  selectedCriterionId: string;
+  assessment: AssessmentPrinciple[];
+  testMethods: RegistryResource[];
+  setAssessment: React.Dispatch<React.SetStateAction<AssessmentPrinciple[]>>;
+}
+
+export const addTestToUntaggedCriterion = ({
+  testData,
+  selectedCriterionId,
+  assessment,
+  testMethods,
+  setAssessment,
+}: AddTestToUntaggedCriterionParams) => {
+  const selectedPrinciple = assessment.find((principle) =>
+    principle.criteria?.some(
+      (criterion) => criterion.id === selectedCriterionId,
+    ),
+  );
+
+  if (selectedPrinciple?.id === "untagged") {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    setAssessment((prevAssessment) => {
+      const updatedAssessment =
+        prevAssessment?.length > 0
+          ? prevAssessment.map((principle) => {
+              if (principle.id === "untagged") {
+                const updatedCriteria =
+                  principle.criteria?.map((criterion) => {
+                    if (criterion.id === selectedCriterionId) {
+                      const newTest = {
+                        id: testData.tes || testData.id || "",
+                        name: testData.label || testData.name || "",
+                        description: testData.description || "",
+                        type:
+                          testMethods.find(
+                            (m) => m.id === testData.test_method_id,
+                          )?.label || "",
+                        params: testData.test_params || "",
+                        text: testData.test_question || "",
+                        tool_tip: testData.tool_tip || "",
+                      };
+
+                      return {
+                        ...criterion,
+                        metric: {
+                          ...criterion.metric,
+                          tests: [...(criterion.metric?.tests || []), newTest],
+                        },
+                      };
+                    }
+                    return criterion;
+                  }) || [];
+
+                return {
+                  ...principle,
+                  criteria: updatedCriteria,
+                };
+              }
+              return principle;
+            })
+          : [];
+
+      return updatedAssessment;
+    });
+  }
+};
+
+interface RemoveTestFromUntaggedCriterionParams {
+  testId: string;
+  selectedCriterionId: string;
+  assessment: AssessmentPrinciple[];
+  setAssessment: React.Dispatch<React.SetStateAction<AssessmentPrinciple[]>>;
+}
+
+export const removeTestFromUntaggedCriterion = ({
+  testId,
+  selectedCriterionId,
+  assessment,
+  setAssessment,
+}: RemoveTestFromUntaggedCriterionParams) => {
+  const selectedPrinciple = assessment.find((principle) =>
+    principle.criteria?.some(
+      (criterion) => criterion.id === selectedCriterionId,
+    ),
+  );
+
+  if (selectedPrinciple?.id === "untagged") {
+    setAssessment((prevAssessment) => {
+      const updatedAssessment = prevAssessment.map((principle) => {
+        if (principle.id === "untagged") {
+          const updatedCriteria =
+            principle.criteria?.map((criterion) => {
+              if (criterion.id === selectedCriterionId) {
+                const updatedTests =
+                  criterion.metric?.tests?.filter(
+                    (test) => test.id?.toLowerCase() !== testId?.toLowerCase(),
+                  ) || [];
+
+                return {
+                  ...criterion,
+                  metric: {
+                    ...criterion.metric,
+                    tests: updatedTests,
+                  },
+                };
+              }
+              return criterion;
+            }) || [];
+
+          return {
+            ...principle,
+            criteria: updatedCriteria,
+          };
+        }
+        return principle;
+      });
+
+      return updatedAssessment;
+    });
+  }
 };

--- a/src/pages/motivations/MotivationMetricTests.tsx
+++ b/src/pages/motivations/MotivationMetricTests.tsx
@@ -1,5 +1,5 @@
 import { AuthContext } from "@/auth";
-import { AlertInfo, MetricTest } from "@/types";
+import { AlertInfo } from "@/types";
 import { useState, useContext, useEffect, useRef, useMemo } from "react";
 import { Button, Col, Row, OverlayTrigger, Tooltip } from "react-bootstrap";
 import toast from "react-hot-toast";
@@ -87,40 +87,27 @@ export default function MotivationMetricTests() {
     params.mtrId || "",
   );
 
-  const {
-    data: selTestData,
-    fetchNextPage: selTestFetchNextPage,
-    hasNextPage: selTestHasNextPage,
-  } = useGetMotivationMetricTests(params.mtvId || "", params.mtrId || "", {
-    size: 5,
-    token: keycloak?.token || "",
-    isRegistered: registered,
-  });
+  const { data: metricTestsData } = useGetMotivationMetricTests(
+    params.mtvId || "",
+    params.mtrId || "",
+    {
+      token: keycloak?.token || "",
+      isRegistered: registered,
+    },
+  );
 
   useEffect(() => {
-    // gather all motivation metric tests in one array
-    let tmpSelTests: MetricTest[] = [];
-
-    // iterate over backend pages and gather all items in the mtv array
-    if (selTestData?.pages) {
-      selTestData.pages.map((page) => {
-        if (page.metric) tmpSelTests = [...tmpSelTests, ...page.metric.tests];
-      });
-      if (selTestHasNextPage) {
-        selTestFetchNextPage();
-      }
-    }
     setSelectedTests(
-      tmpSelTests.map((item) => {
-        return {
+      metricTestsData?.pages
+        .flatMap((page) => page?.metric.tests || [])
+        .map((item) => ({
           id: item.db_id,
           tes: item.id,
           label: item.name,
           description: item.description,
-        };
-      }),
+        })) || [],
     );
-  }, [selTestData, selTestHasNextPage, selTestFetchNextPage]);
+  }, [metricTestsData]);
 
   function handleUpdate() {
     if (selectedTests) {


### PR DESCRIPTION
This PR fixes API call failing when trying to get tests from empty metrics, users seeing the assigned principle in the selection list of principles, and losing focus when working with untagged criteria. We, also, added the ability to manage tests properly for untagged criteria.

- Modified useGetMotivationMetricTests hook to conditionally execute only when metrics exist and have assigned tests
- Added test addition/removal functionality for criteria without associated principles
- Implemented filtering to exclude already assigned principles from available options
- Improved error handling with proper retry logic and registration-based enabling
- Restored proper UI focus behavior when selecting principles for untagged criteria