### PR TITLE
CAT-947 Update validation request form and optional functionality of …

### DIFF
--- a/src/assets/locales/en.json
+++ b/src/assets/locales/en.json
@@ -234,6 +234,7 @@
     "subtitle": "All validation Requests in one place.",
     "org_name": "Organization Name",
     "org_role": "Organization Role",
+    "org": "Organization",
     "actor_name": "Actor Name",
     "tip_view": "View Validation Request"
   },

--- a/src/config.tsx
+++ b/src/config.tsx
@@ -41,6 +41,8 @@ const themeHomeBenefits = config.theme?.home?.display_benefits ?? true;
 const themeActorArt = config.theme?.actor_art;
 const themeAbout = config.theme?.about?.display ?? true;
 
+const autoSubjectType = config.auto_subject_type ?? "";
+
 export {
   API,
   relMtvActorId,
@@ -64,4 +66,5 @@ export {
   themeActorArt,
   themeAbout,
   pidSelectionView,
+  autoSubjectType,
 };

--- a/src/pages/assessments/AssessmentEdit.tsx
+++ b/src/pages/assessments/AssessmentEdit.tsx
@@ -60,6 +60,7 @@ import { useTranslation } from "react-i18next";
 import { GroupTestModal } from "./components/tests/GroupTestModal";
 import { FaGears } from "react-icons/fa6";
 import ROUTES from "../../routes";
+import { autoSubjectType } from "@/config";
 
 type AssessmentEditProps = {
   mode: AssessmentEditMode;
@@ -436,6 +437,16 @@ const AssessmentEdit = ({
       setAssessment((prev_assessment) => ({
         ...templateData!,
         ...prev_assessment!,
+        ...(mode === AssessmentEditMode.Create && autoSubjectType
+          ? {
+              subject: {
+                id: organisation?.id || templateData?.organisation.id || "",
+                name:
+                  organisation?.name || templateData?.organisation.name || "",
+                type: autoSubjectType,
+              },
+            }
+          : {}),
         actor: {
           name: actor?.name || templateData?.actor.name || "",
           id: actor?.id || templateData?.actor.id || "",

--- a/src/pages/assessments/components/AssessmentInfo.tsx
+++ b/src/pages/assessments/components/AssessmentInfo.tsx
@@ -51,8 +51,6 @@ export const AssessmentInfo = (props: AssessmentInfoProps) => {
     }
   };
 
-  console.log(accKeys);
-
   // call use effect to react to required field changes
   useEffect(() => {
     setAccKeys((keys) => {

--- a/src/pages/validations/RequestValidation.tsx
+++ b/src/pages/validations/RequestValidation.tsx
@@ -52,23 +52,6 @@ function RequestValidation() {
     isRegistered: registered,
   });
 
-  useEffect(() => {
-    // gather all registry actors types
-    let tmpAct: RegistryActor[] = [];
-
-    // iterate over backend pages and gather all items in the registry actors array
-    if (actData?.pages) {
-      actData.pages.map((page) => {
-        tmpAct = [...tmpAct, ...page.content];
-      });
-      if (actHasNextPage) {
-        actFetchNextPage();
-      }
-    }
-
-    setActors(tmpAct);
-  }, [actData, actHasNextPage, actFetchNextPage]);
-
   type FormValues = {
     organisation_role: string;
     organisation_id: string;
@@ -102,6 +85,30 @@ function RequestValidation() {
       registry_actor_id: registryActorId,
     },
   });
+
+  useEffect(() => {
+    // gather all registry actors types
+    let tmpAct: RegistryActor[] = [];
+
+    // iterate over backend pages and gather all items in the registry actors array
+    if (actData?.pages) {
+      actData.pages.map((page) => {
+        tmpAct = [...tmpAct, ...page.content];
+      });
+      if (actHasNextPage) {
+        actFetchNextPage();
+      }
+    }
+
+    setActors(tmpAct);
+
+    // Automatically select the actor if there's only one
+    if (tmpAct.length === 1) {
+      const singleActor = tmpAct[0];
+      setValue("registry_actor_id", singleActor.id);
+      setRegistryActorID(singleActor.id);
+    }
+  }, [actData, actHasNextPage, actFetchNextPage, setValue]);
 
   const { mutateAsync: refetchValidationRequest } = useValidationRequest({
     organisation_role: organisationRole,
@@ -205,9 +212,11 @@ function RequestValidation() {
               value != "" || t("page_validation_create.err_select"),
           })}
         >
-          <option disabled value={""}>
-            {t("page_validation_create.select_actor")}...
-          </option>
+          {actors && actors.length > 1 && (
+            <option disabled value={""}>
+              {t("page_validation_create.select_actor")}...
+            </option>
+          )}
           {actors &&
             actors.map((t, i) => {
               return (

--- a/src/pages/validations/ValidationDetails.tsx
+++ b/src/pages/validations/ValidationDetails.tsx
@@ -358,7 +358,7 @@ function ValidationDetails(props: ValidationProps) {
                 </section>
               </div>
               <div className="row border-top py-3 mt-4">
-                <h4>{t("fields.organisation")}</h4>
+                <h4>{t("page_validations.org")}</h4>
                 <section className="col-9 disabled">
                   <div>
                     <strong>{t("fields.id")}: </strong>

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -6,6 +6,7 @@ export interface Config {
   theme?: ConfigTheme;
   links?: ConfigLinks;
   g069_providers: Record<string, string>;
+  auto_subject_type?: string;
 }
 
 export type ConfigRelationIds = {


### PR DESCRIPTION
…adding automatically subject info in a new assessment

### Goal
In cases where the CAT instance has only one actor defined, this actor becomes the predefined selected option when a new validation request is created. Also we introduce an optional parameter in the config.json where the type of an automated subject input can be defined (Fox example "AAI Service"). If this is enabled, then when creating a new assessment, CAT will automatically fill the subject fields (id, name and type) based on the validation information that accompanies the assessment

### Implementation
- [x] When there is a single actor available, update the RequestValidation form select box to display only this actor as preselected (Remove the "Please select actor..." place holder in that case)
- [x] Update config to accept optional parameter for automatic subject configuration in new assessment. 
- [x] Update AssessmentEdit to check if this parameter is defined in configuration. If so the create new assessment form will have prefilled the subject fields with id, name, and type taking inforation from the new parameter and the validation organisation properties.