### PR TITLE
CAT-888 Create specific views and update existing ones for trl, ratio…

### DIFF
--- a/src/pages/assessments/components/CriteriaTabs.tsx
+++ b/src/pages/assessments/components/CriteriaTabs.tsx
@@ -42,7 +42,7 @@ import {
 import { FaCheckCircle, FaInfoCircle, FaTimesCircle } from "react-icons/fa";
 import { useEffect, useState } from "react";
 import { CriterionProgress } from "./CriterionProgress";
-import { TestBinaryParamForm } from "./tests/TestBinaryParam";
+import { TestBinaryParamForm } from "./tests/TestBinaryParamForm";
 import { TestValueFormParam } from "./tests/TestValueFormParam";
 import { TestAutoHttpsCheckForm } from "./tests/TestAutoHttpsCheckForm";
 import { useTranslation } from "react-i18next";
@@ -50,6 +50,9 @@ import { TestAutoMd1Form } from "./tests/TestAutoMd1Form";
 import { TestAutoG069Form } from "./tests/TestAutoG069Form";
 import { defaultG069tokenIntrospection, defaultG069userInfo } from "@/config";
 import { TestAutoValidationForm } from "./tests/TestAutoValidationForm";
+import { TestTRLForm } from "./tests/TestTRLForm";
+import { TestRatioForm } from "./tests/TestRatioForm";
+import { TestPercentForm } from "./tests/TestPercentForm";
 
 type CriteriaTabsProps = {
   autogroups: AutoGroupTest[] | undefined;
@@ -245,15 +248,51 @@ export function CriteriaTabs(props: CriteriaTabsProps) {
           } else if (
             test.type === "Number-Manual" ||
             test.type === "Number-Auto" ||
-            test.type === "Ratio-Manual" ||
-            test.type === "Percent-Manual" ||
-            test.type === "TRL-Manual" ||
             test.type === "Years-Manual"
           ) {
             testList.push(
               <div className="border rounded mt-4" key={test.id}>
                 <div className="cat-test-div">
                   <TestValueFormParam
+                    test={test as TestValueParam}
+                    onTestChange={props.onTestChange}
+                    criterionId={criterion.id}
+                    principleId={principle.id}
+                  />
+                </div>
+              </div>,
+            );
+          } else if (test.type === "TRL-Manual") {
+            testList.push(
+              <div className="border rounded mt-4" key={test.id}>
+                <div className="cat-test-div">
+                  <TestTRLForm
+                    test={test as TestValueParam}
+                    onTestChange={props.onTestChange}
+                    criterionId={criterion.id}
+                    principleId={principle.id}
+                  />
+                </div>
+              </div>,
+            );
+          } else if (test.type === "Percent-Manual") {
+            testList.push(
+              <div className="border rounded mt-4" key={test.id}>
+                <div className="cat-test-div">
+                  <TestPercentForm
+                    test={test as TestValueParam}
+                    onTestChange={props.onTestChange}
+                    criterionId={criterion.id}
+                    principleId={principle.id}
+                  />
+                </div>
+              </div>,
+            );
+          } else if (test.type === "Ratio-Manual") {
+            testList.push(
+              <div className="border rounded mt-4" key={test.id}>
+                <div className="cat-test-div">
+                  <TestRatioForm
                     test={test as TestValueParam}
                     onTestChange={props.onTestChange}
                     criterionId={criterion.id}

--- a/src/pages/assessments/components/tests/TestBinaryParamForm.tsx
+++ b/src/pages/assessments/components/tests/TestBinaryParamForm.tsx
@@ -22,9 +22,10 @@ interface AssessmentTestProps {
 export const TestBinaryParamForm = (props: AssessmentTestProps) => {
   const { t } = useTranslation();
   const handleValueChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    console.log(event.target.checked);
     let result: 0 | 1 = 0;
     let value: boolean = false;
-    if (event.target.value === "1") {
+    if (event.target.checked) {
       value = true;
       result = 1;
     }
@@ -83,24 +84,15 @@ export const TestBinaryParamForm = (props: AssessmentTestProps) => {
             <Form className="form-binary-test" onSubmit={() => false}>
               <Form.Check
                 inline
-                label={t("fields.yes")}
-                value="1"
+                label={
+                  props.test.value === true ? t("fields.yes") : t("fields.no")
+                }
+                value={props.test.value === true ? "1" : "0"}
                 name="test-input-group"
-                type="radio"
-                id="test-check-yes"
+                type="switch"
+                id="test-check"
                 className="fs-6 fw-bold  text-secondary"
                 checked={props.test.value === true}
-                onChange={handleValueChange}
-              />
-              <Form.Check
-                inline
-                label={t("fields.no")}
-                value="0"
-                name="test-input-group"
-                type="radio"
-                className="fs-6 fw-bold  text-secondary"
-                id="test-check-no"
-                checked={props.test.value === false}
                 onChange={handleValueChange}
               />
               {/* here ends the binary test */}

--- a/src/pages/assessments/components/tests/TestPercentForm.tsx
+++ b/src/pages/assessments/components/tests/TestPercentForm.tsx
@@ -1,0 +1,168 @@
+/**
+ * Component to display and edit a percent value test
+ */
+
+import { Col, Form, InputGroup, Row } from "react-bootstrap";
+import { EvidenceURLS } from "./EvidenceURLS";
+import { AssessmentTest, EvidenceURL, TestValueParam } from "@/types";
+import { useState } from "react";
+import { TestToolTip } from "./TestToolTip";
+
+interface AssessmentTestProps {
+  test: TestValueParam;
+  principleId: string;
+  criterionId: string;
+  onTestChange(
+    principleId: string,
+    criterionId: string,
+    newTest: AssessmentTest,
+  ): void;
+}
+
+enum TestValueEventType {
+  Value = "value",
+  Threshold = "threshold",
+}
+
+export const TestPercentForm = (props: AssessmentTestProps) => {
+  const [localValue, setLocalValue] = useState<string>(
+    props.test.value?.toString() || "",
+  );
+
+  const handleValueChange = (
+    eventType: TestValueEventType,
+    event: React.ChangeEvent<HTMLInputElement>,
+  ) => {
+    const newTest = { ...props.test };
+    // keep only number digits as input
+    const numberOnlyVal = event.target.value.replace(/[^0-9.]/g, "");
+
+    if (eventType === TestValueEventType.Value) {
+      // keep value between 0 and 100
+      let val = parseInt(numberOnlyVal);
+      if (isNaN(val)) val = -1;
+      else if (val < 0) val = 0;
+      else if (val > 100) val = 100;
+      newTest.value = val;
+      setLocalValue(val >= 0 ? val.toString() : "");
+    }
+
+    let comparisonMode = "";
+    let comparisonValue = 0;
+    let result: number | null = null;
+
+    // find comparisonMode
+
+    if (newTest.benchmark) {
+      const modes = ["equal_greater_than", "equal_less_than", "equal"];
+
+      for (const mode of modes) {
+        if (mode in newTest.benchmark) {
+          comparisonMode = mode;
+          break;
+        }
+      }
+
+      if (comparisonMode in newTest.benchmark) {
+        if (typeof newTest.benchmark[comparisonMode] === "number") {
+          comparisonValue = newTest.benchmark[comparisonMode] as number;
+        } else if (
+          newTest.benchmark[comparisonMode] === "threshold" &&
+          newTest.threshold
+        ) {
+          comparisonValue = newTest.threshold;
+        }
+      }
+
+      if (newTest.value !== null) {
+        if (comparisonMode === "equal_greater_than") {
+          result = newTest.value >= comparisonValue ? 1 : 0;
+        } else if (comparisonMode === "equal_less_than") {
+          result = newTest.value <= comparisonValue ? 1 : 0;
+        } else {
+          result = newTest.value === comparisonValue ? 1 : 0;
+        }
+      }
+    } else {
+      result = newTest.value;
+    }
+    newTest.result = result;
+    props.onTestChange(props.principleId, props.criterionId, newTest);
+  };
+
+  function onURLChange(newURLS: EvidenceURL[]) {
+    const newTest = { ...props.test, evidence_url: newURLS };
+    props.onTestChange(props.principleId, props.criterionId, newTest);
+  }
+
+  // break parameters
+  const textParams = props.test.text.split("|");
+  const tipParams = props.test.tool_tip.split("|");
+  const testParams = props.test.params.split("|");
+
+  return (
+    <div>
+      <Row>
+        <Col>
+          {props.test.id && (
+            <h6>
+              <small className="text-muted badge badge-pill border bg-light m">
+                {props.test.id && <span className="me-4">{props.test.id}</span>}
+                {props.test.name}
+              </small>
+            </h6>
+          )}
+        </Col>
+        <Col xs={1} className="text-start"></Col>
+      </Row>
+
+      <Row>
+        <Col>
+          <div>
+            {textParams[0] && <h5>{textParams[0]}</h5>}
+            <Row>
+              <Col>
+                <InputGroup>
+                  <InputGroup.Text id="label-first-value">
+                    {tipParams[0] && (
+                      <TestToolTip
+                        tipId={"params-1-" + props.test.id}
+                        tipText={tipParams[0]}
+                      />
+                    )}
+                    {testParams[0] && (
+                      <span className="ms-2">{testParams[0]}</span>
+                    )}
+                    :
+                  </InputGroup.Text>
+                  <Form.Control
+                    value={localValue}
+                    type="text"
+                    id="input-value-control"
+                    onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                      handleValueChange(TestValueEventType.Value, e);
+                    }}
+                  />
+                  <InputGroup.Text id="label-percent">%</InputGroup.Text>
+                </InputGroup>
+              </Col>
+              <Col>
+                <div className="p-2">
+                  <span>Please enter a number between 0 and 100</span>
+                </div>
+              </Col>
+            </Row>
+          </div>
+
+          {testParams[testParams.length - 1] === "evidence" && (
+            <EvidenceURLS
+              urls={props.test.evidence_url || []}
+              onListChange={onURLChange}
+              noTitle={true}
+            />
+          )}
+        </Col>
+      </Row>
+    </div>
+  );
+};

--- a/src/pages/assessments/components/tests/TestRatioForm.tsx
+++ b/src/pages/assessments/components/tests/TestRatioForm.tsx
@@ -1,0 +1,196 @@
+/**
+ * Component to display and edit a ratio test
+ */
+
+import { Col, Form, InputGroup, Row } from "react-bootstrap";
+import { EvidenceURLS } from "./EvidenceURLS";
+import { AssessmentTest, EvidenceURL, TestValueParam } from "@/types";
+import { useState } from "react";
+import { TestToolTip } from "./TestToolTip";
+
+interface AssessmentTestProps {
+  test: TestValueParam;
+  principleId: string;
+  criterionId: string;
+  onTestChange(
+    principleId: string,
+    criterionId: string,
+    newTest: AssessmentTest,
+  ): void;
+}
+
+enum TestValueEventType {
+  Value = "value",
+  Threshold = "threshold",
+}
+
+export const TestRatioForm = (props: AssessmentTestProps) => {
+  const [localValue, setLocalValue] = useState<string>(
+    props.test.value?.toString() || "",
+  );
+  const [localThreshold, setLocalThreshold] = useState<string>(
+    props.test.threshold?.toString() || "",
+  );
+
+  const handleValueChange = (
+    eventType: TestValueEventType,
+    event: React.ChangeEvent<HTMLInputElement>,
+  ) => {
+    const newTest = { ...props.test };
+    // keep only number digits as input
+    const numberOnlyVal = event.target.value.replace(/[^0-9.]/g, "");
+
+    if (eventType === TestValueEventType.Value) {
+      setLocalValue(numberOnlyVal);
+      newTest.value = parseFloat(numberOnlyVal);
+    } else {
+      setLocalThreshold(numberOnlyVal);
+      newTest.threshold = parseFloat(numberOnlyVal);
+    }
+
+    // evaluate result - benchmark till now supports only equal_greater_than
+    // this will change in the future
+    let comparisonMode = "";
+    let comparisonValue = 0;
+    let result: number | null = null;
+
+    // find comparisonMode
+
+    if (newTest.benchmark) {
+      const modes = ["equal_greater_than", "equal_less_than", "equal"];
+
+      for (const mode of modes) {
+        if (mode in newTest.benchmark) {
+          comparisonMode = mode;
+          break;
+        }
+      }
+
+      if (comparisonMode in newTest.benchmark) {
+        if (typeof newTest.benchmark[comparisonMode] === "number") {
+          comparisonValue = newTest.benchmark[comparisonMode] as number;
+        } else if (
+          newTest.benchmark[comparisonMode] === "threshold" &&
+          newTest.threshold
+        ) {
+          comparisonValue = newTest.threshold;
+        }
+      }
+
+      if (newTest.value !== null) {
+        if (comparisonMode === "equal_greater_than") {
+          result = newTest.value >= comparisonValue ? 1 : 0;
+        } else if (comparisonMode === "equal_less_than") {
+          result = newTest.value <= comparisonValue ? 1 : 0;
+        } else {
+          result = newTest.value === comparisonValue ? 1 : 0;
+        }
+      }
+    } else {
+      result = newTest.value;
+    }
+    newTest.result = result;
+    props.onTestChange(props.principleId, props.criterionId, newTest);
+  };
+
+  function onURLChange(newURLS: EvidenceURL[]) {
+    const newTest = { ...props.test, evidence_url: newURLS };
+    props.onTestChange(props.principleId, props.criterionId, newTest);
+  }
+
+  // break parameters
+  const textParams = props.test.text.split("|");
+  const tipParams = props.test.tool_tip.split("|");
+  const testParams = props.test.params.split("|");
+
+  return (
+    <div>
+      <Row>
+        <Col>
+          {props.test.id && (
+            <h6>
+              <small className="text-muted badge badge-pill border bg-light m">
+                {props.test.id && <span className="me-4">{props.test.id}</span>}
+                {props.test.name}
+              </small>
+            </h6>
+          )}
+        </Col>
+        <Col xs={1} className="text-start"></Col>
+      </Row>
+
+      <Row>
+        <Col>
+          <div>
+            {textParams[0] && <h5>{textParams[0]}</h5>}
+            <Row>
+              <Col>
+                <InputGroup>
+                  <InputGroup.Text id="label-first-value">
+                    {tipParams[0] && (
+                      <TestToolTip
+                        tipId={"params-1-" + props.test.id}
+                        tipText={tipParams[0]}
+                      />
+                    )}
+                    {testParams[0] && (
+                      <span className="ms-2">{testParams[0]}</span>
+                    )}
+                    :
+                  </InputGroup.Text>
+                  <Form.Control
+                    value={localValue}
+                    type="text"
+                    id="input-value-control"
+                    onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                      // use this input only if the test is not automated
+
+                      handleValueChange(TestValueEventType.Value, e);
+                    }}
+                  />
+                </InputGroup>
+              </Col>
+              <Col md="auto">
+                <h3>/</h3>
+              </Col>
+              {testParams.length > 1 && testParams[1] !== "evidence" && (
+                <Col>
+                  <InputGroup>
+                    <InputGroup.Text id="label-second-value">
+                      {tipParams[1] && (
+                        <TestToolTip
+                          tipId={"params-2-" + props.test.id}
+                          tipText={tipParams[1]}
+                        />
+                      )}
+                      {testParams[1] && (
+                        <span className="ms-2">{testParams[1]}</span>
+                      )}
+                      :
+                    </InputGroup.Text>
+                    <Form.Control
+                      value={localThreshold || ""}
+                      type="text"
+                      id="input-value-community"
+                      onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                        handleValueChange(TestValueEventType.Threshold, e)
+                      }
+                    />
+                  </InputGroup>
+                </Col>
+              )}
+            </Row>
+          </div>
+
+          {testParams[testParams.length - 1] === "evidence" && (
+            <EvidenceURLS
+              urls={props.test.evidence_url || []}
+              onListChange={onURLChange}
+              noTitle={true}
+            />
+          )}
+        </Col>
+      </Row>
+    </div>
+  );
+};

--- a/src/pages/assessments/components/tests/TestTRLForm.tsx
+++ b/src/pages/assessments/components/tests/TestTRLForm.tsx
@@ -1,0 +1,274 @@
+/**
+ * Component to display and edit a TRL test
+ */
+
+import { Alert, Col, Form, InputGroup, Row } from "react-bootstrap";
+import { EvidenceURLS } from "./EvidenceURLS";
+import { AssessmentTest, EvidenceURL, TestValueParam } from "@/types";
+import { useState } from "react";
+import { TestToolTip } from "./TestToolTip";
+import { FaCogs } from "react-icons/fa";
+import { useTranslation } from "react-i18next";
+
+interface AssessmentTestProps {
+  test: TestValueParam;
+  principleId: string;
+  criterionId: string;
+  onTestChange(
+    principleId: string,
+    criterionId: string,
+    newTest: AssessmentTest,
+  ): void;
+}
+
+enum TestValueEventType {
+  Value = "value",
+  Threshold = "threshold",
+}
+
+export const TestTRLForm = (props: AssessmentTestProps) => {
+  const { t } = useTranslation();
+  const [localValue, setLocalValue] = useState<string>(
+    props.test.value?.toString() || "",
+  );
+  const [localThreshold, setLocalThreshold] = useState<string>(
+    props.test.threshold?.toString() || "",
+  );
+
+  const handleValueChange = (
+    eventType: TestValueEventType,
+    event: React.ChangeEvent<HTMLInputElement>,
+  ) => {
+    const newTest = { ...props.test };
+    // keep only a single digit number as input
+    const trlOnlyVal = event.target.value.replace(/[^1-9]/g, "").slice(0, 1);
+
+    if (eventType === TestValueEventType.Value) {
+      setLocalValue(trlOnlyVal);
+      newTest.value = parseFloat(trlOnlyVal);
+    } else {
+      setLocalThreshold(trlOnlyVal);
+      newTest.threshold = parseFloat(trlOnlyVal);
+    }
+
+    let comparisonMode = "";
+    let comparisonValue = 0;
+    let result: number | null = null;
+
+    // find comparisonMode
+
+    if (newTest.benchmark) {
+      const modes = ["equal_greater_than", "equal_less_than", "equal"];
+
+      for (const mode of modes) {
+        if (mode in newTest.benchmark) {
+          comparisonMode = mode;
+          break;
+        }
+      }
+
+      if (comparisonMode in newTest.benchmark) {
+        if (typeof newTest.benchmark[comparisonMode] === "number") {
+          comparisonValue = newTest.benchmark[comparisonMode] as number;
+        } else if (
+          newTest.benchmark[comparisonMode] === "threshold" &&
+          newTest.threshold
+        ) {
+          comparisonValue = newTest.threshold;
+        }
+      }
+
+      if (newTest.value !== null) {
+        if (comparisonMode === "equal_greater_than") {
+          result = newTest.value >= comparisonValue ? 1 : 0;
+        } else if (comparisonMode === "equal_less_than") {
+          result = newTest.value <= comparisonValue ? 1 : 0;
+        } else {
+          result = newTest.value === comparisonValue ? 1 : 0;
+        }
+      }
+    } else {
+      result = newTest.value;
+    }
+    newTest.result = result;
+    props.onTestChange(props.principleId, props.criterionId, newTest);
+  };
+
+  function onURLChange(newURLS: EvidenceURL[]) {
+    const newTest = { ...props.test, evidence_url: newURLS };
+    props.onTestChange(props.principleId, props.criterionId, newTest);
+  }
+
+  // break parameters
+  const textParams = props.test.text.split("|");
+  const tipParams = props.test.tool_tip.split("|");
+  const testParams = props.test.params.split("|");
+
+  // check if test is automated
+  const automated = props.test.type.endsWith("Auto");
+
+  return (
+    <div>
+      <Row>
+        <Col>
+          {props.test.id && (
+            <h6>
+              <small className="text-muted badge badge-pill border bg-light m">
+                {props.test.id && <span className="me-4">{props.test.id}</span>}
+                {props.test.name}
+              </small>
+            </h6>
+          )}
+        </Col>
+        <Col xs={1} className="text-start"></Col>
+      </Row>
+
+      <Row>
+        <Col>
+          <div>
+            {textParams[0] && <h5>{textParams[0]}</h5>}
+            {automated && (
+              <Alert variant="warning">
+                <div>
+                  <FaCogs />
+                  {` ${t("page_assessment_edit.wip_automated_text")} `}
+                  <em>({t("page_assessment_edit.wip_automated")})</em>
+                </div>
+                <div>
+                  <small>
+                    {`${t("page_assessment_edit.wip_automated_fill")} `}
+                    <code className="text-muted">
+                      {testParams[testParams.length - 1]}
+                    </code>
+                    {` ${t("value")}`}
+                  </small>
+                </div>
+              </Alert>
+            )}
+            <Row>
+              <Col>
+                <InputGroup className="mt-1">
+                  <InputGroup.Text id="label-first-value">
+                    {tipParams[0] && (
+                      <TestToolTip
+                        tipId={"params-1-" + props.test.id}
+                        tipText={tipParams[0]}
+                      />
+                    )}
+                    {testParams[0] && (
+                      <span className="ms-2">{testParams[0]}</span>
+                    )}
+                    :
+                  </InputGroup.Text>
+                  <Form.Control
+                    value={automated ? "" : localValue || ""}
+                    type="text"
+                    id="input-value-control"
+                    onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                      // use this input only if the test is not automated
+                      if (!automated) {
+                        handleValueChange(TestValueEventType.Value, e);
+                      }
+                    }}
+                    disabled={automated}
+                    min={1}
+                    max={9}
+                    step={1}
+                  />
+                </InputGroup>
+              </Col>
+              <Col>
+                <div className="d-flex justify-content-between px-1">
+                  {[1, 2, 3, 4, 5, 6, 7, 8, 9].map((num) => (
+                    <small key={num}>{num}</small>
+                  ))}
+                </div>
+                <Form.Range
+                  min={1}
+                  max={9}
+                  step={1}
+                  value={localValue}
+                  onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                    // use this input only if the test is not automated
+                    if (!automated) {
+                      handleValueChange(TestValueEventType.Value, e);
+                    }
+                  }}
+                />
+              </Col>
+            </Row>
+            {testParams.length > 1 && testParams[1] !== "evidence" && (
+              <>
+                <Row className="mt-1">
+                  <InputGroup className="mt-2">
+                    <InputGroup.Text id="label-second-value">
+                      {tipParams[1] && (
+                        <TestToolTip
+                          tipId={"params-2-" + props.test.id}
+                          tipText={tipParams[1]}
+                        />
+                      )}
+                      {testParams[1] && (
+                        <span className="ms-2">{testParams[1]}</span>
+                      )}
+                      :
+                    </InputGroup.Text>
+                    <Form.Control
+                      value={localThreshold || ""}
+                      type="text"
+                      id="input-value-community"
+                      onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                        handleValueChange(TestValueEventType.Threshold, e)
+                      }
+                      disabled={automated}
+                    />
+                  </InputGroup>
+                </Row>
+              </>
+            )}
+            {automated &&
+              testParams.length > 2 &&
+              testParams[2] !== "evidence" && (
+                <>
+                  <Row className="mt-1">
+                    <InputGroup className="mt-2">
+                      <InputGroup.Text id="label-second-value">
+                        {tipParams[2] && (
+                          <TestToolTip
+                            tipId={"params-3-" + props.test.id}
+                            tipText={tipParams[2]}
+                          />
+                        )}
+                        {testParams[2] && (
+                          <span className="ms-2">{testParams[2]}</span>
+                        )}
+                        :
+                      </InputGroup.Text>
+                      <Form.Control
+                        value={localValue || ""}
+                        type="text"
+                        id="input-value-community"
+                        onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                          if (automated) {
+                            handleValueChange(TestValueEventType.Value, e);
+                          }
+                        }}
+                      />
+                    </InputGroup>
+                  </Row>
+                </>
+              )}
+          </div>
+
+          {testParams[testParams.length - 1] === "evidence" && (
+            <EvidenceURLS
+              urls={props.test.evidence_url || []}
+              onListChange={onURLChange}
+              noTitle={true}
+            />
+          )}
+        </Col>
+      </Row>
+    </div>
+  );
+};

