### PR TITLE
[CAT-983] - Add Edit Mode for Tests in Assessment Builder

### DIFF
--- a/src/api/services/registry.ts
+++ b/src/api/services/registry.ts
@@ -321,6 +321,7 @@ export const useUpdateTest = (token: string, id: string, test: TestInput) => {
     },
   );
 };
+
 export function useDeleteTest(token: string) {
   const queryClient = useQueryClient();
   return useMutation({

--- a/src/custom-hooks/usePubSub/events/assessmentBuilder.ts
+++ b/src/custom-hooks/usePubSub/events/assessmentBuilder.ts
@@ -1,1 +1,3 @@
 export const TestMethodId = new CustomEvent("TestMethodId");
+
+export const LoadTestMethod = new CustomEvent("LoadTestMethod");

--- a/src/pages/assessment-builder/AssessmentBuilder.module.css
+++ b/src/pages/assessment-builder/AssessmentBuilder.module.css
@@ -126,7 +126,7 @@
 }
 
 .column-content:has(.builder-preview) {
-  padding: 1.5rem;
+  padding: 2.6rem 2rem;
   overflow: hidden;
   background: #f8f9fa;
 }
@@ -210,6 +210,7 @@
   display: flex;
   justify-content: space-between;
   padding-top: 0.8rem;
+  padding-bottom: 0.4rem;
   margin-top: 0.5rem;
   border-top: 1px solid #e5e7eb;
 }
@@ -434,22 +435,13 @@
   max-width: 48%;
 }
 
