### PR TITLE
[CAT-975] - Add Live Test Preview to Assessment Builder with Interactive Feedback

### DIFF
--- a/src/custom-hooks/usePubSub/events/assessmentBuilder.ts
+++ b/src/custom-hooks/usePubSub/events/assessmentBuilder.ts
@@ -1,0 +1,3 @@
+export const CreateFormMotivationTest = new CustomEvent("CreateMotivationTest");
+
+export const CancelFormMotivationTest = new CustomEvent("CancelMotivationTest");

--- a/src/custom-hooks/usePubSub/usePublish.ts
+++ b/src/custom-hooks/usePubSub/usePublish.ts
@@ -1,0 +1,31 @@
+import { useCallback, useMemo } from "react";
+
+const usePublish = <T = unknown>(eventName: string, args?: T) => {
+  const nativeEvent = useMemo(
+    () =>
+      new CustomEvent(eventName, {
+        detail: args,
+      }),
+    [eventName, args],
+  );
+
+  const publish = useCallback(
+    <U = T>(instanceEventName?: string, callbackArgs?: U) => {
+      if (instanceEventName) {
+        document.dispatchEvent(
+          new CustomEvent(instanceEventName, {
+            detail: callbackArgs,
+          }),
+        );
+        return;
+      }
+
+      document.dispatchEvent(nativeEvent);
+    },
+    [nativeEvent],
+  );
+
+  return { publish, nativeEvent };
+};
+
+export default usePublish;

--- a/src/custom-hooks/usePubSub/useSubscribe.ts
+++ b/src/custom-hooks/usePubSub/useSubscribe.ts
@@ -1,0 +1,24 @@
+/* eslint-disable react-hooks/exhaustive-deps */
+
+import { useEffect } from "react";
+
+const useSubscribe = <T = unknown>(
+  eventName: string,
+  callback: (detail: T) => void,
+  dependencies: unknown[] = [],
+) => {
+  const eventHandler = (e: Event) => {
+    const customEvent = e as CustomEvent<T>;
+    callback(customEvent.detail);
+  };
+
+  useEffect(() => {
+    document.addEventListener(eventName, eventHandler, { passive: true });
+
+    return () => {
+      document.removeEventListener(eventName, eventHandler);
+    };
+  }, [eventName, ...dependencies]);
+};
+
+export default useSubscribe;

--- a/src/pages/assessment-builder/AssessmentBuilder.module.css
+++ b/src/pages/assessment-builder/AssessmentBuilder.module.css
@@ -75,7 +75,7 @@
   display: flex;
   min-height: 60px;
   padding: 0.8rem 1rem;
-  border-bottom: 1px solid #e9ecef;
+  border-bottom: 2px solid #dbdfe3;
 }
 
 .structure-column .column-header {
@@ -121,12 +121,12 @@
 .column-content {
   position: relative;
   flex: 1;
-  padding: 1rem 0.5rem;
+  padding: 0.8rem 0.5rem;
   overflow-y: auto;
 }
 
 .column-content:has(.builder-preview) {
-  padding: 1rem;
+  padding: 1.5rem;
   overflow: hidden;
   background: #f8f9fa;
 }
@@ -138,7 +138,7 @@
 
 .principle-form h4 {
   padding-bottom: 0.3rem;
-  margin-bottom: 0.7rem;
+  margin-bottom: 0.3rem;
   font-size: 1rem;
   font-weight: 600;
   color: #374151;
@@ -207,14 +207,21 @@
 }
 
 .form-actions-tests {
-  position: absolute;
-  bottom: 12px;
-  width: 98%;
+  display: flex;
+  justify-content: space-between;
+  padding-top: 0.8rem;
+  margin-top: 0.5rem;
+  border-top: 1px solid #e5e7eb;
 }
 
 .form-actions-tests .btn-primary {
-  position: absolute;
-  right: 16px;
+  height: 36px;
+  padding: 0.4rem 0.5rem;
+}
+
+.form-actions-tests .btn-secondary {
+  height: 36px;
+  padding: 0.4rem 0.5rem;
 }
 
 .header-actions .btn-secondary,
@@ -452,7 +459,6 @@
 .column-content .builder-preview {
   height: 100%;
   padding: 2rem;
-  margin: 0.5rem;
   overflow: auto;
   background: #fff;
   border-radius: 0.5rem;
@@ -788,7 +794,6 @@
   }
 
   .form-actions-tests {
-    position: static;
     width: 100%;
     margin-top: 0.5rem;
   }
@@ -823,7 +828,7 @@
   .header-content {
     flex-direction: column;
     gap: 1rem;
-    align-items: flex-start;
+    align-items: flex-end;
   }
 }
 
