### PR TITLE
CAT-987 Expand use of test icons in AssessmentBuilder and Create Test…

### DIFF
--- a/src/pages/assessment-builder/TestsMethods.tsx
+++ b/src/pages/assessment-builder/TestsMethods.tsx
@@ -9,6 +9,7 @@ import {
   TestMethodId,
 } from "@/custom-hooks/usePubSub/events/assessmentBuilder";
 import useSubscribe from "@/custom-hooks/usePubSub/useSubscribe";
+import { TestIcon } from "@/components";
 
 function TestsMethods() {
   const { keycloak, registered } = useContext(AuthContext)!;
@@ -135,7 +136,10 @@ function TestsMethods() {
             }}
           >
             <div className={styles["method-name"]}>
-              {method?.friendly_label || method.label}
+              <TestIcon test={method.label} />
+              <span className="ms-2">
+                {method?.friendly_label || method.label}
+              </span>
             </div>
           </div>
         ))}

--- a/src/pages/tests/components/TestModalContainer.tsx
+++ b/src/pages/tests/components/TestModalContainer.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 import TestHeaderForm from "./TestHeaderForm";
 import TestMethodAndParams from "./TestMethodAndParams";
+import { TestIcon } from "@/components";
 
 export interface TestModalUIProps {
   id?: string;
@@ -199,7 +200,8 @@ function TestModalContainer(props: TestModalUIProps) {
                     }}
                   >
                     <div className="fw-bold mb-1 test-method-label">
-                      {method.label}
+                      <TestIcon test={method.label} />
+                      <span className="ms-2">{method.label}</span>
                     </div>
                     <div className="test-method-description">
                       {method.description}


### PR DESCRIPTION
… views

- [x] Use test icons in Create New Test view (screenshot below):

<img width="1618" height="815" alt="image" src="https://github.com/user-attachments/assets/125825dc-45c4-4de8-9cf0-944eeef7570e" />


---


- [x] Use test icons in Assessment Builder > Test Methods panel (screenshot below):
<img width="1615" height="833" alt="image" src="https://github.com/user-attachments/assets/10683879-27dc-4e01-a321-cc90ef917095" />
