### PR TITLE
[CAT-988] - Refactor pagination handling and improve criterion editing workflow for Assessment Builder

### DIFF
--- a/src/pages/assessment-builder/AssessmentBuilder.tsx
+++ b/src/pages/assessment-builder/AssessmentBuilder.tsx
@@ -1,13 +1,6 @@
 import { useParams, useNavigate } from "react-router-dom";
 import { useTranslation } from "react-i18next";
-import {
-  useState,
-  useContext,
-  useEffect,
-  useRef,
-  useCallback,
-  useMemo,
-} from "react";
+import { useState, useContext, useEffect, useRef, useCallback } from "react";
 import toast from "react-hot-toast";
 import { Button, Container, Spinner } from "react-bootstrap";
 import { AuthContext } from "@/auth";
@@ -26,6 +19,7 @@ import {
   AssessmentBuilderState,
   AlertInfo,
   RegistryMetric,
+  Criterion,
 } from "@/types";
 import { useGetAllCriteria } from "../../api/services/criteria";
 import AssessmentBuilderStructure from "./AssessmentBuilderStructure";
@@ -35,7 +29,8 @@ import AssessmentBuilderPrinciples from "./AssessmentBuilderPrinciples";
 import AssessmentBuilderTests from "./AssessmentBuilderTests";
 import styles from "./AssessmentBuilder.module.css";
 import { useGetAllTests } from "@/api/services/registry";