@@ -961,23 +966,6 @@
 .config-cancel-btn:hover {
   background: #f9fafb;
   border-color: #9ca3af;
-}
-
-.config-save-btn {
-  padding: 0.3rem 1rem;
-  font-size: 0.875rem;
-  font-weight: 500;
-  color: white;
-  cursor: pointer;
-  background: #3b82f6;
-  border: none;
-  border-radius: 0.375rem;
-  transition: all 0.2s;
-}
-
-.config-save-btn:hover {
-  background: #2563eb;
-  box-shadow: 0 2px 4px rgb(59 130 246 / 20%);
 }
 
 /* Error Message Styles */
@@ -1363,9 +1351,20 @@
   transform: scale(1.1);
 }
 
+.test-preview-container {
+  position: relative;
+}
+
+.test-preview-modal {
+  margin-top: 1rem;
+  margin-bottom: 2rem;
+  box-shadow: 0 2px 4px rgb(0 0 0 / 20%);
+}
+
 .test-method-item {
   padding: 0.5rem 0.75rem;
   font-weight: 500;
+  cursor: pointer;
   border-bottom: 1px solid #f3f4f6;
 }
 

--- a/src/pages/assessment-builder/AssessmentBuilder.tsx
+++ b/src/pages/assessment-builder/AssessmentBuilder.tsx
@@ -26,6 +26,7 @@ import AssessmentBuilderCriteria from "./AssessmentBuilderCriteria";
 import AssessmentBuilderPrinciples from "./AssessmentBuilderPrinciples";
 import AssessmentBuilderTests from "./AssessmentBuilderTests";
 import styles from "./AssessmentBuilder.module.css";
+import { TestInput, TestParam } from "@/types/tests";
 
 function AssessmentBuilder() {
   const { mtvId, actId } = useParams<{
@@ -50,6 +51,16 @@ function AssessmentBuilder() {
   });
   const [isPrincipleSelected, setIsPrincipleSelected] = useState(false);
   const [isTestSelected, setIsTestSelected] = useState(false);
+  const [test, setTest] = useState<TestInput>({
+    tes: "",
+    label: "",
+    description: "",
+    test_method_id: "",
+    label_test_definition: "",
+    param_type: "onscreen",
+  });
+  const [params, setParams] = useState<TestParam[]>([]);
+  const [hasEvidence, setHasEvidence] = useState(false);
 
   const {
     data: assessmentData,
@@ -88,22 +99,6 @@ function AssessmentBuilder() {
             assessmentData?.principles?.[0]?.criteria?.length > 0 ? 0 : -1,
         });
       }
-    } else if (
-      ((builderState.formMode !== "none" &&
-        builderState.entityMode !== "none" &&
-        builderState.entityMode !== "criterion") ||
-        (builderState.formMode === "edit" &&
-          builderState.entityMode === "criterion")) &&
-      assessmentData &&
-      assessmentData?.principles?.length === 0
-    ) {
-      setBuilderState({
-        formMode: "none",
-        entityMode: "none",
-        selectedId: "",
-        selectedPrincipleIndex: -1,
-        selectedCriterionIndex: -1,
-      });
     }
   }, [assessmentData, builderState.formMode, builderState.entityMode]);
 
