### PR TITLE
[CAT-992] - Improve Layout and UX for Assessment Builder Test Creation Form

### DIFF
--- a/src/pages/assessment-builder/AssessmentBuilder.module.css
+++ b/src/pages/assessment-builder/AssessmentBuilder.module.css
@@ -414,25 +414,39 @@
 
 .form-group-test-preview {
   display: flex;
-  flex-direction: row;
-  gap: 2.5rem;
+  flex-direction: column;
   align-items: flex-start;
+  width: 100%;
 }
 
 .form-group-test-preview-label {
-  width: 100%;
+  margin-bottom: 0.2rem;
   font-size: 1rem;
   font-weight: 600;
   color: #374151;
   border-bottom: 1px solid #e5e7eb;
 }
 
-.test-params-fields-col {
+.test-info-row {
+  display: flex;
+  flex-direction: row;
+  gap: 1.5rem;
+  width: 100%;
+  margin-bottom: 0.3rem;
+}
+
+.test-info-left {
   display: flex;
   flex: 1;
   flex-direction: column;
-  gap: 0.2rem;
-  max-width: 48%;
+  gap: 0.1rem;
+}
+
+.test-info-right {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  gap: 0.1rem;
 }
 
 @media (width <= 900px) {
@@ -441,8 +455,8 @@
     gap: 1rem;
   }
 
-  .test-params-fields-col {
-    max-width: 100%;
+  .test-info-row {
+    flex-direction: column;
   }
 }
 
@@ -474,17 +488,6 @@
   font-size: 0.875rem;
   font-weight: 500;
   color: #555;
-}
-
-.test-preview-modal input {
-  padding: 0.25rem 0.5rem;
-  font-size: 0.875rem;
-  border: 1px solid #d1d5db;
-  border-radius: 0.375rem;
-}
-
-.test-preview-modal textarea {
-  resize: none;
 }
 
 .form-control {
@@ -903,35 +906,17 @@
   }
 }
 
-/* Algorithm Configuration Styles */
-.algorithm-config-container {
-  background: transparent;
-}
-
-.algorithm-config-container.expanded {
-  margin-bottom: 1rem;
-  overflow: hidden;
-  background: white;
-  border-radius: 0.5rem;
-  outline: 1px solid #e5e7eb;
-}
-
-.algorithm-config-container.expanded:hover {
-  outline-color: #d1d5db;
-  box-shadow: 0 2px 8px rgb(0 0 0 / 10%);
-}
-
 .config-header {
   display: flex;
   gap: 1.2rem;
   align-items: center;
   justify-content: space-between;
   width: 100%;
-  padding: 0.4rem;
+  padding: 0.5rem;
   font-size: 0.875rem;
   cursor: pointer;
   background: transparent;
-  border: 1px dashed #d1d5db;
+  border: 1px solid #f3f4f6;
   border-radius: 0.375rem;
   transition: all 0.2s ease;
 }