-import { canEditCriterion } from "./utils";
+import { canEditMetricAndTests } from "./utils";
+import { RegistryTest } from "@/types/tests";
 
 function AssessmentBuilder() {
   const { mtvId, actId } = useParams<{
@@ -79,16 +74,94 @@ function AssessmentBuilder() {
     [],
   );
 
-  const { data: testData } = useGetAllTests({
-    size: 100,
+  const [allTests, setAllTests] = useState<RegistryTest[]>([]);
+  const [allPrinciples, setAllPrinciples] = useState<Principle[]>([]);
+  const [allCriteria, setAllCriteria] = useState<Criterion[]>([]);
+
+  const {
+    data: testsData,
+    fetchNextPage: testFetchNextPage,
+    hasNextPage: testsHaveNextPage,
+    isFetchingNextPage: testsAreFetchingNextPage,
+  } = useGetAllTests({
+    size: 20,
     token: keycloak?.token || "",
     isRegistered: registered,
   });
 
-  const allTests = useMemo(
-    () => testData?.pages?.flatMap((page) => page.content) || [],
-    [testData?.pages],
-  );
+  const {
+    data: principlesData,
+    refetch: refetchPrinciples,
+    fetchNextPage: principlesFetchNextPage,
+    hasNextPage: principlesHaveNextPage,
+    isFetchingNextPage: principlesAreFetchingNextPage,
+  } = useGetAllPrinciples({
+    token: keycloak?.token || "",
+    isRegistered: registered,
+    size: 20,
+  });
+
+  const {
+    data: criteriaData,
+    fetchNextPage: criteriaFetchNextPage,
+    hasNextPage: criteriaHaveNextPage,
+    isFetchingNextPage: criteriaAreFetchingNextPage,
+  } = useGetAllCriteria({
+    size: 20,
+    token: keycloak?.token || "",
+    isRegistered: registered,
+  });
+
+  useEffect(() => {
+    if (testsData?.pages) {
+      const allTestsData =
+        testsData.pages.flatMap((page) => page.content) || [];
+      setAllTests(allTestsData);
+
+      if (testsHaveNextPage && !testsAreFetchingNextPage) {
+        testFetchNextPage();
+      }
+    }
+  }, [
+    testsData?.pages,
+    testsHaveNextPage,
+    testsAreFetchingNextPage,
+    testFetchNextPage,
+  ]);
+
+  useEffect(() => {
+    if (principlesData?.pages) {
+      const allPrinciplesData =
+        principlesData.pages.flatMap((page) => page.content) || [];
+      setAllPrinciples(allPrinciplesData);
+
+      if (principlesHaveNextPage && !principlesAreFetchingNextPage) {
+        principlesFetchNextPage();
+      }
+    }
+  }, [
+    principlesData?.pages,
+    principlesHaveNextPage,
+    principlesAreFetchingNextPage,
+    principlesFetchNextPage,
+  ]);
+
+  useEffect(() => {
+    if (criteriaData?.pages) {
+      const allCriteriaData =
+        criteriaData.pages.flatMap((page) => page.content) || [];
+      setAllCriteria(allCriteriaData);
+
+      if (criteriaHaveNextPage && !criteriaAreFetchingNextPage) {
+        criteriaFetchNextPage();
+      }
+    }
+  }, [
+    criteriaData?.pages,
+    criteriaHaveNextPage,
+    criteriaAreFetchingNextPage,
+    criteriaFetchNextPage,
+  ]);
 
   useEffect(() => {
     if (
@@ -219,24 +292,6 @@ function AssessmentBuilder() {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [assessmentData]);
-
-  const { data: principlesData, refetch: refetchPrinciples } =
-    useGetAllPrinciples({
-      token: keycloak?.token || "",
-      isRegistered: registered,
-      size: 100,
-    });
-
-  const allPrinciples: Principle[] =
-    principlesData?.pages?.flatMap((page) => page.content) || [];
-
-  const { data: criteriaData } = useGetAllCriteria({
-    size: 100,
-    token: keycloak?.token || "",
-    isRegistered: registered,
-  });
-  const allCriteria =
-    criteriaData?.pages?.flatMap((page) => page.content) || [];
 
   const motivationCriteriaMutation = useGetMotivationCriteriaMutation(
     keycloak?.token || "",
@@ -419,7 +474,7 @@ function AssessmentBuilder() {
               setIsPrincipleSelected={setIsPrincipleSelected}
               isTestSelected={isTestSelected}
               setIsTestSelected={setIsTestSelected}
-              canEditCriterion={canEditCriterion({
+              canEditMetricAndTests={canEditMetricAndTests({
                 currentCriterion: allCriteria.find(
                   (criterion) =>
                     criterion?.cri?.toLowerCase() ===

--- a/src/pages/assessment-builder/AssessmentBuilderCriteria.tsx
+++ b/src/pages/assessment-builder/AssessmentBuilderCriteria.tsx
@@ -689,6 +689,17 @@ function AssessmentBuilderCriteria({
       actId,
     });
 
+  const hasCriterionPrinciple = useMemo(() => {
+    return assessment.some((principle) =>
+      principle.criteria?.some(
+        (c) =>
+          c.id === criterionForm?.cri &&
+          principle.id &&
+          principle.id !== "untagged",
+      ),
+    );
+  }, [assessment, criterionForm?.cri]);
+
   return (
     <>
       {formMode === "new" || formMode === "edit" ? (
@@ -888,25 +899,28 @@ function AssessmentBuilderCriteria({
                     style={{ maxHeight: "160px", overflowY: "auto" }}
                     ref={scrollableContainerRef}
                   >
-                    <div
-                      className={`px-3 py-1 ${!principleTag ? "bg-primary text-white" : ""}`}
-                      style={{ cursor: "pointer" }}
-                      onClick={() => {
-                        setPrincipleTag(null);
-                        setIsDropdownOpen(false);
-                        setPrincipleSearchTerm("");
-                      }}
-                      onMouseEnter={(e) => {
-                        if (!principleTag) return;
-                        e.currentTarget.style.backgroundColor = "#f8f9fa";
-                      }}
-                      onMouseLeave={(e) => {
-                        if (!principleTag) return;
-                        e.currentTarget.style.backgroundColor = "";
-                      }}
-                    >
-                      No principle (Untagged)
-                    </div>
+                    {(formMode !== "edit" ||
+                      (formMode === "edit" && !hasCriterionPrinciple)) && (
+                      <div
+                        className={`px-3 py-1 ${!principleTag ? "bg-primary text-white" : ""}`}
+                        style={{ cursor: "pointer" }}
+                        onClick={() => {
+                          setPrincipleTag(null);
+                          setIsDropdownOpen(false);
+                          setPrincipleSearchTerm("");
+                        }}
+                        onMouseEnter={(e) => {
+                          if (!principleTag) return;
+                          e.currentTarget.style.backgroundColor = "#f8f9fa";
+                        }}
+                        onMouseLeave={(e) => {
+                          if (!principleTag) return;
+                          e.currentTarget.style.backgroundColor = "";
+                        }}
+                      >
+                        No principle (Untagged)
+                      </div>
+                    )}
 
                     {filteredPrinciplesForForm.length === 0 &&
                     principleSearchTerm ? (

--- a/src/pages/assessment-builder/AssessmentBuilderPreview.tsx
+++ b/src/pages/assessment-builder/AssessmentBuilderPreview.tsx
@@ -40,7 +40,7 @@ interface AssessmentBuilderPreviewProps {
   setIsPrincipleSelected: React.Dispatch<React.SetStateAction<boolean>>;
   isTestSelected: boolean;
   setIsTestSelected: React.Dispatch<React.SetStateAction<boolean>>;
-  canEditCriterion: boolean;
+  canEditMetricAndTests: boolean;
 }
 
 function AssessmentBuilderPreview({
@@ -56,7 +56,7 @@ function AssessmentBuilderPreview({
   setIsPrincipleSelected,
   isTestSelected,
   setIsTestSelected,
-  canEditCriterion,
+  canEditMetricAndTests,
 }: AssessmentBuilderPreviewProps) {
   const { keycloak, registered } = useContext(AuthContext)!;
   const [isAdvancedSettingsOpen, setIsAdvancedSettingsOpen] = useState(false);
@@ -262,7 +262,7 @@ function AssessmentBuilderPreview({
                   )}
                 </div>
                 <div className={styles["advanced-settings-container"]}>
-                  {isPrincipleAssigned && canEditCriterion && (
+                  {isPrincipleAssigned && canEditMetricAndTests && (
                     <button
                       className={styles["advanced-settings-btn"]}
                       onClick={() => setIsAdvancedSettingsOpen((prev) => !prev)}
@@ -535,7 +535,7 @@ function AssessmentBuilderPreview({
                                 })
                               }
                               onTestEdit={
-                                canEditCriterion
+                                canEditMetricAndTests
                                   ? () => {
                                       setBuilderState((prevState) => ({
                                         ...prevState,

--- a/src/pages/assessment-builder/utils/assessmentBuilderUtils.ts
+++ b/src/pages/assessment-builder/utils/assessmentBuilderUtils.ts
@@ -661,6 +661,31 @@ export const canEditCriterion = ({
   const currentMotivation = usedByMotivations?.find(
     (motivation) => motivation.id === mtvId,
   );
+  if (currentMotivation && currentMotivation.first_actor_assignment === actId) {
+    return true;
+  }
+
+  return false;
+};
+
+export const canEditMetricAndTests = ({
+  currentCriterion,
+  mtvId,
+  actId,
+}: {
+  currentCriterion: Criterion | undefined;
+  mtvId: string;
+  actId: string;
+}): boolean => {
+  const usedByMotivations = currentCriterion?.used_by_motivations;
+
+  if (!usedByMotivations || usedByMotivations.length === 0) {
+    return true;
+  }
+
+  const currentMotivation = usedByMotivations?.find(
+    (motivation) => motivation.id === mtvId,
+  );
   if (currentMotivation) {
     return currentMotivation.first_actor_assignment === actId;
   }


### PR DESCRIPTION
This PR includes some improvements to optimize data fetching and enhance user experience in the AssessmentBuilder.

- Refactored data fetching to automatically load all pages
- Added canEditMetricAndTests function for permission checking on criterion-related actions
- Prevented users from removing principle assignment to "untagged" when editing criteria that already have principles assigned