### PR TITLE
[CAT-991] - Assessment Builder Enhancements and Refactoring

### DIFF
--- a/src/api/services/registry.ts
+++ b/src/api/services/registry.ts
@@ -78,6 +78,8 @@ export const useGetAllTestMethods = ({
   });
 
 export const useUpdateTestMethodStatus = (token: string) => {
+  const queryClient = useQueryClient();
+
   return useMutation({
     mutationFn: async ({ id, enabled }: { id: string; enabled: boolean }) => {
       const response = await APIClient(token).put(
@@ -85,6 +87,9 @@ export const useUpdateTestMethodStatus = (token: string) => {
         { enabled },
       );
       return response.data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries(["all-test-methods"]);
     },
     onError: (error: AxiosError) => {
       return handleBackendError(error);

--- a/src/pages/admin/settings/TestMethodsSettings.tsx
+++ b/src/pages/admin/settings/TestMethodsSettings.tsx
@@ -96,7 +96,7 @@ const TestMethodsSettings: React.FC = () => {
   // Convert test methods to SettingsItem format
   const settingsItems: SettingsItem[] = testMethods.map((method) => ({
     id: method.id,
-    label: method.label,
+    label: method?.friendly_label || method.label,
     description: method.description,
     enabled: method?.enabled,
     used_by_published_motivations: method?.used_by_published_motivations,

--- a/src/pages/assessment-builder/AssessmentBuilder.module.css
+++ b/src/pages/assessment-builder/AssessmentBuilder.module.css
@@ -466,7 +466,6 @@
   display: flex;
   gap: 0.3rem;
   align-items: center;
-  height: 1.2rem;
 }
 
 .form-group-parameter label,
@@ -1381,7 +1380,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 40px;
+  width: 54px;
   height: 32px;
   padding: 0;
   font-size: 0.85rem;

--- a/src/pages/assessment-builder/AssessmentBuilderMetric.tsx
+++ b/src/pages/assessment-builder/AssessmentBuilderMetric.tsx
@@ -15,6 +15,7 @@ import {
 import { useUpdateMotivationAlgorithmSettings } from "@/api/services/motivations";
 import { AuthContext } from "@/auth";
 import toast from "react-hot-toast";
+import { round } from "./utils";
 
 interface MetricConfiguration {
   mtr: string;
@@ -35,10 +36,8 @@ interface AssessmentBuilderMetricProps {
   builderState: AssessmentBuilderState;
   mtvId?: string;
   mtrId?: string;
-  refetchAssessmentData: () => void;
   criterionPidGraph?: string;
   motivationMetrics?: MetricFull[];
-  setIsConfiguring: React.Dispatch<React.SetStateAction<boolean>>;
   onClose?: () => void;
 }
 
@@ -47,10 +46,8 @@ function AssessmentBuilderMetric({
   builderState,
   mtvId,
   mtrId,
-  refetchAssessmentData,
   criterionPidGraph,
   motivationMetrics,
-  setIsConfiguring,
   onClose,
 }: AssessmentBuilderMetricProps) {
   const { keycloak, registered } = useContext(AuthContext)!;
@@ -83,6 +80,13 @@ function AssessmentBuilderMetric({
 
   const [initialAdvancedSettigns, setInitialAdvancedSettigs] =
     useState<MetricConfiguration>(defaultConfig);
+
+  // Separate state for input display value to handle decimal point
+  const [displayValue, setDisplayValue] = useState<string>("");
+
+  useEffect(() => {
+    setDisplayValue(metricConfig.value_benchmark?.toString() || "0");
+  }, [metricConfig.value_benchmark]);
 
   useEffect(() => {
     setShowErrors(false);
@@ -178,9 +182,6 @@ function AssessmentBuilderMetric({
       if (algorithmDbId) {
         const promise = mutateUpdateMotivationAlgorithm
           .mutateAsync()
-          .then(() => {
-            refetchAssessmentData();
-          })
           .catch((err) => {
             alert.current = {
               message: t("page_motivations.toast_assign_metric_criterion_fail"),
@@ -196,7 +197,6 @@ function AssessmentBuilderMetric({
           });
       }
 
-      setIsConfiguring(false);
       setShowErrors(false);
       if (onClose) {
         onClose();
@@ -207,6 +207,8 @@ function AssessmentBuilderMetric({
       setIsLoading(false);
     }
   };
+
+  console.log("benchmarkValue:", metricConfig.value_benchmark);
 
   const haveAdvancedSettingsChanged = useMemo(() => {
     return (
@@ -482,7 +484,7 @@ function AssessmentBuilderMetric({
                   ...prev,
                   value_benchmark: Math.max(
                     0,
-                    Number(prev?.value_benchmark || 1) - 1,
+                    round(Number(prev?.value_benchmark || 1) - 1),
                   ),
                 }))
               }
@@ -490,18 +492,53 @@ function AssessmentBuilderMetric({
               ▼
             </button>
             <input
-              type="number"
               min="0"
               max="99"
-              value={metricConfig.value_benchmark?.toString() || "0"}
-              onChange={(e) =>
-                setMetricConfig((prev) => ({
-                  ...prev,
-                  value_benchmark: Number(e.target.value) || 0,
-                }))
-              }
+              value={displayValue}
+              onChange={(e) => {
+                const value = e.target.value;
+                if (
+                  (isNaN(Number(value)) && value !== ".") ||
+                  (value?.includes(".") && value.split(".")[1]?.length > 1)
+                ) {
+                  return;
+                }
+
+                if (value === "") {
+                  setMetricConfig((prev) => ({
+                    ...prev,
+                    value_benchmark: 0,
+                  }));
+                  return;
+                }
+
+                if (value.includes("..")) {
+                  return;
+                }
+
+                setDisplayValue(value);
+
+                if (value.endsWith(".")) {
+                  return;
+                }
+
+                const numValue = parseFloat(value);
+
+                // Only update if it's a valid number within range and has max 1 decimal place
+                const decimalPlaces = (value.split(".")[1] || "").length;
+                if (
+                  decimalPlaces <= 1 &&
+                  !isNaN(numValue) &&
+                  numValue >= 0 &&
+                  numValue <= 99
+                ) {
+                  setMetricConfig((prev) => ({
+                    ...prev,
+                    value_benchmark: round(numValue, 1),
+                  }));
+                }
+              }}
               className={styles["spinner-input"]}
-              readOnly
             />
             <button
               className={styles["spinner-btn"]}
@@ -509,7 +546,10 @@ function AssessmentBuilderMetric({
               onClick={() =>
                 setMetricConfig((prev) => ({
                   ...prev,
-                  value_benchmark: Number(prev.value_benchmark || 0) + 1,
+                  value_benchmark: Math.min(
+                    99,
+                    round(Number(prev.value_benchmark || 0) + 1),
+                  ),
                 }))
               }
             >
@@ -526,7 +566,6 @@ function AssessmentBuilderMetric({
         <button
           className={styles["config-cancel-btn"]}
           onClick={() => {
-            setIsConfiguring(false);
             setShowErrors(false);
             if (onClose) {
               onClose();

--- a/src/pages/assessment-builder/AssessmentBuilderPreview.tsx
+++ b/src/pages/assessment-builder/AssessmentBuilderPreview.tsx
@@ -287,8 +287,6 @@ function AssessmentBuilderPreview({
                           mtrId={mtrId}
                           criterionPidGraph={criterionPidGraph}
                           motivationMetrics={motivationMetrics}
-                          refetchAssessmentData={refetchAssessmentData}
-                          setIsConfiguring={setIsAdvancedSettingsOpen}
                           onClose={() => setIsAdvancedSettingsOpen(false)}
                         />
                       </div>
@@ -305,10 +303,13 @@ function AssessmentBuilderPreview({
               </p>
 
               <div
-                className={`${styles["config-header"]} my-3 ${
+                className={`${canEditMetricAndTests && styles["config-header"]} my-3 ${
                   isPrincipleSelected ? styles["selected"] : ""
                 }`}
                 onClick={() => {
+                  if (!canEditMetricAndTests) {
+                    return;
+                  }
                   setIsPrincipleSelected((prev) => {
                     if (!prev) {
                       setIsTestSelected(false);
@@ -369,50 +370,54 @@ function AssessmentBuilderPreview({
                         </span>
                       </OverlayTrigger>
                     </div>
-                    <div className={styles["config-header-right"]}>
-                      <button
-                        className={`${styles["config-edit-btn"]} ${isPrincipleSelected ? styles["selected"] : ""}`}
-                      >
-                        {isPrincipleSelected ? "Editing" : "Edit"}
-                      </button>
-                    </div>
+                    {canEditMetricAndTests && (
+                      <div className={styles["config-header-right"]}>
+                        <button
+                          className={`${styles["config-edit-btn"]} ${isPrincipleSelected ? styles["selected"] : ""}`}
+                        >
+                          {isPrincipleSelected ? "Editing" : "Edit"}
+                        </button>
+                      </div>
+                    )}
                   </>
                 ) : (
-                  <>
-                    <div className={styles["config-header-left"]}>
-                      <span
-                        className={styles["config-header-title"]}
-                        style={{ color: "grey" }}
-                      >
-                        (+) Add a Principle
-                      </span>
-                      <OverlayTrigger
-                        placement="top"
-                        overlay={
-                          <Tooltip id="algorithm-config-tooltip">
-                            Principle is required. Please select a principle for
-                            the criterion.
-                          </Tooltip>
-                        }
-                      >
-                        <span className={styles["config-btn-warning"]}>
-                          <FaExclamationCircle size="18px" />
+                  canEditMetricAndTests && (
+                    <>
+                      <div className={styles["config-header-left"]}>
+                        <span
+                          className={styles["config-header-title"]}
+                          style={{ color: "grey" }}
+                        >
+                          (+) Add a Principle
                         </span>
-                      </OverlayTrigger>
-                    </div>
-                    <div className={styles["config-header-right"]}>
-                      <button
-                        className={`${styles["config-edit-btn"]} ${isPrincipleSelected ? styles["selected"] : ""}`}
-                      >
-                        {isPrincipleSelected ? "Editing" : "Edit"}
-                      </button>
-                    </div>
-                  </>
+                        <OverlayTrigger
+                          placement="top"
+                          overlay={
+                            <Tooltip id="algorithm-config-tooltip">
+                              Principle is required. Please select a principle
+                              for the criterion.
+                            </Tooltip>
+                          }
+                        >
+                          <span className={styles["config-btn-warning"]}>
+                            <FaExclamationCircle size="18px" />
+                          </span>
+                        </OverlayTrigger>
+                      </div>
+                      <div className={styles["config-header-right"]}>
+                        <button
+                          className={`${styles["config-edit-btn"]} ${isPrincipleSelected ? styles["selected"] : ""}`}
+                        >
+                          {isPrincipleSelected ? "Editing" : "Edit"}
+                        </button>
+                      </div>
+                    </>
+                  )
                 )}
               </div>
 
               {/* Tests Configuration Section */}
-              {isPrincipleAssigned && (
+              {isPrincipleAssigned && canEditMetricAndTests && (
                 <div
                   className={`${styles["config-header"]} my-3 
                     ${isTestSelected && styles["selected"]}`}
@@ -528,11 +533,14 @@ function AssessmentBuilderPreview({
                               }}
                               params={getTestParams(test)}
                               testMethodName={test.type}
-                              onTestDelete={() =>
-                                setShowDeleteModal({
-                                  testId: test.id,
-                                  testLabel: test.name,
-                                })
+                              onTestDelete={
+                                canEditMetricAndTests
+                                  ? () =>
+                                      setShowDeleteModal({
+                                        testId: test.id,
+                                        testLabel: test.name,
+                                      })
+                                  : undefined
                               }
                               onTestEdit={
                                 canEditMetricAndTests

--- a/src/pages/assessment-builder/AssessmentBuilderPrinciples.tsx
+++ b/src/pages/assessment-builder/AssessmentBuilderPrinciples.tsx
@@ -234,13 +234,6 @@ function AssessmentBuilderPrinciples({
         principleForm.description
       ) {
         const createPrinciplePromise = createPrincipleToMotivation();
-
-        await toast.promise(createPrinciplePromise, {
-          loading: "Adding principle to motivation...",
-          success: () => alert.current.message,
-          error: () => alert.current.message,
-        });
-
         newPrincipleId = await createPrinciplePromise;
       }
     }

--- a/src/pages/assessment-builder/PreviewTests.tsx
+++ b/src/pages/assessment-builder/PreviewTests.tsx
@@ -176,7 +176,9 @@ function PreviewTests({
       )?.map((index) => {
         if (testToEdit && testToEdit?.params) {
           // Split the string fields by "|" to get individual parameters
-          const paramNames = testToEdit.params.split("|");
+          const paramNames = testToEdit.params
+            ? testToEdit.params.split("|")
+            : [];
           const paramTexts = testToEdit.text ? testToEdit.text.split("|") : [];
           const paramTooltips = testToEdit.tool_tip
             ? testToEdit.tool_tip.split("|")
@@ -289,7 +291,7 @@ function PreviewTests({
         relation: relMtvMetricTest,
       }));
 
-      const createTestPromise = mutateCreateTest
+      mutateCreateTest
         .mutateAsync()
         .then((newTest) => {
           alert.current = {
@@ -331,14 +333,9 @@ function PreviewTests({
           alert.current = {
             message: "Error: " + err.response.data.message,
           };
+          toast.error(alert.current.message);
           throw err;
         });
-
-      toast.promise(createTestPromise, {
-        loading: t("page_tests.toast_create_progress"),
-        success: () => alert.current.message,
-        error: () => alert.current.message,
-      });
     } else if (formMode === "edit") {
       const updateTestPromise = mutateUpdateTest
         .mutateAsync()
@@ -559,13 +556,22 @@ function PreviewTests({
             label: test.label || "",
             description: test.description || "",
           }}
-          params={params}
+          params={
+            hasEvidence &&
+            !params[(params?.length || 1) - 1]?.name?.includes("evidence")
+              ? params.concat({
+                  id: params?.length + 1,
+                  name: "evidence",
+                  text: "",
+                  tooltip: "",
+                })
+              : params
+          }
           testMethodName={
             testMethods?.find(
               (testMethod) => testMethod?.id === test?.test_method_id,
             )?.label || ""
           }
-          hasEvidenceParam={hasEvidence}
         />
       </div>
 

--- a/src/pages/assessment-builder/utils/assessmentBuilderUtils.ts
+++ b/src/pages/assessment-builder/utils/assessmentBuilderUtils.ts
@@ -692,3 +692,8 @@ export const canEditMetricAndTests = ({
 
   return true;
 };
+
+export const round = (value: number, precision = 1) => {
+  const multiplier = Math.pow(10, precision || 0);
+  return Math.round(value * multiplier) / multiplier;
+};

--- a/src/pages/assessments/components/tests/EvidenceURLS.tsx
+++ b/src/pages/assessments/components/tests/EvidenceURLS.tsx
@@ -2,6 +2,7 @@ import { EvidenceURL } from "@/types";
 import { useState } from "react";
 import { InputGroup, Form, Row, Col } from "react-bootstrap";
 import { useTranslation } from "react-i18next";
+import { TestToolTip } from "./TestToolTip";
 
 /**
  * Small component to add url list
@@ -47,6 +48,16 @@ export const EvidenceURLS = (props: EvidenceURLSProps) => {
           <strong>{t("page_assessment_edit.evidence")}:</strong>
         </small>
       )}
+
+      <span className="fw-light-500 text-sm text-secondary">
+        <strong>Can you provide public evidence of such a declaration?</strong>
+        <span className="ms-2">
+          <TestToolTip
+            tipId="evidence-id"
+            tipText="A document, web page, or publication describing the intention"
+          />
+        </span>
+      </span>
 
       <Row className="justify-content-md-right">
         <Col md={10}>

--- a/src/pages/assessments/components/tests/TestAutoHttpsCheckForm.tsx
+++ b/src/pages/assessments/components/tests/TestAutoHttpsCheckForm.tsx
@@ -177,17 +177,9 @@ export const TestAutoHttpsCheckForm = (props: AssessmentTestProps) => {
             )}
         </div>
 
-        {testParams[testParams.length - 1] === "evidence" && (
-          <div className="mt-2">
-            <h6>
-              {textParams[1] && textParams[1]}{" "}
-              {tipParams[1] && (
-                <TestToolTip
-                  tipId={"evidence-" + props.test.id}
-                  tipText={tipParams[1]}
-                />
-              )}
-            </h6>
+        {(testParams[testParams.length - 1] === "evidence" ||
+          testParams?.includes("evidence")) && (
+          <div className="mt-1">
             <EvidenceURLS
               urls={props.test.evidence_url || []}
               onListChange={onURLChange}

--- a/src/pages/assessments/components/tests/TestAutoMd1Form.tsx
+++ b/src/pages/assessments/components/tests/TestAutoMd1Form.tsx
@@ -189,17 +189,9 @@ export const TestAutoMd1Form = (props: AssessmentTestProps) => {
             )}
         </div>
 
-        {testParams[testParams.length - 1] === "evidence" && (
-          <div className="mt-2">
-            <h6>
-              {textParams[1] && textParams[1]}{" "}
-              {tipParams[1] && (
-                <TestToolTip
-                  tipId={"evidence-" + props.test.id}
-                  tipText={tipParams[1]}
-                />
-              )}
-            </h6>
+        {(testParams[testParams.length - 1] === "evidence" ||
+          testParams?.includes("evidence")) && (
+          <div className="mt-1">
             <EvidenceURLS
               urls={props.test.evidence_url || []}
               onListChange={onURLChange}

--- a/src/pages/assessments/components/tests/TestBinaryParamForm.tsx
+++ b/src/pages/assessments/components/tests/TestBinaryParamForm.tsx
@@ -109,15 +109,9 @@ export const TestBinaryParamForm = (props: AssessmentTestProps) => {
       <div>
         <Row>
           <Col>
-            {testParams[testParams.length - 1] === "evidence" && (
-              <div className="mt-2">
-                <span className="fw-light-500 text-sm text-secondary">
-                  <strong>{textParams[textParams?.length - 1]}</strong>
-                  <TestToolTip
-                    tipId={"evidence-" + props.test.id}
-                    tipText={tipParams[tipParams?.length - 1]}
-                  />
-                </span>
+            {(testParams[testParams.length - 1] === "evidence" ||
+              testParams?.includes("evidence")) && (
+              <div className="mt-1">
                 <EvidenceURLS
                   urls={props.test.evidence_url || []}
                   onListChange={onURLChange}

--- a/src/pages/assessments/components/tests/TestPercentForm.tsx
+++ b/src/pages/assessments/components/tests/TestPercentForm.tsx
@@ -154,12 +154,15 @@ export const TestPercentForm = (props: AssessmentTestProps) => {
             </Row>
           </div>
 
-          {testParams[testParams.length - 1] === "evidence" && (
-            <EvidenceURLS
-              urls={props.test.evidence_url || []}
-              onListChange={onURLChange}
-              noTitle={true}
-            />
+          {(testParams[testParams.length - 1] === "evidence" ||
+            testParams?.includes("evidence")) && (
+            <div className="mt-1">
+              <EvidenceURLS
+                urls={props.test.evidence_url || []}
+                onListChange={onURLChange}
+                noTitle={true}
+              />
+            </div>
           )}
         </Col>
       </Row>

--- a/src/pages/assessments/components/tests/TestRatioForm.tsx
+++ b/src/pages/assessments/components/tests/TestRatioForm.tsx
@@ -182,12 +182,15 @@ export const TestRatioForm = (props: AssessmentTestProps) => {
             </Row>
           </div>
 
-          {testParams[testParams.length - 1] === "evidence" && (
-            <EvidenceURLS
-              urls={props.test.evidence_url || []}
-              onListChange={onURLChange}
-              noTitle={true}
-            />
+          {(testParams[testParams.length - 1] === "evidence" ||
+            testParams?.includes("evidence")) && (
+            <div className="mt-1">
+              <EvidenceURLS
+                urls={props.test.evidence_url || []}
+                onListChange={onURLChange}
+                noTitle={true}
+              />
+            </div>
           )}
         </Col>
       </Row>

--- a/src/pages/assessments/components/tests/TestTRLForm.tsx
+++ b/src/pages/assessments/components/tests/TestTRLForm.tsx
@@ -225,12 +225,15 @@ export const TestTRLForm = (props: AssessmentTestProps) => {
             )}
           </div>
 
-          {testParams[testParams.length - 1] === "evidence" && (
-            <EvidenceURLS
-              urls={props.test.evidence_url || []}
-              onListChange={onURLChange}
-              noTitle={true}
-            />
+          {(testParams[testParams.length - 1] === "evidence" ||
+            testParams?.includes("evidence")) && (
+            <div className="mt-1">
+              <EvidenceURLS
+                urls={props.test.evidence_url || []}
+                onListChange={onURLChange}
+                noTitle={true}
+              />
+            </div>
           )}
         </Col>
       </Row>

--- a/src/pages/assessments/components/tests/TestValueFormParam.tsx
+++ b/src/pages/assessments/components/tests/TestValueFormParam.tsx
@@ -239,12 +239,15 @@ export const TestValueFormParam = (props: AssessmentTestProps) => {
               )}
           </div>
 
-          {testParams[testParams.length - 1] === "evidence" && (
-            <EvidenceURLS
-              urls={props.test.evidence_url || []}
-              onListChange={onURLChange}
-              noTitle={true}
-            />
+          {(testParams[testParams.length - 1] === "evidence" ||
+            testParams?.includes("evidence")) && (
+            <div className="mt-1">
+              <EvidenceURLS
+                urls={props.test.evidence_url || []}
+                onListChange={onURLChange}
+                noTitle={true}
+              />
+            </div>
           )}
         </Col>
       </Row>

--- a/src/pages/motivations/components/MotivationActorModal.tsx
+++ b/src/pages/motivations/components/MotivationActorModal.tsx
@@ -299,7 +299,7 @@ export function MotivationActorModal(props: MotivationActorModalProps) {
                       </option>
                       {testMethods.map((item) => (
                         <option key={item.id} value={item.label}>
-                          {item.label}
+                          {item?.friendly_label || item.label}
                         </option>
                       ))}
                     </>

--- a/src/pages/tests/components/TestModalContainer.tsx
+++ b/src/pages/tests/components/TestModalContainer.tsx
@@ -64,9 +64,7 @@ function TestModalContainer(props: TestModalUIProps) {
   const { t } = useTranslation();
   const navigate = useNavigate();
 
-  const testMethodName = testMethods.find(
-    (m) => m.id === test?.test_method_id,
-  )?.label;
+  const testMethod = testMethods.find((m) => m.id === test?.test_method_id);
 
   return (
     <div className="test-container py-3">
@@ -201,7 +199,9 @@ function TestModalContainer(props: TestModalUIProps) {
                   >
                     <div className="fw-bold mb-1 test-method-label">
                       <TestIcon test={method.label} />
-                      <span className="ms-2">{method.label}</span>
+                      <span className="ms-2">
+                        {method?.friendly_label || method.label}
+                      </span>
                     </div>
                     <div className="test-method-description">
                       {method.description}
@@ -243,7 +243,7 @@ function TestModalContainer(props: TestModalUIProps) {
                           Test Method Parameters:
                         </span>
                         <span className="fw-medium fw-bold">
-                          {testMethodName}
+                          {testMethod?.friendly_label || testMethod?.label}
                         </span>
                       </div>
 
@@ -271,7 +271,6 @@ function TestModalContainer(props: TestModalUIProps) {
                       testMethods.find((m) => m.id === test?.test_method_id)
                         ?.label
                     }
-                    hasEvidenceParam={hasEvidence}
                   />
                 </div>
               </div>

--- a/src/pages/tests/components/TestPreviewModal.tsx
+++ b/src/pages/tests/components/TestPreviewModal.tsx
@@ -1,5 +1,4 @@
 import { TestInput, TestParam } from "@/types/tests";
-import { EvidenceURLS, TestToolTip } from "@/pages/assessments/components";
 import { TestBinaryParamForm } from "@/pages/assessments/components/tests/TestBinaryParamForm";
 import { FaEdit, FaTrash } from "react-icons/fa";
 import {
@@ -25,7 +24,6 @@ interface TestPreviewProps {
   test: TestInput;
   params: TestParam[];
   testMethodName?: string;
-  hasEvidenceParam?: boolean;
   onTestEdit?: () => void;
   onTestDelete?: () => void;
 }
@@ -34,7 +32,6 @@ const TestPreviewModal = ({
   test,
   params,
   testMethodName,
-  hasEvidenceParam,
   onTestEdit,
   onTestDelete,
 }: TestPreviewProps) => {
@@ -359,23 +356,6 @@ const TestPreviewModal = ({
               </div>
             )}
           </div>
-
-          {hasEvidenceParam && (
-            <div className="mb-2">
-              <span className="fw-light-500 text-sm text-secondary">
-                <strong>
-                  Can you provide public evidence of such a declaration?
-                </strong>
-                <span className="ms-2">
-                  <TestToolTip
-                    tipId="evidence-id"
-                    tipText="A document, web page, or publication describing the intention"
-                  />
-                </span>
-              </span>
-              <EvidenceURLS urls={[]} onListChange={() => {}} noTitle={true} />
-            </div>
-          )}
         </div>
       ) : null}
     </>


### PR DESCRIPTION
This PR includes several improvements and refactoring tasks for the Assessment Builder functionality to enhance user experience and fix existing issues.

- Prevent editing of all entities (criterion/principle/metric/test) that belong to different actors within the same motivation
- Support float numbers with up to one decimal digit for metric benchmark value
- Enable direct typing of decimal numbers in benchmark value fields with proper validation
- Add descriptive text and helpful tooltips for the Evidence parameter option
- Display single toast notification instead of duplicate messages when creating tests or principles
- Fix modal state handling to prevent closing other modals when advanced settings modal opens
- Show friendly labels for test methods for each component that use them