@@ -942,15 +927,7 @@
 
 .config-header.selected {
   background: #eaebed;
-  box-shadow: 0 2px 4px rgb(0 0 0 / 10%);
-}
-
-.config-header.expanded {
-  padding: 0.6rem 1rem;
-  background: #f8f9fa;
-  border: none;
-  border-bottom: 1px solid #e5e7eb;
-  border-radius: 0;
+  box-shadow: 0 1px 3px rgb(0 0 0 / 6%);
 }
 
 .config-edit-btn {
@@ -1429,6 +1406,27 @@
 .test-preview-modal {
   margin-bottom: 3rem;
   box-shadow: 1px 2px 4px 0 rgb(0 0 0 / 20%);
+  transition: all 0.3s ease;
+}
+
+.test-preview-modal.creating-test {
+  margin-top: 1rem;
+  margin-bottom: 2rem;
+  background: #f8fafc;
+  border: 2px solid #3b82f6;
+  border-radius: 0.75rem;
+  box-shadow: 0 4px 12px rgb(59 130 246 / 20%);
+}
+
+.test-preview-modal input {
+  padding: 0.25rem 0.5rem;
+  font-size: 0.875rem;
+  border: 1px solid #d1d5db;
+  border-radius: 0.375rem;
+}
+
+.test-preview-modal textarea {
+  resize: none;
 }
 
 .test-method-item {

--- a/src/pages/assessment-builder/AssessmentBuilderPreview.tsx
+++ b/src/pages/assessment-builder/AssessmentBuilderPreview.tsx
@@ -419,7 +419,7 @@ function AssessmentBuilderPreview({
               {/* Tests Configuration Section */}
               {isPrincipleAssigned && canEditMetricAndTests && (
                 <div
-                  className={`${styles["config-header"]} my-3 
+                  className={`${styles["config-header"]} mt-4
                     ${isTestSelected && styles["selected"]}`}
                   onClick={() => {
                     if (!isPrincipleAssigned) return;
@@ -506,24 +506,23 @@ function AssessmentBuilderPreview({
                     {tests &&
                       tests.length > 0 &&
                       tests.map((test) => (
-                        <div
-                          key={test.id}
-                          className={`${styles["test-item"]} my-3`}
-                        >
+                        <div key={test.id} className="mt-3 mb-4">
                           {testToEdit &&
                           testToEdit.id === test.id &&
                           builderState.formMode === "edit" ? (
-                            <PreviewTests
-                              mtvId={mtvId || ""}
-                              mtrId={mtrId || ""}
-                              assessment={assessment}
-                              setBuilderState={setBuilderState}
-                              refetchAssessmentData={refetchAssessmentData}
-                              setIsTestSelected={setIsTestSelected}
-                              formMode={builderState.formMode}
-                              testToEdit={testToEdit}
-                              setTestToEdit={setTestToEdit}
-                            />
+                            <div className="mb-5">
+                              <PreviewTests
+                                mtvId={mtvId || ""}
+                                mtrId={mtrId || ""}
+                                assessment={assessment}
+                                setBuilderState={setBuilderState}
+                                refetchAssessmentData={refetchAssessmentData}
+                                setIsTestSelected={setIsTestSelected}
+                                formMode={builderState.formMode}
+                                testToEdit={testToEdit}
+                                setTestToEdit={setTestToEdit}
+                              />
+                            </div>
                           ) : (
                             <TestPreviewModal
                               test={{

--- a/src/pages/assessment-builder/PreviewTests.tsx
+++ b/src/pages/assessment-builder/PreviewTests.tsx
@@ -363,184 +363,196 @@ function PreviewTests({
 
   return (
     <div
-      className={`${styles["test-preview-modal"]} border rounded px-3 py-2 ${testToEdit && "my-4"}`}
+      className={`${styles["test-preview-modal"]} ${styles["creating-test"]} border rounded px-3 py-2 ${testToEdit && "my-4"}`}
     >
-      <div className={`${styles["form-group-test-preview"]} mb-2`}>
-        <div className={styles["test-params-fields-col"]}>
-          <label className={styles["form-group-test-preview-label"]}>
-            Test Information
-          </label>
+      <div className={`${styles["form-group-test-preview"]} mb-3`}>
+        <label className={styles["form-group-test-preview-label"]}>
+          Test Information
+        </label>
 
-          <div className={styles["form-group-parameter"]}>
-            <label htmlFor="input-test-tes">TES (*):</label>
-            <input
-              className={styles["form-control"]}
-              disabled={formMode === "edit"}
-              type="text"
-              id="input-test-tes"
-              value={test.tes}
-              onChange={(e) =>
-                setTest((prev) => ({ ...prev, tes: e.target.value }))
-              }
-              placeholder="Enter test identifier"
-            />
-            {showErrors && test.tes === "" && (
-              <span className={styles["invalid-feedback"]}>
-                {t("required")}
-              </span>
-            )}
+        <div className={styles["test-info-row"]}>
+          <div className={styles["test-info-left"]}>
+            <div className={styles["form-group-parameter"]}>
+              <label htmlFor="input-test-tes">TES (*):</label>
+              <input
+                className={styles["form-control"]}
+                disabled={formMode === "edit"}
+                type="text"
+                id="input-test-tes"
+                value={test.tes}
+                onChange={(e) =>
+                  setTest((prev) => ({ ...prev, tes: e.target.value }))
+                }
+                placeholder="Enter test identifier"
+              />
+              {showErrors && test.tes === "" && (
+                <span className={styles["invalid-feedback"]}>
+                  {t("required")}
+                </span>
+              )}
+            </div>
+
+            <div className={styles["form-group-parameter"]}>
+              <label htmlFor="input-test-label">Label (*):</label>
+              <input
+                type="text"
+                id="input-test-label"
+                value={test.label}
+                onChange={(e) =>
+                  setTest((prev) => ({ ...prev, label: e.target.value }))
+                }
+                className={styles["form-control"]}
+                placeholder="Enter test label"
+              />
+              {showErrors && test.label === "" && (
+                <span className={styles["invalid-feedback"]}>
+                  {t("required")}
+                </span>
+              )}
+            </div>
           </div>
 
-          <div className={styles["form-group-parameter"]}>
-            <label htmlFor="input-test-label">Label (*):</label>
-            <input
-              type="text"
-              id="input-test-label"
-              value={test.label}
-              onChange={(e) =>
-                setTest((prev) => ({ ...prev, label: e.target.value }))
-              }
-              className={styles["form-control"]}
-              placeholder="Enter test label"
-            />
-            {showErrors && test.label === "" && (
-              <span className={styles["invalid-feedback"]}>
-                {t("required")}
-              </span>
-            )}
-          </div>
-
-          <div className={styles["form-group-parameter"]}>
-            <label htmlFor="input-test-description">Description (*):</label>
-            <textarea
-              id="input-test-description"
-              rows={4}
-              value={test.description}
-              onChange={(e) =>
-                setTest((prev) => ({
-                  ...prev,
-                  description: e.target.value,
-                }))
-              }
-              className={styles["form-control"]}
-              placeholder="Enter test description"
-            />
-            {showErrors && test.description === "" && (
-              <span className={styles["invalid-feedback"]}>
-                {t("required")}
-              </span>
-            )}
+          <div className={styles["test-info-right"]}>
+            <div className={styles["form-group-parameter"]}>
+              <label htmlFor="input-test-description">Description (*):</label>
+              <textarea
+                id="input-test-description"
+                rows={4}
+                value={test.description}
+                onChange={(e) =>
+                  setTest((prev) => ({
+                    ...prev,
+                    description: e.target.value,
+                  }))
+                }
+                className={styles["form-control"]}
+                placeholder="Enter test description"
+              />
+              {showErrors && test.description === "" && (
+                <span className={styles["invalid-feedback"]}>
+                  {t("required")}
+                </span>
+              )}
+            </div>
           </div>
         </div>
 
-        <div className={styles["test-params-fields-col"]}>
-          {params?.length > 0 && (
+        {params?.length > 0 && (
+          <>
             <label className={styles["form-group-test-preview-label"]}>
               {params?.length === 1 ? "Method Parameter" : "Method Parameters"}
               {testMethodName && (
                 <span className="fw-light">: ({testMethodName})</span>
               )}
             </label>
-          )}
 
-          {params?.length > 0 &&
-            params.map((param, index) => (
-              <div key={param.id}>
-                <div className={styles["form-group-parameter"]}>
-                  <label className="fw-medium small">
-                    {params?.length === 1
-                      ? "Parameter Name (*)"
-                      : `Parameter Name ${index + 1} (*)`}
-                  </label>
-                  <input
-                    type="text"
-                    className={styles["form-control"]}
-                    value={param.name}
-                    onChange={(e) =>
-                      updateParam(param.id, "name", e.target.value)
-                    }
-                    placeholder="Enter parameter name"
-                  />
-                </div>
-                {showErrors && param.name === "" && (
-                  <span className={styles["invalid-feedback"]}>
-                    {t("required")}
-                  </span>
-                )}
+            {params.map((param, index) => (
+              <div className={styles["test-info-row"]} key={param.id}>
+                <div className={styles["test-info-left"]}>
+                  <div key={`${param.id}-name-help`}>
+                    <div className={styles["form-group-parameter"]}>
+                      <label className="fw-medium small">
+                        {params?.length === 1
+                          ? "Parameter Name (*)"
+                          : `Parameter Name ${index + 1} (*)`}
+                      </label>
+                      <input
+                        type="text"
+                        className={styles["form-control"]}
+                        value={param.name}
+                        onChange={(e) =>
+                          updateParam(param.id, "name", e.target.value)
+                        }
+                        placeholder="Enter parameter name"
+                      />
+                      {showErrors && param.name === "" && (
+                        <span className={styles["invalid-feedback"]}>
+                          {t("required")}
+                        </span>
+                      )}
+                    </div>
 
-                <div className={styles["form-group-parameter"]}>
-                  <label className="fw-medium small">
-                    {params?.length === 1
-                      ? "Question (*)"
-                      : `Question ${index + 1} (*)`}
-                  </label>
-                  <textarea
-                    rows={2}
-                    className={styles["form-control"]}
-                    value={param.text}
-                    onChange={(e) =>
-                      updateParam(param.id, "text", e.target.value)
-                    }
-                    placeholder="Enter the question"
-                  />
+                    <div className={styles["form-group-parameter"]}>
+                      <label className="fw-medium small">
+                        {params?.length === 1
+                          ? "Help Text (*)"
+                          : `Help Text ${index + 1} (*)`}
+                      </label>
+                      <textarea
+                        rows={2}
+                        className={styles["form-control"]}
+                        value={param.tooltip}
+                        onChange={(e) =>
+                          updateParam(param.id, "tooltip", e.target.value)
+                        }
+                        placeholder="Enter helpful guidance"
+                      />
+                      {showErrors && param.tooltip === "" && (
+                        <span className={styles["invalid-feedback"]}>
+                          {t("required")}
+                        </span>
+                      )}
+                    </div>
+                  </div>
                 </div>
-                {showErrors && param.text === "" && (
-                  <span className={styles["invalid-feedback"]}>
-                    {t("required")}
-                  </span>
-                )}
 
-                <div className={styles["form-group-parameter"]}>
-                  <label className="fw-medium small">
-                    {params?.length === 1
-                      ? "Help Text (*)"
-                      : `Help Text ${index + 1} (*)`}
-                  </label>
-                  <textarea
-                    rows={2}
-                    className={styles["form-control"]}
-                    value={param.tooltip}
-                    onChange={(e) =>
-                      updateParam(param.id, "tooltip", e.target.value)
-                    }
-                    placeholder="Enter helpful guidance"
-                  />
+                <div className={styles["test-info-right"]}>
+                  <div
+                    key={`${param.id}-question`}
+                    className={styles["form-group-parameter"]}
+                  >
+                    <label className="fw-medium small">
+                      {params?.length === 1
+                        ? "Question (*)"
+                        : `Question ${index + 1} (*)`}
+                    </label>
+                    <textarea
+                      rows={4}
+                      className={styles["form-control"]}
+                      value={param.text}
+                      onChange={(e) =>
+                        updateParam(param.id, "text", e.target.value)
+                      }
+                      placeholder="Enter the question"
+                    />
+                    {showErrors && param.text === "" && (
+                      <span className={styles["invalid-feedback"]}>
+                        {t("required")}
+                      </span>
+                    )}
+                  </div>
                 </div>
-                {showErrors && param.tooltip === "" && (
-                  <span className={styles["invalid-feedback"]}>
-                    {t("required")}
-                  </span>
-                )}
               </div>
             ))}
 
-          <div className={styles["evidence-parameter-option"]}>
-            <label className="fw-medium small">Evidence Parameter</label>
-            <OverlayTrigger
-              placement="top"
-              overlay={
-                <Tooltip id="evidence-tooltip">
-                  Please provide an evidence of via a public source or URL to
-                  validate the information with an official reference.
-                </Tooltip>
-              }
-            >
-              <span className="ms-1">
-                <FaInfoCircle className="mb-1" />
-              </span>
-            </OverlayTrigger>
-            <Form.Check
-              className="mt-1"
-              aria-label="evidence-toggle"
-              checked={hasEvidence}
-              id="evidence-toggle"
-              onChange={(e) => {
-                setHasEvidence(e.target.checked);
-              }}
-              type="switch"
-            />
-          </div>
-        </div>
+            <div className={styles["evidence-parameter-option"]}>
+              <label className="fw-medium small">Evidence Parameter</label>
+              <OverlayTrigger
+                placement="top"
+                overlay={
+                  <Tooltip id="evidence-tooltip">
+                    Please provide evidence via a public source or URL to
+                    validate the information with an official reference.
+                  </Tooltip>
+                }
+              >
+                <span className="ms-1">
+                  <FaInfoCircle className="mb-1" />
+                </span>
+              </OverlayTrigger>
+              <Form.Check
+                className="mt-1"
+                aria-label="evidence-toggle"
+                checked={hasEvidence}
+                id="evidence-toggle"
+                onChange={(e) => {
+                  setHasEvidence(e.target.checked);
+                }}
+                type="switch"
+              />
+            </div>
+          </>
+        )}
       </div>
 
       <div className="mb-3">


### PR DESCRIPTION
This PR improves the visual design and user experience of the Assessment Builder's test creation form by reorganizing the layout and enhancing visual clarity.

- Changed from two-column layout to single column with test info at top and parameters below
- Added special highlighting with blue border and background when creating or editing tests
- Improved the "Add Principle" and "Add Test" buttons visibility, keeping the buttons easily accessible after adding tests