--- a/src/pages/motivations/components/MotivationMetric.tsx
+++ b/src/pages/motivations/components/MotivationMetric.tsx
@@ -4,7 +4,7 @@ import { defaultG069tokenIntrospection, defaultG069userInfo } from "@/config";
 import { TestAutoG069Form } from "@/pages/assessments/components/tests/TestAutoG069Form";
 import { TestAutoHttpsCheckForm } from "@/pages/assessments/components/tests/TestAutoHttpsCheckForm";
 import { TestAutoMd1Form } from "@/pages/assessments/components/tests/TestAutoMd1Form";
-import { TestBinaryParamForm } from "@/pages/assessments/components/tests/TestBinaryParam";
+import { TestBinaryParamForm } from "@/pages/assessments/components/tests/TestBinaryParamForm";
 import { TestValueFormParam } from "@/pages/assessments/components/tests/TestValueFormParam";
 import {
   TestAutoG069,

--- a/src/pages/tests/components/TestPreviewModal.tsx
+++ b/src/pages/tests/components/TestPreviewModal.tsx
@@ -1,6 +1,6 @@
 import { TestInput, TestParam } from "@/types/tests";
 import { EvidenceURLS, TestToolTip } from "@/pages/assessments/components";
-import { TestBinaryParamForm } from "@/pages/assessments/components/tests/TestBinaryParam";
+import { TestBinaryParamForm } from "@/pages/assessments/components/tests/TestBinaryParamForm";
 import { FaTrash } from "react-icons/fa";
 import {
   TestAutoG069,


### PR DESCRIPTION
…, percent and binary tests

## Summary

Created specialized component for the following types of tests: 
- TRL-Manual (component: `./TestTRLForm.tsx`)
- Ratio-Manual (component: `./TestRatioForm.tsx`)
- Percent-Manual (component: `./TestPercentForm.tsx`)

and updated the Binary test as well (component: `./TestBinaryParamForm.tsx` 

## Implementation

### Binary Test
In Existing binary test we updated the control and replaced the two check boxes (Yes / No) with a single Check switch. This component received recently a few stylization additions that changed the layout so we've tried to keep them intact

before:
<img width="838" height="100" alt="image" src="https://github.com/user-attachments/assets/c8f60b89-f7f1-47d3-826b-d5b685cc0ced" />

after:
<img width="805" height="122" alt="image" src="https://github.com/user-attachments/assets/55d19fb5-edfa-45b6-ab4e-6f61825d237b" />

### TRL Test
We handle the TRL test with a new component `TestTRLForm` and we've added a new discrete slider as a main control with which the user can select one of the 9 TRL levels. The input box has been refactored to take only single digit inputs between 1-9 and the two controls (input box and slider) are in sync

before:
<img width="1017" height="159" alt="image" src="https://github.com/user-attachments/assets/a865afc2-28b7-4658-8fea-5465e1d0b89b" />

after:
<img width="1017" height="169" alt="image" src="https://github.com/user-attachments/assets/8e01e4d7-b5c8-4f0e-8d39-c6efd0f7f001" />

### Ratio Test
The layout of the two parameters has been reorganized to be displayed as a horizontal fraction - Keep in mind the the value handling of the Ratio test is not yet finalized

before:
<img width="1026" height="261" alt="image" src="https://github.com/user-attachments/assets/92f48424-9427-4912-b702-dade963d8745" />

after:
<img width="1018" height="147" alt="image" src="https://github.com/user-attachments/assets/9e82bb86-4cc0-436a-be68-ce9407e18e2d" />


### Percentage Test
A slight update in the layout and the functionality of the input box. The input handling has been updated to accept only numbers between 0 and 100

before:
<img width="1018" height="188" alt="image" src="https://github.com/user-attachments/assets/74b78fc8-7668-45bf-9c2d-257e3d5f5879" />


after:
<img width="1025" height="186" alt="image" src="https://github.com/user-attachments/assets/3da7ac61-62a9-44e8-b46c-a3f7d2a57ac6" />