@@ -265,20 +260,20 @@ function AssessmentBuilder() {
   }, [metricData, mtrHasNextPage, mtrFetchNextPage]);
 
   useEffect(() => {
-    return () => {
-      setAssessment([]);
-      setMotivationMetrics([]);
-      setBuilderState({
-        formMode: "none",
-        entityMode: "none",
-        selectedId: "",
-        selectedPrincipleIndex: -1,
-        selectedCriterionIndex: -1,
-      });
-      setIsPrincipleSelected(false);
-      setIsTestSelected(false);
-    };
-  }, []);
+    setAssessment([]);
+    setMotivationMetrics([]);
+    setBuilderState({
+      formMode: "none",
+      entityMode: "none",
+      selectedId: "",
+      selectedPrincipleIndex: -1,
+      selectedCriterionIndex: -1,
+    });
+    setIsPrincipleSelected(false);
+    setIsTestSelected(false);
+    setHasEvidence(false);
+    setParams([]);
+  }, [mtvId, actId]);
 
   const handleAddCriterion = () => {
     setBuilderState({
@@ -411,6 +406,9 @@ function AssessmentBuilder() {
               setIsPrincipleSelected={setIsPrincipleSelected}
               isTestSelected={isTestSelected}
               setIsTestSelected={setIsTestSelected}
+              test={test}
+              params={params}
+              hasEvidence={hasEvidence}
             />
           </div>
 
@@ -541,6 +539,12 @@ function AssessmentBuilder() {
                   refetchAssessmentData={refetchAssessmentData}
                   mtvId={mtvId || ""}
                   mtrId={getMetricId()}
+                  test={test}
+                  setTest={setTest}
+                  params={params}
+                  setParams={setParams}
+                  hasEvidence={hasEvidence}
+                  setHasEvidence={setHasEvidence}
                 />
               )}
             </div>

--- a/src/pages/assessment-builder/AssessmentBuilderCriteria.tsx
+++ b/src/pages/assessment-builder/AssessmentBuilderCriteria.tsx
@@ -82,18 +82,6 @@ function AssessmentBuilderCriteria({
   const imperativesDropdownRef = useRef<HTMLDivElement>(null);
   const scrollableContainerRef = useRef<HTMLDivElement>(null);
 
-  // useEffect(() => {
-  //   if (assessment?.length === 0) {
-  //     setPrincipleTag(null);
-  //     setCriterionForm({
-  //       cri: "",
-  //       label: "",
-  //       description: "",
-  //       imperative: "",
-  //     });
-  //   }
-  // }, [assessment, setBuilderState]);
-
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
       if (

--- a/src/pages/assessment-builder/AssessmentBuilderMetric.tsx
+++ b/src/pages/assessment-builder/AssessmentBuilderMetric.tsx
@@ -54,6 +54,10 @@ function AssessmentBuilderMetric({
   onClose,
 }: AssessmentBuilderMetricProps) {
   const { keycloak, registered } = useContext(AuthContext)!;
+  const { t } = useTranslation();
+  const alert = useRef<AlertInfo>({
+    message: "",
+  });
   const [isLoading, setIsLoading] = useState(false);
   const [showErrors, setShowErrors] = useState(false);
 
@@ -76,14 +80,12 @@ function AssessmentBuilderMetric({
 
   const [metricConfig, setMetricConfig] =
     useState<MetricConfiguration>(defaultConfig);
-  const { t } = useTranslation();
-  const alert = useRef<AlertInfo>({
-    message: "",
-  });
+
+  const [initialAdvancedSettigns, setInitialAdvancedSettigs] =
+    useState<MetricConfiguration>(defaultConfig);
 
   useEffect(() => {
     setShowErrors(false);
-
     // Find the current criterion in the assessment data
     const currentCriterion = assessment
       ?.flatMap((principle) => principle.criteria)
@@ -116,6 +118,7 @@ function AssessmentBuilderMetric({
               0,
           };
           setMetricConfig(existingMetricConfig);
+          setInitialAdvancedSettigs(existingMetricConfig);
           return;
         }
       }
@@ -123,6 +126,7 @@ function AssessmentBuilderMetric({
 
     // If no existing configuration found, use default config
     setMetricConfig(defaultConfig);
+    setInitialAdvancedSettigs(defaultConfig);
   }, [
     defaultConfig,
     criterionPidGraph,
@@ -171,8 +175,6 @@ function AssessmentBuilderMetric({
         .find((criterion) => criterion.id === builderState.selectedId)
         ?.metric?.db_id;
 
-      console.log("algorithmDbId:", algorithmDbId);
-
       if (algorithmDbId) {
         const promise = mutateUpdateMotivationAlgorithm
           .mutateAsync()
@@ -205,6 +207,16 @@ function AssessmentBuilderMetric({
       setIsLoading(false);
     }
   };
+
+  const haveAdvancedSettingsChanged = useMemo(() => {
+    return (
+      initialAdvancedSettigns.type_algorithm_id !==
+        metricConfig.type_algorithm_id ||
+      initialAdvancedSettigns.type_benchmark_id !==
+        metricConfig.type_benchmark_id ||
+      initialAdvancedSettigns.value_benchmark !== metricConfig.value_benchmark
+    );
+  }, [metricConfig, initialAdvancedSettigns]);
 
   return (
     <div className={styles["algorithm-config-content"]}>
@@ -524,8 +536,9 @@ function AssessmentBuilderMetric({
           Cancel
         </button>
         <button
-          className={styles["config-save-btn"]}
+          className={styles["btn-primary"]}
           onClick={handleSaveAlgorithmConfiguration}
+          disabled={!haveAdvancedSettingsChanged}
         >
           {isLoading ? "Saving..." : "Save Configuration"}
         </button>

--- a/src/pages/assessment-builder/AssessmentBuilderPreview.tsx
+++ b/src/pages/assessment-builder/AssessmentBuilderPreview.tsx
@@ -7,6 +7,8 @@ import {
   AssessmentCriterionImperative,
   MetricFull,
   AlertInfo,
+  AssessmentTest,
+  RegistryResource,
 } from "@/types";
 import { FaExclamationCircle, FaInfoCircle, FaSlidersH } from "react-icons/fa";
 import TestPreviewModal from "../tests/components/TestPreviewModal";
@@ -16,12 +18,18 @@ import {
   useUpdateMotivationMetricTests,
 } from "@/api";
 import { AuthContext } from "@/auth";
-import { RegistryTest } from "@/types/tests";
+import { RegistryTest, TestInput, TestParam } from "@/types/tests";
 import { relMtvMetricTest } from "@/config";
 import toast from "react-hot-toast";
 import styles from "./AssessmentBuilder.module.css";
 import AssessmentBuilderDeleteModal from "./AssessmentBuilderDeleteModal";
 import { removeTestFromUntaggedCriterion } from "./utils/assessmentBuilderUtils";
+import { useGetAllTestMethods } from "@/api/services/registry";
+import {
+  CancelFormMotivationTest,
+  CreateFormMotivationTest,
+} from "@/custom-hooks/usePubSub/events/assessmentBuilder";
+import usePublish from "@/custom-hooks/usePubSub/usePublish";
 
 interface AssessmentBuilderPreviewProps {
   assessment: AssessmentPrinciple[];
@@ -37,6 +45,9 @@ interface AssessmentBuilderPreviewProps {
   setIsPrincipleSelected: React.Dispatch<React.SetStateAction<boolean>>;
   isTestSelected: boolean;
   setIsTestSelected: React.Dispatch<React.SetStateAction<boolean>>;
+  test: TestInput;
+  params: TestParam[];
+  hasEvidence: boolean;
 }
 
 function AssessmentBuilderPreview({
@@ -53,6 +64,9 @@ function AssessmentBuilderPreview({
   setIsPrincipleSelected,
   isTestSelected,
   setIsTestSelected,
+  test,
+  params,
+  hasEvidence,
 }: AssessmentBuilderPreviewProps) {
   const { keycloak, registered } = useContext(AuthContext)!;
   const [isConfiguring, setIsConfiguring] = useState(false);
@@ -63,10 +77,16 @@ function AssessmentBuilderPreview({
     testLabel: "",
   });
   const { t } = useTranslation();
-
   const alert = useRef<AlertInfo>({
     message: "",
   });
+
+  const { publish: saveTestCreation } = usePublish<void>(
+    CreateFormMotivationTest.type,
+  );
+  const { publish: cancelTestCreation } = usePublish<void>(
+    CancelFormMotivationTest.type,
+  );
 
   useEffect(() => {
     if (
@@ -123,6 +143,18 @@ function AssessmentBuilderPreview({
       isRegistered: showDeleteModal?.testId && registered ? registered : false,
     },
   );
+
+  const { data: testMethodsData } = useGetAllTestMethods({
+    size: 100,
+    token: keycloak?.token || "",
+    isRegistered: registered,
+    search: "",
+    enabled: true,
+  });
+
+  // Extract test methods from the paginated data structure
+  const testMethods: RegistryResource[] =
+    testMethodsData?.pages?.flatMap((page) => page.content) || [];
 
   useEffect(() => {
     setSelectedTests(
@@ -182,6 +214,39 @@ function AssessmentBuilderPreview({
     });
   };
 
+  const getTestParams = (test: AssessmentTest) => {
+    // Handle single values vs pipe-separated values
+    const names =
+      "params" in test && test.params
+        ? typeof test.params === "string" && test.params.includes("|")
+          ? test.params.split("|")
+          : [test.params]
+        : [];
+
+    const texts =
+      "text" in test && test.text
+        ? typeof test.text === "string" && test.text.includes("|")
+          ? test.text.split("|")
+          : [test.text]
+        : [];
+
+    const tooltips =
+      "tool_tip" in test && test.tool_tip
+        ? typeof test.tool_tip === "string" && test.tool_tip.includes("|")
+          ? test.tool_tip.split("|")
+          : [test.tool_tip]
+        : [];
+
+    const maxLength = Math.max(names.length, texts.length, tooltips.length);
+
+    return Array.from({ length: maxLength }, (_, index) => ({
+      id: index,
+      name: names[index] || "",
+      text: texts[index] || "",
+      tooltip: tooltips[index] || "",
+    }));
+  };
+
   const confirmDeleteTest = () => {
     if (showDeleteModal.testId) {
       handleTestDelete(showDeleteModal.testId);
@@ -227,13 +292,32 @@ function AssessmentBuilderPreview({
                   )}
                 </div>
                 <div className={styles["advanced-settings-container"]}>
-                  <button
-                    className={styles["advanced-settings-btn"]}
-                    onClick={() => setIsConfiguring((prev) => !prev)}
-                    disabled={isConfiguring}
-                  >
-                    <FaSlidersH /> Advanced Settings
-                  </button>
+                  {isConfiguring || !isPrincipleAssigned ? (
+                    <OverlayTrigger
+                      placement="top"
+                      overlay={
+                        <Tooltip id="test-section-disabled-tooltip">
+                          You must add a principle first in order to can change
+                          the advanced settings
+                        </Tooltip>
+                      }
+                    >
+                      <button
+                        className={styles["advanced-settings-btn"]}
+                        onClick={() => setIsConfiguring((prev) => !prev)}
+                        disabled={isConfiguring || !isPrincipleAssigned}
+                      >
+                        <FaSlidersH /> Advanced Settings
+                      </button>
+                    </OverlayTrigger>
+                  ) : (
+                    <button
+                      className={styles["advanced-settings-btn"]}
+                      onClick={() => setIsConfiguring((prev) => !prev)}
+                    >
+                      <FaSlidersH /> Advanced Settings
+                    </button>
+                  )}
 
                   {/* Advanced Settings Modal positioned relative to button */}
                   {isConfiguring && (
@@ -454,6 +538,29 @@ function AssessmentBuilderPreview({
                   </div>
                 </OverlayTrigger>
               </div>
+              {isTestSelected && builderState.formMode === "new" && (
+                <TestPreviewModal
+                  test={{
+                    tes: test.tes || "",
+                    label: test.label || "",
+                    description: test.description || "",
+                  }}
+                  params={params}
+                  testMethodName={
+                    testMethods?.find(
+                      (testMethod) => testMethod?.id === test?.test_method_id,
+                    )?.label || ""
+                  }
+                  hasEvidenceParam={hasEvidence}
+                  onTestCancel={() =>
+                    cancelTestCreation(CancelFormMotivationTest.type, undefined)
+                  }
+                  onTestSave={() =>
+                    saveTestCreation(CreateFormMotivationTest.type, undefined)
+                  }
+                />
+              )}
+
               {(() => {
                 const tests =
                   assessment[builderState.selectedPrincipleIndex || 0]
@@ -475,46 +582,7 @@ function AssessmentBuilderPreview({
                               label: test.name || "",
                               description: test.description || "",
                             }}
-                            params={(() => {
-                              // Handle single values vs pipe-separated values
-                              const names =
-                                "params" in test && test.params
-                                  ? typeof test.params === "string" &&
-                                    test.params.includes("|")
-                                    ? test.params.split("|")
-                                    : [test.params]
-                                  : [];
-                              const texts =
-                                "text" in test && test.text
-                                  ? typeof test.text === "string" &&
-                                    test.text.includes("|")
-                                    ? test.text.split("|")
-                                    : [test.text]
-                                  : [];
-                              const tooltips =
-                                "tool_tip" in test && test.tool_tip
-                                  ? typeof test.tool_tip === "string" &&
-                                    test.tool_tip.includes("|")
-                                    ? test.tool_tip.split("|")
-                                    : [test.tool_tip]
-                                  : [];
-
-                              const maxLength = Math.max(
-                                names.length,
-                                texts.length,
-                                tooltips.length,
-                              );
-
-                              return Array.from(
-                                { length: maxLength },
-                                (_, index) => ({
-                                  id: index,
-                                  name: names[index] || "",
-                                  text: texts[index] || "",
-                                  tooltip: tooltips[index] || "",
-                                }),
-                              );
-                            })()}
+                            params={getTestParams(test)}
                             testMethodName={test.type}
                             onTestDelete={() =>
                               setShowDeleteModal({

--- a/src/pages/assessment-builder/AssessmentBuilderStructure.tsx
+++ b/src/pages/assessment-builder/AssessmentBuilderStructure.tsx
@@ -381,7 +381,7 @@ function AssessmentBuilderStructure({
                   <FaFolder />
                 </span>
                 <span className={styles["principle-display"]}>
-                  Criteria with no Principles
+                  Criteria without Principle
                 </span>
                 <span style={{ marginLeft: "auto", marginRight: "8px" }}>
                   {collapsedPrinciples.has("untagged") ? (

--- a/src/pages/assessment-builder/AssessmentBuilderTests.tsx
+++ b/src/pages/assessment-builder/AssessmentBuilderTests.tsx
@@ -28,6 +28,11 @@ import { useUpdateMotivationMetricTests } from "@/api";
 import { relMtvMetricTest } from "@/config";
 import toast from "react-hot-toast";
 import { addTestToUntaggedCriterion } from "./utils/assessmentBuilderUtils";
+import useSubscribe from "@/custom-hooks/usePubSub/useSubscribe";
+import {
+  CancelFormMotivationTest,
+  CreateFormMotivationTest,
+} from "@/custom-hooks/usePubSub/events/assessmentBuilder";
 
 interface AssessmentBuilderTestsProps {
   mtvId: string;
@@ -38,6 +43,12 @@ interface AssessmentBuilderTestsProps {
   setBuilderState: React.Dispatch<React.SetStateAction<AssessmentBuilderState>>;
   refetchAssessmentData: () => void;
   setIsTestSelected: React.Dispatch<React.SetStateAction<boolean>>;
+  test: TestInput;
+  setTest: React.Dispatch<React.SetStateAction<TestInput>>;
+  params: TestParam[];
+  setParams: React.Dispatch<React.SetStateAction<TestParam[]>>;
+  hasEvidence: boolean;
+  setHasEvidence: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
 function AssessmentBuilderTests({
@@ -49,6 +60,12 @@ function AssessmentBuilderTests({
   setAssessment,
   setBuilderState,
   setIsTestSelected,
+  test,
+  setTest,
+  params,
+  setParams,
+  hasEvidence,
+  setHasEvidence,
 }: AssessmentBuilderTestsProps) {
   const { t } = useTranslation();
   const { keycloak, registered } = useContext(AuthContext)!;
@@ -56,22 +73,31 @@ function AssessmentBuilderTests({
     message: "",
   });
 
-  const [test, setTest] = useState<TestInput>({
-    tes: "",
-    label: "",
-    description: "",
-    test_method_id: "",
-    label_test_definition: "",
-    param_type: "onscreen",
-  });
-  const [params, setParams] = useState<TestParam[]>([]);
-  const [hasEvidence, setHasEvidence] = useState(false);
   const [showErrors, setShowErrors] = useState(false);
   const [searchTerm, setSearchTerm] = useState("");
   const [filterType, setFilterType] = useState("all");
-  const [selectedTestId, setSelectedTestId] = useState<string>("");
+  const [testId, setTestId] = useState<string>("");
 
   const formMode = builderState.formMode;
+
+  const resetTestStates = useCallback(() => {
+    setTest({
+      tes: "",
+      label: "",
+      description: "",
+      test_method_id: "",
+      test_question: "",
+      test_params: "",
+      tool_tip: "",
+      param_type: "onscreen",
+    });
+    setParams([]);
+    setHasEvidence(false);
+    setShowErrors(false);
+    setSearchTerm("");
+    setFilterType("all");
+    setTestId("");
+  }, [setTest, setParams, setHasEvidence]);
 
   const getSearchString = () => {
     if (filterType === "manual") {
@@ -139,8 +165,10 @@ function AssessmentBuilderTests({
   });
 
   // Extract test methods from the paginated data structure
-  const testMethods: RegistryResource[] =
-    testMethodsData?.pages?.flatMap((page) => page.content) || [];
+  const testMethods: RegistryResource[] = useMemo(
+    () => testMethodsData?.pages?.flatMap((page) => page.content) || [],
+    [testMethodsData?.pages],
+  );
 
   const filteredTestMethods = testMethods.filter((method) => {
     const matchesSearch = method.label
@@ -156,25 +184,28 @@ function AssessmentBuilderTests({
     return matchesSearch;
   });
 
-  const addNewParams = useCallback((numberOfParams = 1) => {
-    const tmpParams = Array.from(
-      { length: numberOfParams },
-      (_, i) => i + 1,
-    )?.map((i) => ({
-      id: i,
-      name: "",
-      text: "",
-      tooltip: "",
-    }));
-    setParams(tmpParams);
-  }, []);
+  const addNewParams = useCallback(
+    (numberOfParams = 1) => {
+      const tmpParams = Array.from(
+        { length: numberOfParams },
+        (_, i) => i + 1,
+      )?.map((i) => ({
+        id: i,
+        name: "",
+        text: "",
+        tooltip: "",
+      }));
+      setParams(tmpParams);
+    },
+    [setParams],
+  );
 
-  // Initialize test method to first available method
+  // Initialize test method to "Binary-Manual" if no method is selected
   useEffect(() => {
     if (testMethods?.length > 0 && !test?.test_method_id) {
       setTest((prevTest) => ({
         ...prevTest,
-        test_method_id: testMethods[0]?.id || "",
+        test_method_id: "pid_graph:8D79984F",
       }));
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -191,6 +222,8 @@ function AssessmentBuilderTests({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [test.test_method_id, JSON.stringify(testMethods)]);
 
+  useEffect(() => () => resetTestStates(), [resetTestStates]);
+
   const updateParam = (id: number, field: keyof TestParam, value: string) => {
     setParams((prev) =>
       prev.map((param) =>
@@ -199,7 +232,7 @@ function AssessmentBuilderTests({
     );
   };
 
-  const updateParamTestDef = () => {
+  const updateParamTestDef = useCallback(() => {
     let names = "";
     let text = "";
     let tips = "";
@@ -229,9 +262,9 @@ function AssessmentBuilderTests({
       test_params: names,
       tool_tip: tips,
     }));
-  };
+  }, [params, hasEvidence, setTest]);
 
-  const handleValidate = (): boolean => {
+  const handleValidate = useCallback((): boolean => {
     const isValid =
       test.tes.trim() !== "" &&
       test.label.trim() !== "" &&
@@ -246,17 +279,19 @@ function AssessmentBuilderTests({
 
     setShowErrors(!isValid);
     return isValid;
-  };
+  }, [test, params]);
 
-  const handleCancel = () => {
+  const handleCancel = useCallback(() => {
+    resetTestStates();
     setBuilderState((prevState) => ({
       ...prevState,
-      entityMode: "none",
-      formMode: "none",
+      entityMode: "criterion",
+      formMode: "edit",
     }));
-  };
+    setIsTestSelected(false);
+  }, [resetTestStates, setBuilderState, setIsTestSelected]);
 
-  const handleSubmit = async () => {
+  const handleSubmit = useCallback(() => {
     if (formMode === "new") {
       if (!handleValidate()) {
         return;
@@ -292,13 +327,9 @@ function AssessmentBuilderTests({
       relation: relMtvMetricTest,
     }));
 
-    if (
-      formMode === "select" &&
-      selectedTestId &&
-      !existingTestIds.includes(selectedTestId)
-    ) {
+    if (formMode === "select" && testId && !existingTestIds.includes(testId)) {
       metricAssignment.push({
-        test_id: selectedTestId,
+        test_id: testId,
         relation: relMtvMetricTest,
       });
     }
@@ -341,6 +372,7 @@ function AssessmentBuilderTests({
               alert.current = {
                 message: t("page_motivations.toast_assign_metric_success"),
               };
+              resetTestStates();
             });
 
           toast.promise(assignTestsToMetricPromise, {
@@ -376,9 +408,7 @@ function AssessmentBuilderTests({
         .then(() => {
           refetchAssessmentData();
           // Add test to untagged criterion if needed
-          const selectedTest = allTests.find(
-            (test) => test.id === selectedTestId,
-          );
+          const selectedTest = allTests.find((test) => test.id === testId);
           if (selectedTest) {
             addTestToUntaggedCriterion({
               testData: selectedTest,
@@ -391,6 +421,7 @@ function AssessmentBuilderTests({
           alert.current = {
             message: t("page_motivations.toast_assign_metric_success"),
           };
+          resetTestStates();
         });
 
       toast.promise(assignTestsToMetricPromise, {
@@ -401,7 +432,30 @@ function AssessmentBuilderTests({
     }
 
     setIsTestSelected(false);
-  };
+  }, [
+    allTests,
+    assessment,
+    builderState,
+    formMode,
+    mutateCreateTest,
+    mutationUpdateMetricTests,
+    refetchAssessmentData,
+    resetTestStates,
+    setAssessment,
+    setIsTestSelected,
+    t,
+    testId,
+    testMethods,
+    updateParamTestDef,
+    handleValidate,
+  ]);
+
+  useSubscribe<void>(CancelFormMotivationTest.type, handleCancel, [
+    handleCancel,
+  ]);
+  useSubscribe<void>(CreateFormMotivationTest.type, handleSubmit, [
+    handleSubmit,
+  ]);
 
   return (
     <>
@@ -412,7 +466,7 @@ function AssessmentBuilderTests({
               <button
                 className={styles["select-principle-btn"]}
                 onClick={handleSubmit}
-                disabled={!selectedTestId}
+                disabled={!testId}
               >
                 Select Test
               </button>
@@ -421,7 +475,7 @@ function AssessmentBuilderTests({
             <div className={styles["form-group"]}>
               <input
                 type="text"
-                className={`${styles["form-control"]} mb-1`}
+                className={styles["form-control"]}
                 style={{ width: "98%", margin: "0 auto" }}
                 placeholder="Search principles by ID, label or description..."
                 value={searchTerm}
@@ -442,8 +496,8 @@ function AssessmentBuilderTests({
                 {filteredTests?.map((test) => (
                   <div
                     key={test.id}
-                    className={`${styles["principle-card"]} ${selectedTestId === test.id ? styles["selected"] : ""}`}
-                    onClick={() => setSelectedTestId(test.id)}
+                    className={`${styles["principle-card"]} ${testId === test.id ? styles["selected"] : ""}`}
+                    onClick={() => setTestId(test.id)}
                   >
                     <div className={styles["principle-card-compact-header"]}>
                       <FaClipboardQuestion
@@ -468,10 +522,7 @@ function AssessmentBuilderTests({
         </div>
       ) : (
         formMode === "new" && (
-          <div
-            className={styles["builder-column"]}
-            style={{ height: "92%", overflow: "auto" }}
-          >
+          <div className={styles["builder-column"]}>
             <div className={styles["principle-form"]}>
               {/* Test Details Form */}
               <div className="mb-2">
@@ -737,23 +788,6 @@ function AssessmentBuilderTests({
                       <FaInfoCircle />
                     </span>
                   </OverlayTrigger>
-                </div>
-
-                <div className={styles["form-actions-tests"]}>
-                  <button
-                    type="button"
-                    className={styles["btn-secondary"]}
-                    onClick={handleCancel}
-                  >
-                    Cancel
-                  </button>
-                  <button
-                    type="button"
-                    className={styles["btn-primary"]}
-                    onClick={handleSubmit}
-                  >
-                    Create Test
-                  </button>
                 </div>
               </div>
             </div>

--- a/src/pages/assessments/components/tests/TestBinaryParamForm.tsx
+++ b/src/pages/assessments/components/tests/TestBinaryParamForm.tsx
@@ -48,19 +48,17 @@ export const TestBinaryParamForm = (props: AssessmentTestProps) => {
     <div>
       <Row>
         <div style={{ width: "75%" }}>
-          {props.test?.name && (
-            <div className="flex items-center gap-2">
-              <span className="cat-test-title ">
-                <span className="">{props.test.id}</span> / {props.test.name}
-                <span className="mt-2 p-2  fs-6">
-                  <TestToolTip
-                    tipId={"text-" + props.test.id}
-                    tipText={testDescription || ""}
-                  />
-                </span>
+          <div className="flex items-center gap-2">
+            <span className="cat-test-title ">
+              <span className="">{props.test.id}</span> / {props.test?.name}
+              <span className="mt-2 p-2  fs-6">
+                <TestToolTip
+                  tipId={"text-" + props.test.id}
+                  tipText={testDescription || ""}
+                />
               </span>
-            </div>
-          )}
+            </span>
+          </div>
         </div>
       </Row>
       <Row className="d-flex justify-content-between">

--- a/src/pages/tests/components/TestPreviewModal.tsx
+++ b/src/pages/tests/components/TestPreviewModal.tsx
@@ -16,10 +16,10 @@ import { TestAutoG069Form } from "@/pages/assessments/components/tests/TestAutoG
 import { TestAutoHttpsCheckForm } from "@/pages/assessments/components/tests/TestAutoHttpsCheckForm";
 import { TestAutoMd1Form } from "@/pages/assessments/components/tests/TestAutoMd1Form";
 import { TestAutoValidationForm } from "@/pages/assessments/components/tests/TestAutoValidationForm";
-import styles from "@/pages/assessment-builder/AssessmentBuilder.module.css";
 import { TestTRLForm } from "@/pages/assessments/components/tests/TestTRLForm";
 import { TestPercentForm } from "@/pages/assessments/components/tests/TestPercentForm";
 import { TestRatioForm } from "@/pages/assessments/components/tests/TestRatioForm";
+import styles from "@/pages/assessment-builder/AssessmentBuilder.module.css";
 
 interface TestPreviewProps {
   test: TestInput;
@@ -27,6 +27,8 @@ interface TestPreviewProps {
   testMethodName?: string;
   hasEvidenceParam?: boolean;
   onTestDelete?: () => void;
+  onTestCancel?: () => void;
+  onTestSave?: () => void;
 }
 
 const TestPreviewModal = ({
@@ -35,6 +37,8 @@ const TestPreviewModal = ({
   testMethodName,
   hasEvidenceParam,
   onTestDelete,
+  onTestCancel,
+  onTestSave,
 }: TestPreviewProps) => {
   const testParams: JSX.Element[] = [];
 
@@ -295,7 +299,9 @@ const TestPreviewModal = ({
   return (
     <>
       {testParams?.length > 0 ? (
-        <div className="border rounded cat-test-div position-relative">
+        <div
+          className={`border rounded cat-test-div position-relative ${onTestSave ? styles["test-preview-modal"] : ""}`}
+        >
           {onTestDelete && (
             <span
               onClick={(e) => {
@@ -307,15 +313,32 @@ const TestPreviewModal = ({
                 top: "12px",
                 right: "12px",
                 cursor: "pointer",
+                zIndex: 1001,
               }}
             >
               <FaTrash className={styles["delete-icon"]} size="16px" />
             </span>
           )}
-          {testParams}
+          <div className={styles["test-preview-container"]}>
+            {test?.tes ||
+            test?.label ||
+            test?.description ||
+            params?.[0]?.name ||
+            params?.[0]?.text ||
+            params?.[0]?.tooltip ? (
+              testParams
+            ) : (
+              <div className="p-3 text-center">
+                <span className="text-secondary">
+                  Complete the form fields in the Builder to see the preview of
+                  the test.
+                </span>
+              </div>
+            )}
+          </div>
 
           {hasEvidenceParam && (
-            <div className="mt-4 mb-2">
+            <div className="mb-2">
               <span className="fw-light-500 text-sm text-secondary">
                 <strong>
                   Can you provide public evidence of such a declaration?
@@ -330,6 +353,25 @@ const TestPreviewModal = ({
               <EvidenceURLS urls={[]} onListChange={() => {}} noTitle={true} />
             </div>
           )}
+          {typeof onTestSave === "function" &&
+            typeof onTestCancel === "function" && (
+              <div className={styles["form-actions-tests"]}>
+                <button
+                  type="button"
+                  className={styles["btn-secondary"]}
+                  onClick={onTestCancel}
+                >
+                  Cancel
+                </button>
+                <button
+                  type="button"
+                  className={styles["btn-primary"]}
+                  onClick={onTestSave}
+                >
+                  Create Test
+                </button>
+              </div>
+            )}
         </div>
       ) : null}
     </>


### PR DESCRIPTION
This PR implements live preview functionality for test creation in the Assessment Builder to provide real-time feedback as users fill out test forms. Additionally, it includes UI improvements for proper state management for test lifecycle, Pub/Sub pattern integration for component communication, and some improvements on how we should reset the state variables of Assessment Builder when navigate to different pages.

- Implement live preview updates in real-time as users type in test form fields
- Position Create and Cancel buttons within the Test Preview column
- Integrate Pub/Sub pattern to handle Create and Cancel test operations between components
- Reset test state properly on cancel, deselect, or successful creation
- Add visual focus indicators to highlight the active test preview during creation
- Reset Assessment Builder state when navigating to different pages
