### PR TITLE
[CAT-994] - Add Confirmation Dialog for Unsaved Changes When Switching Criteria

### DIFF
--- a/src/pages/assessment-builder/AssessmentBuilder.module.css
+++ b/src/pages/assessment-builder/AssessmentBuilder.module.css
@@ -846,24 +846,6 @@
   background-color: #c82333;
 }
 
-/* Algorithm Configuration Styles */
-.algorithm-config-container {
-  background: transparent;
-}
-
-.algorithm-config-container.expanded {
-  margin-bottom: 1rem;
-  overflow: hidden;
-  outline: 1px solid #e5e7eb;
-  background: white;
-  border-radius: 0.5rem;
-}
-
-.algorithm-config-container.expanded:hover {
-  outline-color: #d1d5db;
-  box-shadow: 0 2px 8px rgb(0 0 0 / 10%);
-}
-
 .config-header {
   display: flex;
   gap: 1.2rem;
@@ -1399,7 +1381,6 @@
   position: absolute;
   top: 6px;
   right: 36px;
-  z-index: 1050;
   flex-shrink: 0;
 }
 

--- a/src/pages/assessment-builder/AssessmentBuilder.tsx
+++ b/src/pages/assessment-builder/AssessmentBuilder.tsx
@@ -56,6 +56,7 @@ function AssessmentBuilder() {
   });
   const [isPrincipleSelected, setIsPrincipleSelected] = useState(false);
   const [isTestSelected, setIsTestSelected] = useState(false);
+  const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
 
   const {
     data: assessmentData,
@@ -367,6 +368,10 @@ function AssessmentBuilder() {
     );
   }, [assessment, builderState.selectedId]);
 
