### PR TITLE
[CAT-984] - Fix test assignment to metrics conflict when creating new tests

### DIFF
--- a/src/pages/assessment-builder/AssessmentBuilderPreview.tsx
+++ b/src/pages/assessment-builder/AssessmentBuilderPreview.tsx
@@ -489,6 +489,7 @@ function AssessmentBuilderPreview({
                   setIsTestSelected={setIsTestSelected}
                   allTests={allTests}
                   formMode={builderState.formMode}
+                  selectedCriterionId={builderState.selectedId}
                 />
               )}
 

--- a/src/pages/assessment-builder/AssessmentBuilderTests.tsx
+++ b/src/pages/assessment-builder/AssessmentBuilderTests.tsx
@@ -51,7 +51,7 @@ function AssessmentBuilderTests({
 
   const filteredTests = useMemo(() => {
     // First, get all existing tests from the assessment
-    const existingTestIds = assessment
+    const allTestIdsInAssessment = assessment
       ?.flatMap((principle) => principle.criteria || [])
       ?.flatMap((criterion) => criterion?.metric?.tests || [])
       ?.map((test) => test?.id?.toLowerCase())
@@ -60,7 +60,7 @@ function AssessmentBuilderTests({
     // Then filter allTests based on existence and search term
     return allTests?.filter((test) => {
       // Check if test already exists in assessment
-      const existsInAssessment = existingTestIds?.includes(
+      const existsInAssessment = allTestIdsInAssessment?.includes(
         test.tes?.toLowerCase(),
       );
 
@@ -86,7 +86,7 @@ function AssessmentBuilderTests({
 
   const handleSubmit = useCallback(() => {
     const selectedCriterionId = builderState.selectedId;
-    const existingTestIds: string[] = [];
+    let testIdsInCriterion: string[] = [];
 
     if (selectedCriterionId) {
       // Find the selected criterion in the assessment
@@ -94,20 +94,14 @@ function AssessmentBuilderTests({
         ?.flatMap((principle) => principle.criteria || [])
         ?.find((criterion) => criterion.id === selectedCriterionId);
 
-      if (
-        selectedCriterion?.metric?.tests &&
-        selectedCriterion.metric.tests.length > 0
-      ) {
-        // Extract existing test IDs
-        selectedCriterion.metric.tests.forEach((test) => {
-          if (test.id) {
-            existingTestIds.push(test.id);
-          }
-        });
-      }
+      // Get existing test IDs only from the selected criterion
+      testIdsInCriterion =
+        selectedCriterion?.metric?.tests
+          ?.map((test) => test?.id?.toLowerCase())
+          ?.filter(Boolean) || [];
     }
 
-    const metricAssignment = existingTestIds.map((testId) => ({
+    const metricAssignment = testIdsInCriterion.map((testId) => ({
       test_id:
         allTests.find(
           (test) => test.tes?.toLowerCase() === testId?.toLowerCase(),
@@ -115,7 +109,7 @@ function AssessmentBuilderTests({
       relation: relMtvMetricTest,
     }));
 
-    if (testId && !existingTestIds.includes(testId)) {
+    if (testId && !testIdsInCriterion.includes(testId)) {
       metricAssignment.push({
         test_id: testId,
         relation: relMtvMetricTest,

--- a/src/pages/assessment-builder/PreviewTests.tsx
+++ b/src/pages/assessment-builder/PreviewTests.tsx
@@ -34,6 +34,7 @@ import useSubscribe from "@/custom-hooks/usePubSub/useSubscribe";
 interface AssessmentBuilderTestsProps {
   mtvId: string;
   mtrId: string;
+  selectedCriterionId?: string;
   assessment: AssessmentPrinciple[];
   setBuilderState: React.Dispatch<React.SetStateAction<AssessmentBuilderState>>;
   refetchAssessmentData: () => void;
@@ -48,6 +49,7 @@ function PreviewTests({
   assessment,
   mtvId,
   mtrId,
+  selectedCriterionId,
   setBuilderState,
   setIsTestSelected,
   refetchAssessmentData,
@@ -59,8 +61,6 @@ function PreviewTests({
   const alert = useRef<AlertInfo>({
     message: "",
   });
-
-  console.log("testToEdit:", testToEdit);
 
   const { keycloak, registered } = useContext(AuthContext)!;
   const { t } = useTranslation();
@@ -86,7 +86,6 @@ function PreviewTests({
         ]
       : [],
   );
-  console.log("params", params);
 
   const [hasEvidence, setHasEvidence] = useState(
     testToEdit?.params?.includes("evidence") || false,
@@ -121,11 +120,14 @@ function PreviewTests({
     [testMethodsData],
   );
 
-  const existingTestIds = assessment
+  const selectedCriterion = assessment
     ?.flatMap((principle) => principle.criteria || [])
-    ?.flatMap((criterion) => criterion?.metric?.tests || [])
-    ?.map((test) => test?.id?.toLowerCase())
-    ?.filter(Boolean);
+    ?.find((criterion) => criterion.id === selectedCriterionId);
+
+  const testIdsInCriterion =
+    selectedCriterion?.metric?.tests
+      ?.map((test) => test?.id?.toLowerCase())
+      ?.filter(Boolean) || [];
 
   const testMethodName = useMemo(() => {
     const testMethod = testMethods?.find(
@@ -159,10 +161,6 @@ function PreviewTests({
     if (hasEvidence) {
       names = names === "" ? "evidence" : names + "|evidence";
     }
-
-    console.log("text", text);
-    console.log("names", names);
-    console.log("tips", tips);
 
     setTest((test) => ({
       ...test,
@@ -263,8 +261,6 @@ function PreviewTests({
   }, [test, params]);
 
   const updateParam = (id: number, field: keyof TestParam, value: string) => {
-    console.log("Updating param:", id, field, value);
-
     setParams((prev) =>
       prev.map((param) =>
         param.id === id ? { ...param, [field]: value } : param,
@@ -282,7 +278,7 @@ function PreviewTests({
     setTestToEdit?.(null);
   }, [resetTestStates, setBuilderState, setTestToEdit]);
 
-  const handleSubmit = async () => {
+  const handleSubmit = () => {
     if (!handleValidate()) {
       return;
     }
@@ -290,7 +286,7 @@ function PreviewTests({
     updateParamTestDef();
 
     if (formMode === "new") {
-      const metricAssignment = existingTestIds.map((testId) => ({
+      const metricAssignment = testIdsInCriterion?.map((testId) => ({
         test_id:
           allTests.find(
             (test) => test.tes?.toLowerCase() === testId?.toLowerCase(),
@@ -298,7 +294,7 @@ function PreviewTests({
         relation: relMtvMetricTest,
       }));
 
-      const createTestPromise = await mutateCreateTest
+      const createTestPromise = mutateCreateTest
         .mutateAsync()
         .then((newTest) => {
           alert.current = {
@@ -334,7 +330,7 @@ function PreviewTests({
             error: () => alert.current.message,
           });
 
-          return newTest;
+          setIsTestSelected(false);
         })
         .catch((err) => {
           alert.current = {
@@ -348,8 +344,6 @@ function PreviewTests({
         success: () => alert.current.message,
         error: () => alert.current.message,
       });
-
-      setIsTestSelected(false);
     } else if (formMode === "edit") {
       const updateTestPromise = mutateUpdateTest
         .mutateAsync()

--- a/src/pages/assessment-builder/TestsMethods.tsx
+++ b/src/pages/assessment-builder/TestsMethods.tsx
@@ -41,19 +41,13 @@ function TestsMethods() {
     [testMethodsData?.pages],
   );
 
-  console.log("testMethods:", testMethods);
-
   useSubscribe<string>(
     LoadTestMethod.type,
     (testMethodLabel) => {
-      console.log("testMethodLabel:", testMethodLabel);
-
       const testMethodId = testMethods.find(
         (method) =>
           method.label?.toLowerCase() === testMethodLabel?.toLowerCase(),
       )?.id;
-      console.log("testMethodId:", testMethodId);
-
       setSelectedTestMethodId(testMethodId || "pid_graph:8D79984F");
     },
     [testMethods, setSelectedTestMethodId],


### PR DESCRIPTION
This PR resolves an issue where assigning a newly created test to a metric failed because of conflicting retrieval of tests for a certain criterion. The problem was caused by overlapping logic in how we fetched and filtered the test list, before executing the assignment.