### PR TITLE
CAT-949 create new assessment in two steps

### DIFF
--- a/src/api/services/assessments.ts
+++ b/src/api/services/assessments.ts
@@ -30,8 +30,14 @@ export function useCreateAssessment(token: string) {
       return APIClient(token).post("/v2/assessments", postData);
     },
     // for the time being redirect to assessment list
-    onSuccess: () => {
-      navigate(ROUTES.ASSESSMENTS.ROOT);
+    onSuccess: (resp) => {
+      const respData = resp as { data: { id?: string } };
+      if (respData.data.id) {
+        navigate(`${ROUTES.ASSESSMENTS.ROOT}/${respData.data.id}#assessment`);
+      } else {
+        // fallback if ID isn't returned for some reason
+        navigate(ROUTES.ASSESSMENTS.ROOT);
+      }
     },
   });
 }

--- a/src/pages/assessments/AssessmentEdit.tsx
+++ b/src/pages/assessments/AssessmentEdit.tsx
@@ -201,6 +201,13 @@ const AssessmentEdit = ({
     }
   }, [extraTab]);
 
+  useEffect(() => {
+    if (mode === AssessmentEditMode.Edit) {
+      setActiveTab(3);
+      setResetCriterionTab(true);
+    }
+  }, [mode, extraTab]);
+
   // TODO: Get all available pages in an infinite scroll not all sequentially.
   useEffect(() => {
     // gather all actor/org/type mappings in one array
@@ -284,6 +291,11 @@ const AssessmentEdit = ({
   }
 
   function handleNextTab() {
+    // in case we are creating a new assessment don't move over second tab
+    if (mode === AssessmentEditMode.Create && activeTab > 1) {
+      return;
+    }
+
     if (
       (mode === AssessmentEditMode.Import && activeTab < 4) ||
       activeTab < 3
@@ -618,7 +630,9 @@ const AssessmentEdit = ({
       ? importDone
         ? activeTab === 1 || (wizardTabActive && activeTab <= 3)
         : false
-      : wizardTabActive && activeTab < 3;
+      : mode === AssessmentEditMode.Create
+        ? wizardTabActive && activeTab < 2
+        : wizardTabActive && activeTab < 3;
 
   // check if assessment has automated test groups
   const hasAutoGroups =
@@ -783,21 +797,23 @@ const AssessmentEdit = ({
                   )}
                 </Nav.Link>
               </Nav.Item>
-              <Nav.Item
-                className={`bg-light border rounded me-2 ${
-                  !wizardTabActive ? "opacity-25" : ""
-                }`}
-              >
-                <Nav.Link
-                  eventKey={`step-${3 + extraTab}`}
-                  disabled={!wizardTabActive}
+              {mode !== AssessmentEditMode.Create && (
+                <Nav.Item
+                  className={`bg-light border rounded me-2 ${
+                    !wizardTabActive ? "opacity-25" : ""
+                  }`}
                 >
-                  <span className="badge text-black bg-light me-2">
-                    {`${t("page_assessment_edit.step")} ${3 + extraTab}.`}
-                  </span>{" "}
-                  {t("assessment")}
-                </Nav.Link>
-              </Nav.Item>
+                  <Nav.Link
+                    eventKey={`step-${3 + extraTab}`}
+                    disabled={!wizardTabActive}
+                  >
+                    <span className="badge text-black bg-light me-2">
+                      {`${t("page_assessment_edit.step")} ${3 + extraTab}.`}
+                    </span>{" "}
+                    {t("assessment")}
+                  </Nav.Link>
+                </Nav.Item>
+              )}
             </Nav>
           </Card.Header>
           <Card.Body>

--- a/src/pages/assessments/components/AssessmentInfo.tsx
+++ b/src/pages/assessments/components/AssessmentInfo.tsx
@@ -40,7 +40,8 @@ interface AssessmentInfoProps {
 }
 
 export const AssessmentInfo = (props: AssessmentInfoProps) => {
-  const [accKeys, setAccKeys] = useState<string[]>([]);
+  // always have first accordeon item open by default
+  const [accKeys, setAccKeys] = useState<string[]>(["acc-1"]);
   const { t } = useTranslation();
   const toggleAccKey = (name: string) => {
     if (accKeys.includes(name)) {
@@ -49,6 +50,8 @@ export const AssessmentInfo = (props: AssessmentInfoProps) => {
       setAccKeys([...accKeys, name]);
     }
   };
+
+  console.log(accKeys);
 
   // call use effect to react to required field changes
   useEffect(() => {
@@ -65,7 +68,7 @@ export const AssessmentInfo = (props: AssessmentInfoProps) => {
   }, [props.reqFields]);
 
   return (
-    <Accordion defaultActiveKey={["acc-1"]} activeKey={accKeys} alwaysOpen>
+    <Accordion activeKey={accKeys}>
       <Accordion.Item eventKey="acc-1" id="accordion_general">
         <Accordion.Header onClick={() => toggleAccKey("acc-1")}>
           <span>

--- a/src/pages/assessments/components/AssessmentSelectSubject.tsx
+++ b/src/pages/assessments/components/AssessmentSelectSubject.tsx
@@ -45,69 +45,73 @@ export const AssessmentSelectSubject = (
 
   return (
     <>
-      <div className="mb-">
-        <h6>{t("page_assessment_edit.select_subject_text")}</h6>
-      </div>
-      <Row className="mb-2">
-        <div className="input-group mb-3">
-          <label className="input-group-text" htmlFor="inputGroupSelect01">
-            {" "}
-            {t("fields.subject")} (*)
-          </label>
-          <select
-            className="form-select"
-            id="subject_id"
-            value={selected}
-            onChange={(e) => {
-              const subject = data?.content
-                .filter((t) => t.id === parseInt(e.target.value))
-                .map((t) => {
-                  return t;
-                });
-              if (subject !== undefined) {
-                props.onSubjectChange({
-                  db_id: subject[0].id,
-                  name: subject[0].name,
-                  type: subject[0].type,
-                  id: subject[0].subject_id,
-                });
-                setSelected(e.target.value);
-              }
-            }}
-          >
-            <option disabled value={-1}>
-              {t("page_assessment_edit.select_object")}
-            </option>
-            {data?.content &&
-              data?.content.map((t, i) => {
-                return (
-                  <option key={`type-${i}`} value={t.id}>
-                    {t.name}-{t.type}-{t.subject_id}
-                  </option>
-                );
-              })}
-          </select>
-          <button
-            className={
-              selected !== "-1"
-                ? "btn btn-outline-danger"
-                : "btn btn-outline-danger disabled"
-            }
-            type="button"
-            disabled={selected === "-1" ? true : false}
-            onClick={() => {
-              setSelected("-1");
-              props.onSubjectChange({
-                id: "",
-                name: "",
-                type: "",
-              });
-            }}
-          >
-            {t("buttons.clear_selection")}
-          </button>
-        </div>
-      </Row>
+      {data?.content && data.content.length > 0 && (
+        <>
+          <div className="mb-">
+            <h6>{t("page_assessment_edit.select_subject_text")}</h6>
+          </div>
+          <Row className="mb-2">
+            <div className="input-group mb-3">
+              <label className="input-group-text" htmlFor="inputGroupSelect01">
+                {" "}
+                {t("fields.subject")} (*)
+              </label>
+              <select
+                className="form-select"
+                id="subject_id"
+                value={selected}
+                onChange={(e) => {
+                  const subject = data?.content
+                    .filter((t) => t.id === parseInt(e.target.value))
+                    .map((t) => {
+                      return t;
+                    });
+                  if (subject !== undefined) {
+                    props.onSubjectChange({
+                      db_id: subject[0].id,
+                      name: subject[0].name,
+                      type: subject[0].type,
+                      id: subject[0].subject_id,
+                    });
+                    setSelected(e.target.value);
+                  }
+                }}
+              >
+                <option disabled value={-1}>
+                  {t("page_assessment_edit.select_object")}
+                </option>
+                {data?.content &&
+                  data?.content.map((t, i) => {
+                    return (
+                      <option key={`type-${i}`} value={t.id}>
+                        {t.name}-{t.type}-{t.subject_id}
+                      </option>
+                    );
+                  })}
+              </select>
+              <button
+                className={
+                  selected !== "-1"
+                    ? "btn btn-outline-danger"
+                    : "btn btn-outline-danger disabled"
+                }
+                type="button"
+                disabled={selected === "-1" ? true : false}
+                onClick={() => {
+                  setSelected("-1");
+                  props.onSubjectChange({
+                    id: "",
+                    name: "",
+                    type: "",
+                  });
+                }}
+              >
+                {t("buttons.clear_selection")}
+              </button>
+            </div>
+          </Row>
+        </>
+      )}
       <Row>
         <Row>
           <InputGroup className="mb-1">


### PR DESCRIPTION
### Goal

We want to quickly lead the user to the creation of the assessment before filling in any questions

Allow the user to create the assessment by present only the first two steps: `Step 1. Actor` and `Step 2. Submision`. After that the user must hit Create to create the assessment. Once the assessment is created the user is automatically navigated into edit mode and the third step appears `Step 3. Assessment` giving the ability to fill in questions.

### Implementation
- [x] Refactor CreateAssessment backend hook to lead to editing the assessment on success
- [x] Make the third tab active when editing the assessment
- [x] Change Next / Prev button limits
- [x] Update subject info form: The combo box to select existing subjects is hidden when no subjects exist