### PR TITLE
[CAT-986] - Refactor test_id handling when assign tests to a metric

### DIFF
--- a/src/pages/assessment-builder/AssessmentBuilder.tsx
+++ b/src/pages/assessment-builder/AssessmentBuilder.tsx
@@ -419,7 +419,6 @@ function AssessmentBuilder() {
               setIsPrincipleSelected={setIsPrincipleSelected}
               isTestSelected={isTestSelected}
               setIsTestSelected={setIsTestSelected}
-              allTests={allTests}
               canEditCriterion={canEditCriterion({
                 currentCriterion: allCriteria.find(
                   (criterion) =>

--- a/src/pages/assessment-builder/AssessmentBuilderPreview.tsx
+++ b/src/pages/assessment-builder/AssessmentBuilderPreview.tsx
@@ -40,7 +40,6 @@ interface AssessmentBuilderPreviewProps {
   setIsPrincipleSelected: React.Dispatch<React.SetStateAction<boolean>>;
   isTestSelected: boolean;
   setIsTestSelected: React.Dispatch<React.SetStateAction<boolean>>;
-  allTests: RegistryTest[];
   canEditCriterion: boolean;
 }
 
@@ -57,7 +56,6 @@ function AssessmentBuilderPreview({
   setIsPrincipleSelected,
   isTestSelected,
   setIsTestSelected,
-  allTests,
   canEditCriterion,
 }: AssessmentBuilderPreviewProps) {
   const { keycloak, registered } = useContext(AuthContext)!;
@@ -487,7 +485,6 @@ function AssessmentBuilderPreview({
                   setBuilderState={setBuilderState}
                   refetchAssessmentData={refetchAssessmentData}
                   setIsTestSelected={setIsTestSelected}
-                  allTests={allTests}
                   formMode={builderState.formMode}
                   selectedCriterionId={builderState.selectedId}
                 />
@@ -518,7 +515,6 @@ function AssessmentBuilderPreview({
                               setBuilderState={setBuilderState}
                               refetchAssessmentData={refetchAssessmentData}
                               setIsTestSelected={setIsTestSelected}
-                              allTests={allTests}
                               formMode={builderState.formMode}
                               testToEdit={testToEdit}
                               setTestToEdit={setTestToEdit}

--- a/src/pages/assessment-builder/AssessmentBuilderTests.tsx
+++ b/src/pages/assessment-builder/AssessmentBuilderTests.tsx
@@ -97,19 +97,16 @@ function AssessmentBuilderTests({
       // Get existing test IDs only from the selected criterion
       testIdsInCriterion =
         selectedCriterion?.metric?.tests
-          ?.map((test) => test?.id?.toLowerCase())
+          ?.map((test) => test?.db_id || "")
           ?.filter(Boolean) || [];
     }
 
-    const metricAssignment = testIdsInCriterion.map((testId) => ({
-      test_id:
-        allTests.find(
-          (test) => test.tes?.toLowerCase() === testId?.toLowerCase(),
-        )?.id || "",
+    const metricAssignment = testIdsInCriterion.map((testDbId) => ({
+      test_id: testDbId,
       relation: relMtvMetricTest,
     }));
 
-    if (testId && !testIdsInCriterion.includes(testId)) {
+    if (testId) {
       metricAssignment.push({
         test_id: testId,
         relation: relMtvMetricTest,
@@ -127,10 +124,11 @@ function AssessmentBuilderTests({
       })
       .then(() => {
         refetchAssessmentData();
-
         alert.current = {
           message: t("page_motivations.toast_assign_metric_success"),
         };
+      })
+      .finally(() => {
         resetTestStates();
       });
 
@@ -142,7 +140,6 @@ function AssessmentBuilderTests({
 
     setIsTestSelected(false);
   }, [
-    allTests,
     assessment,
     builderState,
     mutationUpdateMetricTests,

--- a/src/pages/assessment-builder/PreviewTests.tsx
+++ b/src/pages/assessment-builder/PreviewTests.tsx
@@ -11,7 +11,7 @@ import { FaInfoCircle } from "react-icons/fa";
 import { Form, Tooltip, OverlayTrigger } from "react-bootstrap";
 import styles from "./AssessmentBuilder.module.css";
 import { useTranslation } from "react-i18next";
-import { RegistryTest, TestFull, TestInput, TestParam } from "@/types/tests";
+import { TestFull, TestInput, TestParam } from "@/types/tests";
 import toast from "react-hot-toast";
 import { relMtvMetricTest } from "@/config";
 import TestPreviewModal from "../tests/components/TestPreviewModal";
@@ -39,7 +39,6 @@ interface AssessmentBuilderTestsProps {
   setBuilderState: React.Dispatch<React.SetStateAction<AssessmentBuilderState>>;
   refetchAssessmentData: () => void;
   setIsTestSelected: React.Dispatch<React.SetStateAction<boolean>>;
-  allTests: RegistryTest[];
   testToEdit?: TestFull | null;
   setTestToEdit?: React.Dispatch<React.SetStateAction<TestFull | null>>;
   formMode: FormMode;
@@ -53,7 +52,6 @@ function PreviewTests({
   setBuilderState,
   setIsTestSelected,
   refetchAssessmentData,
-  allTests,
   testToEdit,
   setTestToEdit,
   formMode,
@@ -126,7 +124,7 @@ function PreviewTests({
 
   const testIdsInCriterion =
     selectedCriterion?.metric?.tests
-      ?.map((test) => test?.id?.toLowerCase())
+      ?.map((test) => test?.db_id || "")
       ?.filter(Boolean) || [];
 
   const testMethodName = useMemo(() => {
@@ -286,11 +284,8 @@ function PreviewTests({
     updateParamTestDef();
 
     if (formMode === "new") {
-      const metricAssignment = testIdsInCriterion?.map((testId) => ({
-        test_id:
-          allTests.find(
-            (test) => test.tes?.toLowerCase() === testId?.toLowerCase(),
-          )?.id || "",
+      const metricAssignment = testIdsInCriterion?.map((testDbId) => ({
+        test_id: testDbId,
         relation: relMtvMetricTest,
       }));
 

--- a/src/types/tests.ts
+++ b/src/types/tests.ts
@@ -18,6 +18,7 @@ export interface RegistryTest {
   used_by_motivations?: MotivationReference[];
   test_versions?: RegistryTest[];
   is_latest_version?: boolean;
+  db_id?: string;
 }
 
 export type RegistryTestsResponse = ResponsePage<RegistryTest[]>;


### PR DESCRIPTION
Updated test ID mapping in Assessment Builder Test component when assigning tests to a metric