+  const handleUnsavedChangesUpdate = useCallback((hasChanges: boolean) => {
+    setHasUnsavedChanges(hasChanges);
+  }, []);
+
   if (isLoading) {
     return (
       <Container fluid className="py-4">
@@ -440,6 +445,7 @@ function AssessmentBuilder() {
                 setBuilderState={setBuilderState}
                 selectedId={builderState.selectedId || ""}
                 allCriteria={allCriteria}
+                hasUnsavedChanges={hasUnsavedChanges}
               />
             </div>
           </div>
@@ -485,6 +491,7 @@ function AssessmentBuilder() {
                 mtvId: mtvId || "",
                 actId: actId || "",
               })}
+              onUnsavedChangesUpdate={handleUnsavedChangesUpdate}
             />
           </div>
 

--- a/src/pages/assessment-builder/AssessmentBuilderPreview.tsx
+++ b/src/pages/assessment-builder/AssessmentBuilderPreview.tsx
@@ -41,6 +41,7 @@ interface AssessmentBuilderPreviewProps {
   isTestSelected: boolean;
   setIsTestSelected: React.Dispatch<React.SetStateAction<boolean>>;
   canEditMetricAndTests: boolean;
+  onUnsavedChangesUpdate?: (hasChanges: boolean) => void;
 }
 
 function AssessmentBuilderPreview({
@@ -57,6 +58,7 @@ function AssessmentBuilderPreview({
   isTestSelected,
   setIsTestSelected,
   canEditMetricAndTests,
+  onUnsavedChangesUpdate,
 }: AssessmentBuilderPreviewProps) {
   const { keycloak, registered } = useContext(AuthContext)!;
   const [isAdvancedSettingsOpen, setIsAdvancedSettingsOpen] = useState(false);
@@ -227,6 +229,19 @@ function AssessmentBuilderPreview({
   const cancelDeleteTest = () => {
     setShowDeleteModal({ testId: "", testLabel: "" });
   };
+
+  const hasUnsavedChanges =
+    isPrincipleSelected ||
+    isTestSelected ||
+    isAdvancedSettingsOpen ||
+    (builderState.entityMode === "principle" &&
+      builderState.formMode === "new") ||
+    (builderState.entityMode === "test" &&
+      (builderState.formMode === "new" || builderState.formMode === "edit"));
+
+  useEffect(() => {
+    onUnsavedChangesUpdate?.(hasUnsavedChanges);
+  }, [hasUnsavedChanges, onUnsavedChangesUpdate]);
 
   return (
     <div className={styles["column-content"]}>

--- a/src/pages/assessment-builder/AssessmentBuilderStructure.tsx
+++ b/src/pages/assessment-builder/AssessmentBuilderStructure.tsx
@@ -30,6 +30,7 @@ function AssessmentBuilderStructure({
   setAssessment,
   selectedId,
   allCriteria,
+  hasUnsavedChanges,
 }: {
   mtvId: string;
   actId: string;
@@ -38,6 +39,7 @@ function AssessmentBuilderStructure({
   setAssessment: React.Dispatch<React.SetStateAction<AssessmentPrinciple[]>>;
   selectedId?: string;
   allCriteria: Criterion[];
+  hasUnsavedChanges?: boolean;
 }) {
   const { keycloak, registered } = useContext(AuthContext)!;
   const [collapsedPrinciples, setCollapsedPrinciples] = useState<Set<string>>(
@@ -50,6 +52,16 @@ function AssessmentBuilderStructure({
     criterionId: string;
     criterionName: string;
   } | null>(null);
+
+  const [showUnsavedChangesModal, setShowUnsavedChangesModal] = useState(false);
+  const [pendingNavigation, setPendingNavigation] =
+    useState<AssessmentBuilderState | null>({
+      formMode: "none",
+      entityMode: "none",
+      selectedId: "",
+      selectedPrincipleIndex: -1,
+      selectedCriterionIndex: -1,
+    });
 
   const [selectedCriteria, setSelectedCriteria] = useState<Criterion[]>([]);
 
@@ -245,6 +257,46 @@ function AssessmentBuilderStructure({
     setCriterionToDelete(null);
   };
 
+  const handleCriterionClick = (
+    criterionId: string,
+    principleIndex: number,
+    criterionIndex: number,
+  ) => {
+    // Check if we're switching to a different criterion and have unsaved changes
+    if (hasUnsavedChanges && selectedId !== criterionId) {
+      setPendingNavigation({
+        entityMode: "criterion",
+        formMode: "edit",
+        selectedId: criterionId,
+        selectedPrincipleIndex: principleIndex,
+        selectedCriterionIndex: criterionIndex,
+      });
+      setShowUnsavedChangesModal(true);
+      return;
+    }
+
+    setBuilderState({
+      entityMode: "criterion",
+      formMode: "edit",
+      selectedId: criterionId,
+      selectedPrincipleIndex: principleIndex,
+      selectedCriterionIndex: criterionIndex,
+    });
+  };
+
+  const confirmDiscardChanges = () => {
+    if (pendingNavigation) {
+      setBuilderState(pendingNavigation);
+    }
+    setShowUnsavedChangesModal(false);
+    setPendingNavigation(null);
+  };
+
+  const cancelDiscardChanges = () => {
+    setShowUnsavedChangesModal(false);
+    setPendingNavigation(null);
+  };
+
   return (
     <div className={styles["structure-tree"]}>
       {assessment?.map((principle: AssessmentPrinciple, principleIndex) => {
@@ -287,13 +339,11 @@ function AssessmentBuilderStructure({
                         : ""
                     }`}
                     onClick={() =>
-                      setBuilderState({
-                        entityMode: "criterion",
-                        formMode: "edit",
-                        selectedId: criterion.id,
-                        selectedPrincipleIndex: principleIndex,
-                        selectedCriterionIndex: criterionIndex,
-                      })
+                      handleCriterionClick(
+                        criterion.id,
+                        principleIndex,
+                        criterionIndex,
+                      )
                     }
                   >
                     <div className="d-flex align-items-center gap-1">
@@ -411,13 +461,11 @@ function AssessmentBuilderStructure({
                           selectedId === criterion.id ? styles["selected"] : ""
                         }`}
                         onClick={() =>
-                          setBuilderState({
-                            entityMode: "criterion",
-                            formMode: "edit",
-                            selectedId: criterion.id,
-                            selectedPrincipleIndex: untaggedPrincipleIndex,
-                            selectedCriterionIndex: untaggedCriteriaIndex,
-                          })
+                          handleCriterionClick(
+                            criterion.id,
+                            untaggedPrincipleIndex,
+                            untaggedCriteriaIndex,
+                          )
                         }
                       >
                         <span className={styles["tree-icon"]}>
@@ -485,6 +533,38 @@ function AssessmentBuilderStructure({
         onConfirm={confirmDelete}
         onCancel={cancelDelete}
       />
+
+      {showUnsavedChangesModal && (
+        <div
+          className={styles["delete-modal-overlay"]}
+          onClick={cancelDiscardChanges}
+        >
+          <div
+            className={styles["delete-modal-content"]}
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h4 className={styles["delete-modal-title"]}>Unsaved Changes</h4>
+            <p className={styles["delete-modal-message"]}>
+              You have unsaved changes. Are you sure you want to discard them
+              and continue?
+            </p>
+            <div className={styles["delete-modal-actions"]}>
+              <button
+                className={styles["delete-modal-cancel-btn"]}
+                onClick={cancelDiscardChanges}
+              >
+                Cancel
+              </button>
+              <button
+                className={styles["delete-modal-remove-btn"]}
+                onClick={confirmDiscardChanges}
+              >
+                Discard Changes
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
Prevents data loss by showing a confirmation dialog when users try to navigate away from a criterion with unsaved changes.

- Added unsaved changes tracking to can detect when users are actively editing principles, tests, or have algorithm settings open
- Added navigation interception to prevent criterion switching when unsaved changes are detected
- Added confirmation modal to show a dialog asking users to discard changes or cancel navigation