-.test-preview-modal-col {
-  display: flex;
-  flex: 1 1 0;
-  flex-direction: column;
-  gap: 0.5rem;
-  max-width: 48%;
-}
-
 @media (width <= 900px) {
   .form-group-test-preview {
     flex-direction: column;
     gap: 1rem;
   }
 
-  .test-params-fields-col,
-  .test-preview-modal-col {
+  .test-params-fields-col {
     max-width: 100%;
   }
 }
@@ -1437,7 +1429,7 @@
 
 .test-preview-modal {
   margin-bottom: 3rem;
-  box-shadow: 1px 2px 4px rgb(0 0 0 / 20%);
+  box-shadow: 1px 2px 4px 0 rgb(0 0 0 / 20%);
 }
 
 .test-method-item {
@@ -1479,7 +1471,10 @@
 }
 
 .advanced-settings-container {
-  position: relative;
+  position: absolute;
+  top: 6px;
+  right: 36px;
+  z-index: 1050;
   flex-shrink: 0;
 }
 

--- a/src/pages/assessment-builder/AssessmentBuilder.tsx
+++ b/src/pages/assessment-builder/AssessmentBuilder.tsx
@@ -35,6 +35,7 @@ import AssessmentBuilderPrinciples from "./AssessmentBuilderPrinciples";
 import AssessmentBuilderTests from "./AssessmentBuilderTests";
 import styles from "./AssessmentBuilder.module.css";
 import { useGetAllTests } from "@/api/services/registry";
+import { canEditCriterion } from "./utils";
 
 function AssessmentBuilder() {
   const { mtvId, actId } = useParams<{
@@ -419,6 +420,15 @@ function AssessmentBuilder() {
               isTestSelected={isTestSelected}
               setIsTestSelected={setIsTestSelected}
               allTests={allTests}
+              canEditCriterion={canEditCriterion({
+                currentCriterion: allCriteria.find(
+                  (criterion) =>
+                    criterion?.cri?.toLowerCase() ===
+                    builderState.selectedId?.toLowerCase(),
+                ),
+                mtvId: mtvId || "",
+                actId: actId || "",
+              })}
             />
           </div>
 
@@ -467,6 +477,7 @@ function AssessmentBuilder() {
                     Select
                   </button>
                   {(builderState.entityMode === "criterion" ||
+                    builderState.entityMode === "test" ||
                     builderState.entityMode === "none") && (
                     <>
                       <div className={styles["tab-divider"]} />

--- a/src/pages/assessment-builder/AssessmentBuilderCriteria.tsx
+++ b/src/pages/assessment-builder/AssessmentBuilderCriteria.tsx
@@ -28,6 +28,7 @@ import {
   handleNewCriterion,
   formatDataToAssignPrincipleToCriterion,
   handleEditCriterion,
+  canEditCriterion,
 } from "./utils";
 import styles from "./AssessmentBuilder.module.css";
 
@@ -325,27 +326,6 @@ function AssessmentBuilderCriteria({
     }
   }, [hoveredCriterion]);
 
-  // Check if criterion can be edited based on motivation usage
-  const canEditCriterion = (): boolean => {
-    const criterion = allCriteria.find(
-      (c) => c.id === selectedCriterionPidGraph,
-    );
-    if (criterion?.used_by_motivations?.length === 0) return true;
-
-    const usedByMotivations = criterion?.used_by_motivations;
-
-    if (Number(usedByMotivations?.length) > 1) {
-      return false;
-    }
-    if (usedByMotivations?.length === 1) {
-      const usedMotivation = usedByMotivations[0];
-      if (usedMotivation.id === mtvId || usedMotivation?.lodMTV === mtvId) {
-        return true;
-      } else return false;
-    }
-    return true;
-  };
-
   // Handle edit mode form population
   useEffect(() => {
     // initial form for new or select mode
@@ -416,7 +396,7 @@ function AssessmentBuilderCriteria({
   };
 
   const assignCriteriaToActor = async () => {
-    const criImp = selectedCriteria?.map((item) => ({
+    let criImp = selectedCriteria?.map((item) => ({
       criterion_id: item.id,
       imperative_id: item.imperative.id,
     }));
@@ -517,19 +497,41 @@ function AssessmentBuilderCriteria({
           throw error;
         }
       }
-
-      if (selectedCriterionPidGraph) {
-        criImp.push({
-          criterion_id: selectedCriterionPidGraph,
-          imperative_id:
-            criterionForm?.imperative ||
-            (imperatives.length > 0 ? imperatives[0].id : ""),
-        });
-      }
     }
 
-    if (formMode !== "edit" || (formMode === "edit" && principleTag)) {
+    const currentCriterionInAssessment = assessment
+      .flatMap((principle) => principle.criteria || [])
+      .find(
+        (criterion) =>
+          criterion.id?.toLowerCase() === criterionId?.toLowerCase(),
+      );
+    const oldImperativeLabel = currentCriterionInAssessment?.imperative;
+
+    const matchingImperative = imperatives.find(
+      (imp) => imp.id === criterionForm?.imperative,
+    );
+
+    if (
+      formMode !== "edit" ||
+      (formMode === "edit" &&
+        oldImperativeLabel?.toLowerCase() !==
+          matchingImperative?.label?.toLowerCase())
+    ) {
       try {
+        if (formMode === "edit") {
+          criImp = criImp.map((item) => {
+            if (item.criterion_id === selectedCriterionPidGraph) {
+              return {
+                criterion_id: item.criterion_id,
+                imperative_id: matchingImperative?.id || "",
+              };
+            }
+            return {
+              criterion_id: item.criterion_id,
+              imperative_id: item.imperative_id,
+            };
+          });
+        }
         await assignCriteriaToActorMutation.mutateAsync(criImp);
       } catch (error) {
         console.error("Assign criteria to actor failed:", error);
@@ -677,7 +679,15 @@ function AssessmentBuilderCriteria({
 
   // Check if current criterion can be edited
   const isEditingDisabled =
-    formMode === "edit" && criterionId && !canEditCriterion();
+    formMode === "edit" &&
+    criterionId &&
+    !canEditCriterion({
+      currentCriterion: allCriteria.find(
+        (criterion) => criterion.cri === criterionId,
+      ),
+      mtvId,
+      actId,
+    });
 
   return (
     <>

--- a/src/pages/assessment-builder/AssessmentBuilderPreview.tsx
+++ b/src/pages/assessment-builder/AssessmentBuilderPreview.tsx
@@ -17,12 +17,14 @@ import {
   useUpdateMotivationMetricTests,
 } from "@/api";
 import { AuthContext } from "@/auth";
-import { RegistryTest } from "@/types/tests";
+import { RegistryTest, TestFull } from "@/types/tests";
 import { relMtvMetricTest } from "@/config";
 import toast from "react-hot-toast";
 import styles from "./AssessmentBuilder.module.css";
 import AssessmentBuilderDeleteModal from "./AssessmentBuilderDeleteModal";
 import PreviewTests from "./PreviewTests";
+import usePublish from "@/custom-hooks/usePubSub/usePublish";
+import { LoadTestMethod } from "@/custom-hooks/usePubSub/events/assessmentBuilder";
 
 interface AssessmentBuilderPreviewProps {
   assessment: AssessmentPrinciple[];
@@ -39,6 +41,7 @@ interface AssessmentBuilderPreviewProps {
   isTestSelected: boolean;
   setIsTestSelected: React.Dispatch<React.SetStateAction<boolean>>;
   allTests: RegistryTest[];
+  canEditCriterion: boolean;
 }
 
 function AssessmentBuilderPreview({
@@ -55,15 +58,20 @@ function AssessmentBuilderPreview({
   isTestSelected,
   setIsTestSelected,
   allTests,
+  canEditCriterion,
 }: AssessmentBuilderPreviewProps) {
   const { keycloak, registered } = useContext(AuthContext)!;
   const [isAdvancedSettingsOpen, setIsAdvancedSettingsOpen] = useState(false);
   const [isPrincipleAssigned, setIsPrincipleAssigned] = useState(false);
   const [selectedTests, setSelectedTests] = useState<RegistryTest[]>([]);
+  const [testToEdit, setTestToEdit] = useState<TestFull | null>(null);
   const [showDeleteModal, setShowDeleteModal] = useState({
     testId: "",
     testLabel: "",
   });
+
+  const { publish: loadTestMethod } = usePublish(LoadTestMethod.type);
+
   const { t } = useTranslation();
   const alert = useRef<AlertInfo>({
     message: "",
@@ -103,6 +111,7 @@ function AssessmentBuilderPreview({
       setIsPrincipleSelected(false);
       setIsTestSelected(false);
       setIsAdvancedSettingsOpen(false);
+      setTestToEdit(null);
     }
   }, [
     builderState.selectedId,
@@ -255,7 +264,7 @@ function AssessmentBuilderPreview({
                   )}
                 </div>
                 <div className={styles["advanced-settings-container"]}>
-                  {isPrincipleAssigned && (
+                  {isPrincipleAssigned && canEditCriterion && (
                     <button
                       className={styles["advanced-settings-btn"]}
                       onClick={() => setIsAdvancedSettingsOpen((prev) => !prev)}
@@ -479,6 +488,7 @@ function AssessmentBuilderPreview({
                   refetchAssessmentData={refetchAssessmentData}
                   setIsTestSelected={setIsTestSelected}
                   allTests={allTests}
+                  formMode={builderState.formMode}
                 />
               )}
 
@@ -497,21 +507,57 @@ function AssessmentBuilderPreview({
                           key={test.id}
                           className={`${styles["test-item"]} my-3`}
                         >
-                          <TestPreviewModal
-                            test={{
-                              tes: test.id || "",
-                              label: test.name || "",
-                              description: test.description || "",
-                            }}
-                            params={getTestParams(test)}
-                            testMethodName={test.type}
-                            onTestDelete={() =>
-                              setShowDeleteModal({
-                                testId: test.id,
-                                testLabel: test.name,
-                              })
-                            }
-                          />
+                          {testToEdit &&
+                          testToEdit.id === test.id &&
+                          builderState.formMode === "edit" ? (
+                            <PreviewTests
+                              mtvId={mtvId || ""}
+                              mtrId={mtrId || ""}
+                              assessment={assessment}
+                              setBuilderState={setBuilderState}
+                              refetchAssessmentData={refetchAssessmentData}
+                              setIsTestSelected={setIsTestSelected}
+                              allTests={allTests}
+                              formMode={builderState.formMode}
+                              testToEdit={testToEdit}
+                              setTestToEdit={setTestToEdit}
+                            />
+                          ) : (
+                            <TestPreviewModal
+                              test={{
+                                tes: test.id || "",
+                                label: test.name || "",
+                                description: test.description || "",
+                              }}
+                              params={getTestParams(test)}
+                              testMethodName={test.type}
+                              onTestDelete={() =>
+                                setShowDeleteModal({
+                                  testId: test.id,
+                                  testLabel: test.name,
+                                })
+                              }
+                              onTestEdit={
+                                canEditCriterion
+                                  ? () => {
+                                      setBuilderState((prevState) => ({
+                                        ...prevState,
+                                        entityMode: "test",
+                                        formMode: "edit",
+                                      }));
+                                      setTimeout(() => {
+                                        setIsTestSelected(false);
+                                        setTestToEdit(test);
+                                        loadTestMethod(
+                                          LoadTestMethod.type,
+                                          test?.type || "Binary-Manual",
+                                        );
+                                      }, 0);
+                                    }
+                                  : undefined
+                              }
+                            />
+                          )}
                         </div>
                       ))}
                   </div>

--- a/src/pages/assessment-builder/AssessmentBuilderTests.tsx
+++ b/src/pages/assessment-builder/AssessmentBuilderTests.tsx
@@ -222,7 +222,7 @@ function AssessmentBuilderTests({
           </div>
         </div>
       ) : (
-        formMode === "new" && (
+        (formMode === "new" || formMode === "edit") && (
           <div className={styles["builder-column"]}>
             <div className={styles["principle-form"]}>
               <TestsMethods />

--- a/src/pages/assessment-builder/PreviewTests.tsx
+++ b/src/pages/assessment-builder/PreviewTests.tsx
@@ -11,7 +11,7 @@ import { FaInfoCircle } from "react-icons/fa";
 import { Form, Tooltip, OverlayTrigger } from "react-bootstrap";
 import styles from "./AssessmentBuilder.module.css";
 import { useTranslation } from "react-i18next";
-import { RegistryTest, TestInput, TestParam } from "@/types/tests";
+import { RegistryTest, TestFull, TestInput, TestParam } from "@/types/tests";
 import toast from "react-hot-toast";
 import { relMtvMetricTest } from "@/config";
 import TestPreviewModal from "../tests/components/TestPreviewModal";
@@ -19,9 +19,14 @@ import {
   AlertInfo,
   AssessmentBuilderState,
   AssessmentPrinciple,
+  FormMode,
   RegistryResource,
 } from "@/types";
-import { useCreateTest, useGetAllTestMethods } from "@/api/services/registry";
+import {
+  useCreateTest,
+  useGetAllTestMethods,
+  useUpdateTest,
+} from "@/api/services/registry";
 import { useUpdateMotivationMetricTests } from "@/api";
 import { TestMethodId } from "@/custom-hooks/usePubSub/events/assessmentBuilder";
 import useSubscribe from "@/custom-hooks/usePubSub/useSubscribe";
@@ -34,6 +39,9 @@ interface AssessmentBuilderTestsProps {
   refetchAssessmentData: () => void;
   setIsTestSelected: React.Dispatch<React.SetStateAction<boolean>>;
   allTests: RegistryTest[];
+  testToEdit?: TestFull | null;
+  setTestToEdit?: React.Dispatch<React.SetStateAction<TestFull | null>>;
+  formMode: FormMode;
 }
 
 function PreviewTests({
@@ -44,27 +52,55 @@ function PreviewTests({
   setIsTestSelected,
   refetchAssessmentData,
   allTests,
+  testToEdit,
+  setTestToEdit,
+  formMode,
 }: AssessmentBuilderTestsProps) {
   const alert = useRef<AlertInfo>({
     message: "",
   });
+
+  console.log("testToEdit:", testToEdit);
+
   const { keycloak, registered } = useContext(AuthContext)!;
   const { t } = useTranslation();
   const [test, setTest] = useState<TestInput>({
-    tes: "",
-    label: "",
-    description: "",
-    test_method_id: "pid_graph:8D79984F",
+    tes: testToEdit?.id || "",
+    label: testToEdit?.name || "",
+    description: testToEdit?.description || "",
+    test_method_id: testToEdit?.type_db_id || "pid_graph:8D79984F",
+    db_id: testToEdit?.db_id || "",
     label_test_definition: "",
     param_type: "onscreen",
   });
 
-  const [params, setParams] = useState<TestParam[]>([]);
-  const [hasEvidence, setHasEvidence] = useState(false);
+  const [params, setParams] = useState<TestParam[]>(
+    testToEdit
+      ? [
+          {
+            id: 1,
+            name: testToEdit.params || "",
+            text: testToEdit.text || "",
+            tooltip: testToEdit.tool_tip || "",
+          },
+        ]
+      : [],
+  );
+  console.log("params", params);
+
+  const [hasEvidence, setHasEvidence] = useState(
+    testToEdit?.params?.includes("evidence") || false,
+  );
 
   const [showErrors, setShowErrors] = useState(false);
 
   const mutateCreateTest = useCreateTest(keycloak?.token || "", test);
+  const mutateUpdateTest = useUpdateTest(
+    keycloak?.token || "",
+    test?.db_id || "",
+    { ...test, tooltip: test.tool_tip },
+  );
+
   const mutationUpdateMetricTests = useUpdateMotivationMetricTests(
     keycloak?.token || "",
     mtvId || "",
@@ -137,16 +173,34 @@ function PreviewTests({
   }, [params, hasEvidence, setTest]);
 
   const addNewParams = useCallback(
-    (numberOfParams = 1) => {
+    (numberOfParams = 1, testToEdit: TestFull | undefined) => {
       const tmpParams = Array.from(
         { length: numberOfParams },
         (_, i) => i + 1,
-      )?.map((i) => ({
-        id: i,
-        name: "",
-        text: "",
-        tooltip: "",
-      }));
+      )?.map((index) => {
+        if (testToEdit && testToEdit?.params) {
+          // Split the string fields by "|" to get individual parameters
+          const paramNames = testToEdit.params.split("|");
+          const paramTexts = testToEdit.text ? testToEdit.text.split("|") : [];
+          const paramTooltips = testToEdit.tool_tip
+            ? testToEdit.tool_tip.split("|")
+            : [];
+
+          return {
+            id: index,
+            name: paramNames[index - 1] || "",
+            text: paramTexts[index - 1] || "",
+            tooltip: paramTooltips[index - 1] || "",
+          };
+        }
+
+        return {
+          id: index,
+          name: "",
+          text: "",
+          tooltip: "",
+        };
+      });
       setParams(tmpParams);
     },
     [setParams],
@@ -157,7 +211,7 @@ function PreviewTests({
     if (testMethods?.length > 0 && test.test_method_id) {
       const method = testMethods.find((m) => m.id === test.test_method_id);
       if (method) {
-        addNewParams(method?.num_params);
+        addNewParams(method?.num_params, testToEdit ? testToEdit : undefined);
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -178,7 +232,8 @@ function PreviewTests({
     setHasEvidence(false);
     setShowErrors(false);
     setIsTestSelected(false);
-  }, [setTest, setParams, setHasEvidence, setIsTestSelected]);
+    setTestToEdit?.(null);
+  }, [setTest, setParams, setHasEvidence, setIsTestSelected, setTestToEdit]);
 
   useSubscribe<string>(
     TestMethodId.type,
@@ -208,6 +263,8 @@ function PreviewTests({
   }, [test, params]);
 
   const updateParam = (id: number, field: keyof TestParam, value: string) => {
+    console.log("Updating param:", id, field, value);
+
     setParams((prev) =>
       prev.map((param) =>
         param.id === id ? { ...param, [field]: value } : param,
@@ -222,83 +279,107 @@ function PreviewTests({
       entityMode: "criterion",
       formMode: "edit",
     }));
-  }, [resetTestStates, setBuilderState]);
+    setTestToEdit?.(null);
+  }, [resetTestStates, setBuilderState, setTestToEdit]);
 
-  const handleCreateTest = async () => {
+  const handleSubmit = async () => {
     if (!handleValidate()) {
       return;
     }
 
-    const metricAssignment = existingTestIds.map((testId) => ({
-      test_id:
-        allTests.find(
-          (test) => test.tes?.toLowerCase() === testId?.toLowerCase(),
-        )?.id || "",
-      relation: relMtvMetricTest,
-    }));
-
     updateParamTestDef();
 
-    const createTestPromise = await mutateCreateTest
-      .mutateAsync()
-      .then((newTest) => {
-        alert.current = {
-          message: t("page_tests.toast_create_success"),
-        };
+    if (formMode === "new") {
+      const metricAssignment = existingTestIds.map((testId) => ({
+        test_id:
+          allTests.find(
+            (test) => test.tes?.toLowerCase() === testId?.toLowerCase(),
+          )?.id || "",
+        relation: relMtvMetricTest,
+      }));
 
-        // Add the newly created test to the metric assignment
-        metricAssignment.push({
-          test_id: newTest.id,
-          relation: relMtvMetricTest,
-        });
+      const createTestPromise = await mutateCreateTest
+        .mutateAsync()
+        .then((newTest) => {
+          alert.current = {
+            message: t("page_tests.toast_create_success"),
+          };
 
-        // Now execute the assignment to metric after successful test creation
-        const assignTestsToMetricPromise = mutationUpdateMetricTests
-          .mutateAsync(metricAssignment)
-          .catch((err) => {
-            alert.current = {
-              message: t("page_motivations.toast_assign_metric_fail"),
-            };
-            throw err;
-          })
-          .then(() => {
-            refetchAssessmentData();
-
-            alert.current = {
-              message: t("page_motivations.toast_assign_metric_success"),
-            };
-            resetTestStates();
+          // Add the newly created test to the metric assignment
+          metricAssignment.push({
+            test_id: newTest.id,
+            relation: relMtvMetricTest,
           });
 
-        toast.promise(assignTestsToMetricPromise, {
-          loading: t("toast_assign_metric_progress"),
-          success: () => alert.current.message,
-          error: () => alert.current.message,
+          // Now execute the assignment to metric after successful test creation
+          const assignTestsToMetricPromise = mutationUpdateMetricTests
+            .mutateAsync(metricAssignment)
+            .catch((err) => {
+              alert.current = {
+                message: t("page_motivations.toast_assign_metric_fail"),
+              };
+              throw err;
+            })
+            .then(() => {
+              alert.current = {
+                message: t("page_motivations.toast_assign_metric_success"),
+              };
+              refetchAssessmentData();
+              resetTestStates();
+            });
+
+          toast.promise(assignTestsToMetricPromise, {
+            loading: t("toast_assign_metric_progress"),
+            success: () => alert.current.message,
+            error: () => alert.current.message,
+          });
+
+          return newTest;
+        })
+        .catch((err) => {
+          alert.current = {
+            message: "Error: " + err.response.data.message,
+          };
+          throw err;
         });
 
-        return newTest;
-      })
-      .catch((err) => {
-        alert.current = {
-          message: "Error: " + err.response.data.message,
-        };
-        throw err;
+      toast.promise(createTestPromise, {
+        loading: t("page_tests.toast_create_progress"),
+        success: () => alert.current.message,
+        error: () => alert.current.message,
       });
 
-    toast.promise(createTestPromise, {
-      loading: t("page_tests.toast_create_progress"),
-      success: () => alert.current.message,
-      error: () => alert.current.message,
-    });
+      setIsTestSelected(false);
+    } else if (formMode === "edit") {
+      const updateTestPromise = mutateUpdateTest
+        .mutateAsync()
+        .then(() => {
+          alert.current = {
+            message: t("page_tests.toast_update_success"),
+          };
+          refetchAssessmentData();
+          resetTestStates();
+        })
+        .catch((err) => {
+          alert.current = {
+            message: "Error: " + err.response.data.message,
+          };
+          throw err;
+        });
 
-    setIsTestSelected(false);
+      toast.promise(updateTestPromise, {
+        loading: t("page_tests.toast_update_progress"),
+        success: () => alert.current.message,
+        error: () => alert.current.message,
+      });
+    }
   };
 
   return (
-    <div className={`${styles["test-preview-modal"]} border rounded px-3 py-2`}>
-      {/* Top Row: Test Metadata and Parameters */}
+    <div
+      className={`${styles["test-preview-modal"]} border rounded px-3 py-2 ${testToEdit && "my-4"}`}
+    >
       <div className={`${styles["form-group-test-preview"]} mb-2`}>
-        {/* Left column: Test metadata (TES, Label, Description) */}
         <div className={styles["test-params-fields-col"]}>
           <label className={styles["form-group-test-preview-label"]}>
             Test Information
@@ -308,6 +389,7 @@ function PreviewTests({
             <label htmlFor="input-test-tes">TES (*):</label>
             <input
               className={styles["form-control"]}
+              disabled={formMode === "edit"}
               type="text"
               id="input-test-tes"
               value={test.tes}
@@ -365,7 +447,6 @@ function PreviewTests({
           </div>
         </div>
 
-        {/* Right column: Test parameters */}
         <div className={styles["test-params-fields-col"]}>
           {params?.length > 0 && (
             <label className={styles["form-group-test-preview-label"]}>
@@ -447,7 +528,6 @@ function PreviewTests({
               </div>
             ))}
 
-          {/* Evidence Parameter Option */}
           <div className={styles["evidence-parameter-option"]}>
             <label className="fw-medium small">Evidence Parameter</label>
             <OverlayTrigger
@@ -477,7 +557,6 @@ function PreviewTests({
         </div>
       </div>
 
-      {/* Bottom Row: Test Preview - Full Width */}
       <div className="mb-3">
         <label
           className={styles["form-group-test-preview-label"]}
@@ -512,9 +591,9 @@ function PreviewTests({
         <button
           type="button"
           className={styles["btn-primary"]}
-          onClick={handleCreateTest}
+          onClick={handleSubmit}
         >
-          Create Test
+          {testToEdit ? "Update Test" : "Create Test"}
         </button>
       </div>
     </div>

--- a/src/pages/assessment-builder/TestsMethods.tsx
+++ b/src/pages/assessment-builder/TestsMethods.tsx
@@ -4,7 +4,11 @@ import { AuthContext } from "@/auth";
 import { useGetAllTestMethods } from "@/api/services/registry";
 import { RegistryResource } from "@/types";
 import usePublish from "@/custom-hooks/usePubSub/usePublish";
-import { TestMethodId } from "@/custom-hooks/usePubSub/events/assessmentBuilder";
+import {
+  LoadTestMethod,
+  TestMethodId,
+} from "@/custom-hooks/usePubSub/events/assessmentBuilder";
+import useSubscribe from "@/custom-hooks/usePubSub/useSubscribe";
 
 function TestsMethods() {
   const { keycloak, registered } = useContext(AuthContext)!;
@@ -35,6 +39,24 @@ function TestsMethods() {
   const testMethods: RegistryResource[] = useMemo(
     () => testMethodsData?.pages?.flatMap((page) => page.content) || [],
     [testMethodsData?.pages],
+  );
+
+  console.log("testMethods:", testMethods);
+
+  useSubscribe<string>(
+    LoadTestMethod.type,
+    (testMethodLabel) => {
+      console.log("testMethodLabel:", testMethodLabel);
+
+      const testMethodId = testMethods.find(
+        (method) =>
+          method.label?.toLowerCase() === testMethodLabel?.toLowerCase(),
+      )?.id;
+      console.log("testMethodId:", testMethodId);
+
+      setSelectedTestMethodId(testMethodId || "pid_graph:8D79984F");
+    },
+    [testMethods, setSelectedTestMethodId],
   );
 
   const filteredTestMethods = testMethods.filter((method) => {

--- a/src/pages/assessment-builder/utils/assessmentBuilderUtils.ts
+++ b/src/pages/assessment-builder/utils/assessmentBuilderUtils.ts
@@ -642,3 +642,28 @@ export const formatDataToAssignPrincipleToCriterion = ({
 
   return priCri;
 };
+
+export const canEditCriterion = ({
+  currentCriterion,
+  mtvId,
+  actId,
+}: {
+  currentCriterion: Criterion | undefined;
+  mtvId: string;
+  actId: string;
+}): boolean => {
+  const usedByMotivations = currentCriterion?.used_by_motivations;
+
+  if (!usedByMotivations || usedByMotivations.length === 0) {
+    return true;
+  }
+
+  const currentMotivation = usedByMotivations?.find(
+    (motivation) => motivation.id === mtvId,
+  );
+  if (currentMotivation) {
+    return currentMotivation.first_actor_assignment === actId;
+  }
+
+  return true;
+};

--- a/src/pages/tests/components/TestPreviewModal.tsx
+++ b/src/pages/tests/components/TestPreviewModal.tsx
@@ -1,7 +1,7 @@
 import { TestInput, TestParam } from "@/types/tests";
 import { EvidenceURLS, TestToolTip } from "@/pages/assessments/components";
 import { TestBinaryParamForm } from "@/pages/assessments/components/tests/TestBinaryParamForm";
-import { FaTrash } from "react-icons/fa";
+import { FaEdit, FaTrash } from "react-icons/fa";
 import {
   TestAutoG069,
   TestAutoHttpsCheck,
@@ -26,6 +26,7 @@ interface TestPreviewProps {
   params: TestParam[];
   testMethodName?: string;
   hasEvidenceParam?: boolean;
+  onTestEdit?: () => void;
   onTestDelete?: () => void;
 }
 
@@ -34,6 +35,7 @@ const TestPreviewModal = ({
   params,
   testMethodName,
   hasEvidenceParam,
+  onTestEdit,
   onTestDelete,
 }: TestPreviewProps) => {
   const testParams: JSX.Element[] = [];
@@ -58,6 +60,7 @@ const TestPreviewModal = ({
 
     testParams.push(
       <TestBinaryParamForm
+        key={`binary-${test.tes}`}
         test={adaptedTest}
         onTestChange={() => {}}
         criterionId=""
@@ -88,6 +91,7 @@ const TestPreviewModal = ({
 
     testParams.push(
       <TestValueFormParam
+        key={`value-${test.tes}`}
         test={adaptedTest}
         onTestChange={() => {}}
         criterionId=""
@@ -108,6 +112,7 @@ const TestPreviewModal = ({
 
     testParams.push(
       <TestTRLForm
+        key={`trl-${test.tes}`}
         test={adaptedTest}
         onTestChange={() => {}}
         criterionId=""
@@ -128,6 +133,7 @@ const TestPreviewModal = ({
 
     testParams.push(
       <TestPercentForm
+        key={`percent-${test.tes}`}
         test={adaptedTest}
         onTestChange={() => {}}
         criterionId=""
@@ -148,6 +154,7 @@ const TestPreviewModal = ({
 
     testParams.push(
       <TestRatioForm
+        key={`ratio-${test.tes}`}
         test={adaptedTest}
         onTestChange={() => {}}
         criterionId=""
@@ -170,6 +177,7 @@ const TestPreviewModal = ({
 
     testParams.push(
       <TestAutoG069Form
+        key={`auto-g069-${test.tes}`}
         g069param=""
         test={adaptedTest}
         onTestChange={() => {}}
@@ -192,6 +200,7 @@ const TestPreviewModal = ({
     } as unknown as TestAutoValidation;
     testParams.push(
       <TestAutoValidationForm
+        key={`auto-validation-${test.tes}`}
         test={adaptedTest}
         onAutoGroupTestCall={() => {}}
       />,
@@ -212,6 +221,7 @@ const TestPreviewModal = ({
 
     testParams.push(
       <TestAutoG069Form
+        key={`auto-g069-user-${test.tes}`}
         g069param={defaultG069userInfo}
         test={adaptedTest}
         onTestChange={() => {}}
@@ -235,6 +245,7 @@ const TestPreviewModal = ({
 
     testParams.push(
       <TestAutoG069Form
+        key={`auto-g069-token-${test.tes}`}
         g069param={defaultG069tokenIntrospection}
         test={adaptedTest}
         onTestChange={() => {}}
@@ -258,6 +269,7 @@ const TestPreviewModal = ({
 
     testParams.push(
       <TestAutoHttpsCheckForm
+        key={`auto-https-${test.tes}`}
         test={adaptedTest}
         onTestChange={() => {}}
         criterionId=""
@@ -284,6 +296,7 @@ const TestPreviewModal = ({
 
     testParams.push(
       <TestAutoMd1Form
+        key={`auto-md1-${test.tes}`}
         test={adaptedTest}
         onTestChange={() => {}}
         criterionId=""
@@ -296,6 +309,23 @@ const TestPreviewModal = ({
     <>
       {testParams?.length > 0 ? (
         <div className="border rounded cat-test-div position-relative">
+          {onTestEdit && (
+            <span
+              onClick={(e) => {
+                e.stopPropagation();
+                onTestEdit();
+              }}
+              style={{
+                position: "absolute",
+                top: "12px",
+                right: "36px",
+                cursor: "pointer",
+                zIndex: 1001,
+              }}
+            >
+              <FaEdit className={styles["delete-icon"]} size="16px" />
+            </span>
+          )}
           {onTestDelete && (
             <span
               onClick={(e) => {
@@ -310,7 +340,7 @@ const TestPreviewModal = ({
                 zIndex: 1001,
               }}
             >
-              <FaTrash className={styles["delete-icon"]} size="16px" />
+              <FaTrash className={styles["delete-icon"]} size="14px" />
             </span>
           )}
           <div className={styles["test-preview-container"]}>

--- a/src/types/motivation.ts
+++ b/src/types/motivation.ts
@@ -127,6 +127,8 @@ export interface MotivationReference {
   mtv: string;
   label: string;
   lodMTV?: string;
+  first_actor_assignment?: string;
+  first_actor_assignment_label?: string;
 }
 
 export interface MotivationPrincipleInput {

--- a/src/types/tests.ts
+++ b/src/types/tests.ts
@@ -32,6 +32,10 @@ export interface TestInput {
   test_params?: string;
   test_question?: string;
   tool_tip?: string;
+  db_id?: string;
+  id?: string;
+  name?: string;
+  tooltip?: string;
 }
 
 export interface TestParam {
@@ -39,4 +43,28 @@ export interface TestParam {
   name: string;
   text: string;
   tooltip: string;
+}
+
+export interface TestFull {
+  id: string;
+  tes?: string;
+  label?: string;
+  description?: string;
+  last_touch?: string;
+  version?: string;
+  test_method_id?: string;
+  label_test_definition?: string;
+  motivation_id?: string;
+  param_type?: string;
+  test_params?: TestParam[];
+  test_question?: string;
+  used_by_motivations?: MotivationReference[];
+  test_versions?: RegistryTest[];
+  is_latest_version?: boolean;
+  name?: string;
+  db_id?: string;
+  type_db_id?: string;
+  params?: string;
+  text?: string;
+  tool_tip?: string;
 }


### PR DESCRIPTION
This PR implements edit mode functionality for tests in the Assessment Builder, enabling users to modify existing tests. The implementation repositions the Advanced Settings button outside the Preview column content and defines conditional editing permissions for existing criteria in the Assessment Builder.

-  Added comprehensive edit mode functionality for tests in Assessment Builder 
-  Repositioned Advanced Settings button outside the Preview column content area
-  Implemented conditional editing logic that allows criterion modification only when the current actor is the first assignment for the motivation
- Fixed criterion imperative_id update mechanism to properly handle changes during edit operations