### PR TITLE
[CAT-998] - Integrate Assessment Builder Preview Mode into Assessment List

### DIFF
--- a/src/api/services/motivations.ts
+++ b/src/api/services/motivations.ts
@@ -351,7 +351,7 @@ export const useGetAllMotivationMetrics = (
       }
     },
     retry: false,
-    enabled: isRegistered,
+    enabled: isRegistered && mtvId != null && mtvId !== "",
   });
 
 export const useGetMotivationCriteria = (
@@ -376,7 +376,7 @@ export const useGetMotivationCriteria = (
       }
     },
     retry: false,
-    enabled: isRegistered,
+    enabled: isRegistered && mtvId != null && mtvId !== "",
   });
 
 export const useGetMotivationCriteriaMutation = (token: string) => {
@@ -445,7 +445,12 @@ export const useGetMotivationActorCriteria = (
       }
     },
     retry: false,
-    enabled: isRegistered,
+    enabled:
+      isRegistered &&
+      mtvId != null &&
+      mtvId !== "" &&
+      actId != null &&
+      actId !== "",
   });
 
 export const useGetMotivationMetric = ({
@@ -917,6 +922,11 @@ export const useGetMotivationAssessmentTypeTemplate = (
       return failureCount < 2;
     },
     enabled:
-      !!token && isRegistered && mtvId !== undefined && actId !== undefined,
+      !!token &&
+      isRegistered &&
+      mtvId != null &&
+      mtvId !== "" &&
+      actId != null &&
+      actId !== "",
     refetchOnWindowFocus: false,
   });

--- a/src/api/services/templates.ts
+++ b/src/api/services/templates.ts
@@ -35,7 +35,13 @@ export const useGetMotivationTemplate = (
       );
       return response.data;
     },
-    enabled: !!token && isRegistered && mtvId !== "" && actId !== "",
+    enabled:
+      !!token &&
+      isRegistered &&
+      mtvId != null &&
+      mtvId !== "" &&
+      actId != null &&
+      actId !== "",
     refetchOnWindowFocus: false,
   });
 
@@ -54,6 +60,11 @@ export const useGetMotivationAssessmentType = (
       return response.data;
     },
     enabled:
-      !!token && isRegistered && mtvId !== undefined && actId !== undefined,
+      !!token &&
+      isRegistered &&
+      mtvId != null &&
+      mtvId !== "" &&
+      actId != null &&
+      actId !== "",
     refetchOnWindowFocus: false,
   });

--- a/src/pages/assessment-builder/AssessmentBuilder.module.css
+++ b/src/pages/assessment-builder/AssessmentBuilder.module.css
@@ -33,6 +33,7 @@
 .header-actions {
   display: flex;
   gap: 0.75rem;
+  align-items: center;
 }
 
 .builder-layout {
@@ -229,37 +230,6 @@
 .form-actions-tests .btn-secondary {
   height: 36px;
   padding: 0.4rem 0.5rem;
-}
-
-.header-actions .btn-secondary,
-.header-actions .btn-primary {
-  padding: 0.5rem 1rem;
-  font-weight: 500;
-  border-radius: 0.375rem;
-  transition: all 0.2s;
-}
-
-.header-actions .btn-secondary {
-  color: #374151;
-  background: #f8f9fa;
-  border: 1px solid #d1d5db;
-}
-
-.header-actions .btn-secondary:hover {
-  background: #e5e7eb;
-  border-color: #9ca3af;
-  box-shadow: 0 2px 4px rgb(0 0 0 / 10%);
-}
-
-.header-actions .btn-primary {
-  color: white;
-  background: #3b82f6;
-  border: none;
-}
-
-.header-actions .btn-primary:hover {
-  background: #2563eb;
-  box-shadow: 0 4px 8px rgb(59 130 246 / 30%);
 }
 
 .btn-outline-primary {
@@ -512,17 +482,6 @@
   margin: 0;
   font-size: 0.875rem;
   color: #dc3545;
-}
-
-.header-actions .btn-primary:disabled {
-  cursor: not-allowed;
-  background: #9ca3af;
-  box-shadow: none;
-}
-
-.header-actions .btn-primary:disabled:hover {
-  background: #9ca3af;
-  box-shadow: none;
 }
 
 .column-content .builder-preview {

--- a/src/pages/assessment-builder/AssessmentBuilder.tsx
+++ b/src/pages/assessment-builder/AssessmentBuilder.tsx
@@ -1,15 +1,12 @@
 import { useParams, useNavigate } from "react-router-dom";
 import { useTranslation } from "react-i18next";
-import { useState, useContext, useEffect, useRef, useCallback } from "react";
-import toast from "react-hot-toast";
+import { useState, useContext, useEffect, useCallback } from "react";
 import { Button, Container, Spinner } from "react-bootstrap";
+import { FaEye } from "react-icons/fa";
 import { AuthContext } from "@/auth";
 import { useGetAllPrinciples, useGetMotivationAssessmentType } from "@/api";
 import { useGetMotivationAssessmentTypeTemplate } from "@/api/services/motivations";
 import {
-  usePublishMotivationActor,
-  useUnpublishMotivationActor,
-  useGetMotivation,
   useGetMotivationCriteriaMutation,
   useGetAllMotivationMetrics,
 } from "@/api/services/motivations";
@@ -17,7 +14,6 @@ import { useQueryClient } from "@tanstack/react-query";
 import {
   type Principle,
   type AssessmentBuilderState,
-  type AlertInfo,
   type RegistryMetric,
   type Criterion,
   type AssessmentTest,
@@ -25,6 +21,7 @@ import {
   type Assessment,
   type AssessmentPrinciple,
   AssessmentCriterionImperative,
+  type AutoGroupTest,
 } from "@/types";
 import { useGetAllCriteria } from "../../api/services/criteria";
 import { useGetAllTests } from "@/api/services/registry";
@@ -40,7 +37,29 @@ import { canEditMetricAndTests } from "./utils";
 import styles from "./AssessmentBuilder.module.css";
 import AssessmentEvalStats from "./AssessmentEvalStats";
 
-function AssessmentBuilder({ isEditing }: { isEditing?: boolean }) {
+interface AssessmentBuilderProps {
+  assessmentTemplate?: Assessment;
+  setAssessmentTemplate?: React.Dispatch<
+    React.SetStateAction<Assessment | undefined>
+  >;
+  isEditing?: boolean;
+  onAutoTestGroup?: (autoGroup: AutoGroupTest) => void;
+  onAssessmentCreate?: () => void;
+  onSaveAssessmentChanges?: (exit?: boolean) => void;
+  onAssessmentSubmit?: (exit?: boolean) => void;
+  wizardTabActive?: boolean;
+}
+
+function AssessmentBuilder({
+  assessmentTemplate,
+  setAssessmentTemplate,
+  isEditing,
+  onAutoTestGroup,
+  onAssessmentCreate,
+  onSaveAssessmentChanges,
+  onAssessmentSubmit,
+  wizardTabActive,
+}: AssessmentBuilderProps) {
   const { mtvId, actId } = useParams<{
     mtvId: string;
     actId: string;
@@ -50,9 +69,6 @@ function AssessmentBuilder({ isEditing }: { isEditing?: boolean }) {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
 
-  const alert = useRef<AlertInfo>({
-    message: "",
-  });
   const { t } = useTranslation();
 
   const [builderState, setBuilderState] = useState<AssessmentBuilderState>({
@@ -74,14 +90,14 @@ function AssessmentBuilder({ isEditing }: { isEditing?: boolean }) {
     mtvId || "",
     actId || "",
     keycloak?.token || "",
-    registered,
+    registered && !assessmentTemplate,
   );
 
   const { data: assessmentTemplateData } = useGetMotivationAssessmentType(
     mtvId || "",
     actId || "",
     keycloak?.token || "",
-    registered,
+    registered && !assessmentTemplate,
   );
 
   const [assessment, setAssessment] = useState<AssessmentPrinciple[]>(
@@ -91,6 +107,10 @@ function AssessmentBuilder({ isEditing }: { isEditing?: boolean }) {
   const [motivationMetrics, setMotivationMetrics] = useState<RegistryMetric[]>(
     [],
   );
+
+  // Use props if available, otherwise use local state
+  const currentAssessmentInfo = assessmentTemplate || assessmentInfo;
+  const setCurrentAssessmentInfo = setAssessmentTemplate || setAssessmentInfo;
 
   const [allTests, setAllTests] = useState<RegistryTest[]>([]);
   const [allPrinciples, setAllPrinciples] = useState<Principle[]>([]);
@@ -183,9 +203,11 @@ function AssessmentBuilder({ isEditing }: { isEditing?: boolean }) {
 
   useEffect(() => {
     if (assessmentTemplateData) {
-      setAssessmentInfo(assessmentTemplateData);
+      setCurrentAssessmentInfo(assessmentTemplateData);
     }
-  }, [assessmentTemplateData]);
+  }, [assessmentTemplateData, setCurrentAssessmentInfo]);
+
+  console.log("builderState:", builderState);
 
   useEffect(() => {
     if (
@@ -208,144 +230,101 @@ function AssessmentBuilder({ isEditing }: { isEditing?: boolean }) {
               assessmentData?.principles?.[0]?.criteria?.length > 0 ? 0 : -1,
           });
         }
-      } else {
-        if (
-          assessmentTemplateData &&
-          assessmentTemplateData?.principles?.[0]?.criteria?.length > 0
-        ) {
-          setBuilderState({
-            formMode: "edit",
-            entityMode: "criterion",
-            selectedId:
-              assessmentTemplateData?.principles?.[0]?.criteria?.length > 0
-                ? assessmentTemplateData?.principles?.[0]?.criteria?.[0]?.id
-                : "",
-            selectedPrincipleIndex:
-              assessmentTemplateData?.principles?.length > 0 ? 0 : -1,
-            selectedCriterionIndex:
-              assessmentTemplateData?.principles?.[0]?.criteria?.length > 0
-                ? 0
-                : -1,
-          });
-        }
+      } else if (
+        assessmentTemplateData &&
+        assessmentTemplateData?.principles?.[0]?.criteria?.length > 0
+      ) {
+        setBuilderState({
+          formMode: "edit",
+          entityMode: "criterion",
+          selectedId:
+            assessmentTemplateData?.principles?.[0]?.criteria?.length > 0
+              ? assessmentTemplateData?.principles?.[0]?.criteria?.[0]?.id
+              : "",
+          selectedPrincipleIndex:
+            assessmentTemplateData?.principles?.length > 0 ? 0 : -1,
+          selectedCriterionIndex:
+            assessmentTemplateData?.principles?.[0]?.criteria?.length > 0
+              ? 0
+              : -1,
+        });
       }
+    } else if (
+      assessmentTemplate &&
+      assessmentTemplate?.principles?.[0]?.criteria?.length > 0 &&
+      builderState.formMode === "none" &&
+      builderState.entityMode === "none"
+    ) {
+      console.log("assessmentTemplate:", assessmentTemplate);
+      setBuilderState({
+        formMode: "edit",
+        entityMode: "criterion",
+        selectedId:
+          assessmentTemplate?.principles?.[0]?.criteria?.length > 0
+            ? assessmentTemplate?.principles?.[0]?.criteria?.[0]?.id
+            : "",
+        selectedPrincipleIndex:
+          assessmentTemplate?.principles?.length > 0 ? 0 : -1,
+        selectedCriterionIndex:
+          assessmentTemplate?.principles?.[0]?.criteria?.length > 0 ? 0 : -1,
+      });
     }
   }, [
     assessmentData,
     assessmentTemplateData,
+    assessmentTemplate,
     builderState.formMode,
     builderState.entityMode,
     isEditing,
   ]);
 
-  const { data: motivationData } = useGetMotivation({
-    id: mtvId || "",
-    token: keycloak?.token || "",
-    isRegistered: registered,
-  });
-
-  const isPublished =
-    motivationData?.actors?.find((actor) => actor.id === actId)?.published ||
-    false;
-
-  const mutationPublish = usePublishMotivationActor(keycloak?.token || "");
-  const mutationUnpublish = useUnpublishMotivationActor(keycloak?.token || "");
-
-  const handlePublish = () => {
-    if (!mtvId || !actId) return;
-
-    const promise = mutationPublish
-      .mutateAsync({ mtvId, actId })
-      .catch((err) => {
-        alert.current = {
-          message: t("page_motivations.toast_asmt_publish_fail"),
-        };
-        throw err;
-      })
-      .then(() => {
-        alert.current = {
-          message: t("page_motivations.toast_asmt_publish_success"),
-        };
-        refetchAssessmentData();
-      });
-
-    toast.promise(promise, {
-      loading: t("page_motivations.toast_asmt_publish_progress"),
-      success: () => `${alert.current.message}`,
-      error: () => `${alert.current.message}`,
-    });
-  };
-
-  const handleUnpublish = () => {
-    if (!mtvId || !actId) return;
-
-    const promise = mutationUnpublish
-      .mutateAsync({ mtvId, actId })
-      .catch((err) => {
-        alert.current = {
-          message: t("page_motivations.toast_asmt_unpublish_fail"),
-        };
-        throw err;
-      })
-      .then(() => {
-        alert.current = {
-          message: t("page_motivations.toast_asmt_unpublish_success"),
-        };
-        refetchAssessmentData();
-      });
-
-    toast.promise(promise, {
-      loading: t("page_motivations.toast_asmt_unpublish_progress"),
-      success: () => `${alert.current.message}`,
-      error: () => `${alert.current.message}`,
-    });
-  };
-
-  function handleTestChange(
+  const handleTestChange = (
     principleID: string,
     criterionID: string,
     newTest: AssessmentTest,
-  ) {
+  ) => {
     // update criterion change
     const mandatory: (number | null)[] = [];
     const optional: (number | null)[] = [];
 
-    console.log("assessmentInfo", assessmentInfo);
+    console.log("currentAssessmentInfo", currentAssessmentInfo);
 
-    if (assessmentInfo) {
-      const newPrinciples = assessmentInfo?.principles.map((principle) => {
-        if (principle.id === principleID) {
-          const newCriteria = principle.criteria.map((criterion) => {
-            let resultCriterion: AssessmentCriterion;
-            if (criterion.id === criterionID) {
-              const newTests = criterion.metric.tests.map((test) => {
-                if (test.id === newTest.id) {
-                  return newTest;
-                }
-                return test;
-              });
-              let newMetric = { ...criterion.metric, tests: newTests };
-              const { result, value } = evalMetric(newMetric);
-              newMetric = { ...newMetric, result: result, value: value };
-              // create a new criterion object with updates due to changes
-              resultCriterion = { ...criterion, metric: newMetric };
-            } else {
-              // use the old object with no changes
-              resultCriterion = criterion;
-            }
+    if (currentAssessmentInfo) {
+      const newPrinciples = currentAssessmentInfo?.principles.map(
+        (principle) => {
+          if (principle.id === principleID) {
+            const newCriteria = principle.criteria.map((criterion) => {
+              let resultCriterion: AssessmentCriterion;
+              if (criterion.id === criterionID) {
+                const newTests = criterion.metric.tests.map((test) => {
+                  if (test.id === newTest.id) {
+                    return newTest;
+                  }
+                  return test;
+                });
+                let newMetric = { ...criterion.metric, tests: newTests };
+                const { result, value } = evalMetric(newMetric);
+                newMetric = { ...newMetric, result: result, value: value };
+                // create a new criterion object with updates due to changes
+                resultCriterion = { ...criterion, metric: newMetric };
+              } else {
+                // use the old object with no changes
+                resultCriterion = criterion;
+              }
 
-            return resultCriterion;
-          });
+              return resultCriterion;
+            });
 
-          return { ...principle, criteria: newCriteria };
-        }
-        return principle;
-      });
+            return { ...principle, criteria: newCriteria };
+          }
+          return principle;
+        },
+      );
 
       let compliance: boolean | null;
 
       const newAssessment = {
-        ...assessmentInfo,
+        ...currentAssessmentInfo,
         principles: newPrinciples,
       };
       // update criteria result reference tables
@@ -369,17 +348,28 @@ function AssessmentBuilder({ isEditing }: { isEditing?: boolean }) {
         compliance = mandatory.every((result) => result === 1);
       }
 
-      const ranking: number | null = optional.reduce((sum, result) => {
-        if (sum === null || result === null) return null;
-        return sum + result;
-      }, 0);
+      // get how many optional items have passed
+      const optionalPass: number = optional.reduce(
+        (sum: number, current: number | null) => {
+          if (current && current > 0) {
+            return sum + 1;
+          }
+          return sum;
+        },
+        0,
+      );
 
-      setAssessmentInfo({
+      // if there any optional items available, ranking is equal to the percentage of optional passed / total optional
+      // else ranking is 0
+      const ranking =
+        optional.length > 0 ? (optionalPass / optional.length) * 100 : 0;
+
+      setCurrentAssessmentInfo({
         ...newAssessment,
         result: { compliance: compliance, ranking: ranking },
       });
     }
-  }
+  };
 
   useEffect(() => {
     window.scrollTo(0, 70);
@@ -517,30 +507,32 @@ function AssessmentBuilder({ isEditing }: { isEditing?: boolean }) {
     );
   }
 
-  const evalResult = evalAssessment(assessmentInfo);
+  const evalResult = evalAssessment(currentAssessmentInfo);
 
   return (
     <>
       <div className={`${styles["assessment-builder"]} mb-3`}>
         <div className={styles["assessment-builder-header"]}>
           <div className={styles["header-content"]}>
-            <div className="d-flex flex-column">
-              <h1 className={styles["builder-title"]}>
-                {isEditing ? "Assessment Builder" : "Assessment Preview"}
-              </h1>
-              {assessmentData && (
-                <p className="lead m-0">
-                  {t("page_preview.motivation")}:{" "}
-                  <strong>{assessmentData?.assessment_type.name}</strong>{" "}
-                  {t("page_preview.actor")}:{" "}
-                  <strong>{assessmentData?.actor.name}</strong>
-                </p>
-              )}
-            </div>
+            {!assessmentTemplate && (
+              <div className="d-flex flex-column">
+                <h1 className={styles["builder-title"]}>
+                  {isEditing ? "Assessment Builder" : "Assessment Preview"}
+                </h1>
+                {assessmentData && (
+                  <p className="lead m-0">
+                    {t("page_preview.motivation")}:{" "}
+                    <strong>{assessmentData?.assessment_type.name}</strong>{" "}
+                    {t("page_preview.actor")}:{" "}
+                    <strong>{assessmentData?.actor.name}</strong>
+                  </p>
+                )}
+              </div>
+            )}
             {isEditing && (
               <div className={styles["header-actions"]}>
                 <button
-                  className={styles["btn-secondary"]}
+                  className={styles["add-principle-btn"]}
                   onClick={() =>
                     window.open(
                       buildRoute(
@@ -554,33 +546,24 @@ function AssessmentBuilder({ isEditing }: { isEditing?: boolean }) {
                     )
                   }
                 >
+                  <FaEye className="mt-1" />
                   Preview
                 </button>
-                {isPublished ? (
-                  <button
-                    className={styles["btn-outline-primary"]}
-                    onClick={handleUnpublish}
-                  >
-                    Unpublish
-                  </button>
-                ) : (
-                  <button
-                    className={styles["btn-primary"]}
-                    onClick={handlePublish}
-                  >
-                    Publish
-                  </button>
-                )}
               </div>
             )}
           </div>
         </div>
 
         {/* Assessment Status Header */}
-        {!isEditing && evalResult && assessmentInfo?.result && (
+        {!isEditing && evalResult && currentAssessmentInfo?.result && (
           <AssessmentEvalStats
             evalResult={evalResult}
-            assessmentResult={assessmentInfo.result}
+            assessmentResult={currentAssessmentInfo.result}
+            onAssessmentCreate={onAssessmentCreate}
+            onSaveAssessmentChanges={onSaveAssessmentChanges}
+            onAssessmentSubmit={onAssessmentSubmit}
+            wizardTabActive={wizardTabActive}
+            currentAssessmentInfo={currentAssessmentInfo}
           />
         )}
 
@@ -606,10 +589,12 @@ function AssessmentBuilder({ isEditing }: { isEditing?: boolean }) {
                 mtvId={mtvId || ""}
                 actId={actId || ""}
                 assessment={
-                  isEditing ? assessment : assessmentInfo?.principles || []
+                  isEditing
+                    ? assessment
+                    : currentAssessmentInfo?.principles || []
                 }
                 setAssessment={setAssessment}
-                setAssessmentInfo={setAssessmentInfo}
+                setAssessmentInfo={setCurrentAssessmentInfo}
                 setBuilderState={setBuilderState}
                 selectedId={builderState.selectedId || ""}
                 allCriteria={allCriteria}
@@ -644,7 +629,7 @@ function AssessmentBuilder({ isEditing }: { isEditing?: boolean }) {
                 )?.id
               }
               assessment={
-                isEditing ? assessment : assessmentInfo?.principles || []
+                isEditing ? assessment : currentAssessmentInfo?.principles || []
               }
               setAssessment={setAssessment}
               builderState={builderState}
@@ -667,6 +652,8 @@ function AssessmentBuilder({ isEditing }: { isEditing?: boolean }) {
               onUnsavedChangesUpdate={handleUnsavedChangesUpdate}
               isEditing={isEditing}
               onTestChange={handleTestChange}
+              onAutoTestGroup={onAutoTestGroup}
+              autogroups={currentAssessmentInfo?.automated_group_test || []}
             />
           </div>
 
@@ -807,15 +794,19 @@ function AssessmentBuilder({ isEditing }: { isEditing?: boolean }) {
           )}
         </div>
       </div>
-      <Button
-        className="mt-4 ms-1"
-        variant="secondary"
-        onClick={() => {
-          navigate(`/admin/motivations/${mtvId || ""}`);
-        }}
-      >
-        {t("buttons.back")}
-      </Button>
+      {!assessmentTemplate && (
+        <Button
+          className="mt-4 ms-1"
+          variant="secondary"
+          onClick={() =>
+            isEditing
+              ? navigate(`/admin/motivations/${mtvId || ""}`)
+              : navigate(-1)
+          }
+        >
+          {t("buttons.back")}
+        </Button>
+      )}
     </>
   );
 }

--- a/src/pages/assessment-builder/AssessmentBuilderPreview.tsx
+++ b/src/pages/assessment-builder/AssessmentBuilderPreview.tsx
@@ -8,6 +8,7 @@ import {
   type MetricFull,
   type AlertInfo,
   type AssessmentTest,
+  type AutoGroupTest,
 } from "@/types";
 import { FaExclamationCircle, FaInfoCircle, FaSlidersH } from "react-icons/fa";
 import TestPreviewModal from "../tests/components/TestPreviewModal";
@@ -49,6 +50,8 @@ interface AssessmentBuilderPreviewProps {
     criterionId: string,
     newTest: AssessmentTest,
   ) => void;
+  autogroups?: AutoGroupTest[];
+  onAutoTestGroup?: (autoGroup: AutoGroupTest) => void;
 }
 
 function AssessmentBuilderPreview({
@@ -68,6 +71,8 @@ function AssessmentBuilderPreview({
   onUnsavedChangesUpdate,
   isEditing,
   onTestChange,
+  autogroups,
+  onAutoTestGroup,
 }: AssessmentBuilderPreviewProps) {
   const { keycloak, registered } = useContext(AuthContext)!;
   const [isAdvancedSettingsOpen, setIsAdvancedSettingsOpen] = useState(false);
@@ -617,6 +622,8 @@ function AssessmentBuilderPreview({
                               onTestChange={onTestChange}
                               criterionId={criterionId}
                               principleId={principleId}
+                              autogroups={autogroups}
+                              onAutoTestGroup={onAutoTestGroup}
                             />
                           )}
                         </div>

--- a/src/pages/assessment-builder/AssessmentEvalStats.tsx
+++ b/src/pages/assessment-builder/AssessmentEvalStats.tsx
@@ -1,15 +1,25 @@
 import { useTranslation } from "react-i18next";
-import type { AssessmentResult, ResultStats } from "@/types";
+import type { Assessment, AssessmentResult, ResultStats } from "@/types";
 import { prettyPrintRanking } from "@/utils";
 import styles from "./AssessmentBuilder.module.css";
-import { ProgressBar } from "react-bootstrap";
+import { Button, ProgressBar } from "react-bootstrap";
 
 function AssessmentEvalStats({
   evalResult,
   assessmentResult,
+  onAssessmentCreate,
+  onSaveAssessmentChanges,
+  onAssessmentSubmit,
+  wizardTabActive,
+  currentAssessmentInfo,
 }: {
   evalResult: ResultStats;
   assessmentResult: AssessmentResult;
+  onAssessmentCreate?: () => void;
+  onSaveAssessmentChanges?: () => void;
+  onAssessmentSubmit?: () => void;
+  wizardTabActive?: boolean;
+  currentAssessmentInfo?: Assessment | null;
 }) {
   const { t } = useTranslation();
 
@@ -119,6 +129,45 @@ function AssessmentEvalStats({
           </ProgressBar>
         </div>
       )}
+      <div className="d-flex align-items-center ms-auto">
+        {onAssessmentCreate && (
+          <Button
+            id="create_assessment_button"
+            disabled={!wizardTabActive}
+            className="ms-5 btn btn-primary px-5"
+            onClick={onAssessmentCreate}
+          >
+            {t("buttons.create")}
+          </Button>
+        )}
+        {onSaveAssessmentChanges && (
+          <Button
+            id="save_assessment_button"
+            disabled={!wizardTabActive}
+            className="ms-2 px-3"
+            variant="outline-primary"
+            onClick={onSaveAssessmentChanges}
+          >
+            {t("buttons.save_progress")}
+          </Button>
+        )}
+        {onAssessmentSubmit && (
+          <Button
+            id="submit_assessment_button"
+            disabled={
+              !(
+                currentAssessmentInfo &&
+                currentAssessmentInfo.result &&
+                currentAssessmentInfo.result.compliance !== null
+              )
+            }
+            className="ms-2 btn btn-primary px-3"
+            onClick={onAssessmentSubmit}
+          >
+            {t("buttons.submit")}
+          </Button>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/pages/assessments/AssessmentEdit.tsx
+++ b/src/pages/assessments/AssessmentEdit.tsx
@@ -9,12 +9,9 @@ import {
 import {
   type Assessment,
   type AssessmentSubject,
-  type AssessmentTest,
-  AssessmentCriterionImperative,
   type AlertInfo,
   AssessmentEditMode,
   type ActorOrgAsmtType,
-  type AssessmentCriterion,
   type AutoGroupTest,
 } from "@/types";
 import { useParams } from "react-router";
@@ -27,7 +24,7 @@ import {
   Alert,
   Offcanvas,
 } from "react-bootstrap";
-import { AssessmentInfo, CriteriaTabs } from "@/pages/assessments/components";
+import { AssessmentInfo } from "@/pages/assessments/components";
 import {
   FaCheckCircle,
   FaComment,
@@ -40,18 +37,14 @@ import {
   FaTimesCircle,
   FaUsers,
 } from "react-icons/fa";
-import { evalAssessment, evalMetric } from "@/utils";
-
 import {
   useCreateAssessment,
   useGetAssessment,
   useUpdateAssessment,
 } from "@/api";
 import { Link, useNavigate } from "react-router-dom";
-import { AssessmentEvalStats } from "./components/AssessmentEvalStats";
 import { DebugJSON } from "./components/DebugJSON";
 import { AssessmentSelectActor } from "./components/AssessmentSelectActor";
-
 import { toast } from "react-hot-toast";
 import { ShareModal } from "./components/ShareModal";
 import { Comments } from "./components/Comments";
@@ -61,6 +54,7 @@ import { GroupTestModal } from "./components/tests/GroupTestModal";
 import { FaGears } from "react-icons/fa6";
 import ROUTES from "../../routes";
 import { autoSubjectType } from "@/config";
+import AssessmentBuilder from "../assessment-builder/AssessmentBuilder";
 
 type AssessmentEditProps = {
   mode: AssessmentEditMode;
@@ -135,22 +129,8 @@ const AssessmentEdit = ({
   const handleGuideClose = () =>
     setGuide({ id: "", title: "", text: "", show: false });
 
-  const handleGuide = (id: string, title: string, text: string) => {
-    if (id == guide.id) {
-      setGuide({ id: "", title: "", text: "", show: false });
-    } else {
-      setGuide({
-        id: id,
-        text: text,
-        title: title,
-        show: true,
-      });
-    }
-  };
-
   const navigate = useNavigate();
 
-  const [resetCriterionTab, setResetCriterionTab] = useState(false);
   const [importInfo, setImportInfo] = useState<Assessment>();
 
   const qTemplate = useGetMotivationTemplate(
@@ -198,14 +178,12 @@ const AssessmentEdit = ({
       setActiveTab(2 + extraTab);
     } else if (hash === "#assessment") {
       setActiveTab(3 + extraTab);
-      setResetCriterionTab(true);
     }
   }, [extraTab]);
 
   useEffect(() => {
     if (mode === AssessmentEditMode.Edit) {
       setActiveTab(3);
-      setResetCriterionTab(true);
     }
   }, [mode, extraTab]);
 
@@ -233,10 +211,6 @@ const AssessmentEdit = ({
     keycloak?.token || "",
     asmtId,
   );
-
-  function handleResetCriterionTabComplete() {
-    setResetCriterionTab(false);
-  }
 
   // function that checks if the required fields are empty
   function checkRequiredFields(assessment: Assessment): boolean {
@@ -281,12 +255,6 @@ const AssessmentEdit = ({
 
   // handle tab changes in wizard
   function handleChangeTab(tabKey: number) {
-    // if user selects the last step in the wizard (assessment)
-    // triger the reset criterion tab signal so as to select the first
-    // available criterion as the active sub-tab inside assessment
-    if (tabKey == 3) {
-      setResetCriterionTab(true);
-    }
     // set the active tab in the wizard
     setActiveTab(tabKey);
   }
@@ -477,8 +445,6 @@ const AssessmentEdit = ({
   useEffect(() => {
     if (mode !== AssessmentEditMode.Edit && qTemplate.data) {
       const data = qTemplate.data;
-
-      // setAssessment(data);
       setTemplateData(data);
       // if not on create mode load assessment itself
     } else if (mode === AssessmentEditMode.Edit && qAssessment.data) {
@@ -538,98 +504,6 @@ const AssessmentEdit = ({
       reader.readAsText(file);
     }
   };
-
-  function handleCriterionChange(
-    principleID: string,
-    criterionID: string,
-    newTest: AssessmentTest,
-  ) {
-    // update criterion change
-    const mandatory: (number | null)[] = [];
-    const optional: (number | null)[] = [];
-
-    if (assessment) {
-      const newPrinciples = assessment?.principles.map((principle) => {
-        if (principle.id === principleID) {
-          const newCriteria = principle.criteria.map((criterion) => {
-            let resultCriterion: AssessmentCriterion;
-            if (criterion.id === criterionID) {
-              const newTests = criterion.metric.tests.map((test) => {
-                if (test.id === newTest.id) {
-                  return newTest;
-                }
-                return test;
-              });
-              let newMetric = { ...criterion.metric, tests: newTests };
-              const { result, value } = evalMetric(newMetric);
-              newMetric = { ...newMetric, result: result, value: value };
-              // create a new criterion object with updates due to changes
-              resultCriterion = { ...criterion, metric: newMetric };
-            } else {
-              // use the old object with no changes
-              resultCriterion = criterion;
-            }
-
-            return resultCriterion;
-          });
-
-          return { ...principle, criteria: newCriteria };
-        }
-        return principle;
-      });
-
-      let compliance: boolean | null;
-
-      const newAssessment = {
-        ...assessment,
-        principles: newPrinciples,
-      };
-      // update criteria result reference tables
-
-      newAssessment.principles.forEach((principle) => {
-        principle.criteria.forEach((criterion) => {
-          if (
-            criterion.imperative === AssessmentCriterionImperative.Must ||
-            criterion.imperative === AssessmentCriterionImperative.MUST
-          ) {
-            mandatory.push(criterion.metric.result);
-          } else {
-            optional.push(criterion.metric.result);
-          }
-        });
-      });
-
-      if (mandatory.some((result) => result === null)) {
-        compliance = null;
-      } else {
-        compliance = mandatory.every((result) => result === 1);
-      }
-
-      // get how many optional items have passed
-      const optionalPass: number = optional.reduce(
-        (sum: number, current: number | null) => {
-          if (current && current > 0) {
-            return sum + 1;
-          }
-          return sum;
-        },
-        0,
-      );
-
-      // if there any optional items available, ranking is equal to the percentage of optional passed / total optional
-      // else ranking is 0
-      const ranking =
-        optional.length > 0 ? (optionalPass / optional.length) * 100 : 0;
-
-      setAssessment({
-        ...newAssessment,
-        result: { compliance: compliance, ranking: ranking },
-      });
-    }
-  }
-
-  // evaluate the assessment
-  const evalResult = evalAssessment(assessment);
 
   let importDone = true;
   if (mode === AssessmentEditMode.Import) {
@@ -763,7 +637,7 @@ const AssessmentEdit = ({
         }}
       >
         <Card className="mb-3 mt-3">
-          <Card.Header>
+          <Card.Header className="d-flex justify-content-between align-items-center">
             <Nav variant="pills">
               {mode === AssessmentEditMode.Import && (
                 <Nav.Item className="bg-light border rounded me-2">
@@ -827,7 +701,7 @@ const AssessmentEdit = ({
               )}
             </Nav>
           </Card.Header>
-          <Card.Body>
+          <Card.Body className="p-1">
             <Tab.Content className="p-2">
               {mode === AssessmentEditMode.Import && (
                 <Tab.Pane className="text-black" eventKey={"step-1"}>
@@ -1058,16 +932,6 @@ const AssessmentEdit = ({
                 className="text-black"
                 eventKey={`step-${3 + extraTab}`}
               >
-                {evalResult && assessment?.result && (
-                  <AssessmentEvalStats
-                    evalResult={evalResult}
-                    assessmentResult={assessment.result}
-                  />
-                )}
-                <div
-                  className="row bg-secondary"
-                  style={{ height: "1px" }}
-                ></div>
                 {hasAutoGroups && (
                   <div className="row cat-alert-warning-colors p-2">
                     <div>
@@ -1096,15 +960,18 @@ const AssessmentEdit = ({
                     </div>
                   </div>
                 )}
-                <CriteriaTabs
+                <AssessmentBuilder
+                  assessmentTemplate={assessment}
+                  setAssessmentTemplate={setAssessment}
                   onAutoTestGroup={handleAutoTestGroup}
-                  autogroups={assessment?.automated_group_test}
-                  principles={assessment?.principles || []}
-                  resetActiveTab={resetCriterionTab}
-                  onTestChange={handleCriterionChange}
-                  onResetActiveTab={handleResetCriterionTabComplete}
-                  handleGuide={handleGuide}
-                  handleGuideClose={handleGuideClose}
+                  onAssessmentCreate={
+                    mode !== AssessmentEditMode.Edit
+                      ? handleCreateAssessment
+                      : undefined
+                  }
+                  onSaveAssessmentChanges={() => handleUpdateAssessment(false)}
+                  onAssessmentSubmit={() => handleUpdateAssessment(true)}
+                  wizardTabActive={wizardTabActive}
                 />
               </Tab.Pane>
             </Tab.Content>
@@ -1135,9 +1002,8 @@ const AssessmentEdit = ({
                 {`${t("buttons.next")} →`}
               </Button>
             </div>
-            {/* Add SAVE button here and cancel */}
             <div>
-              {mode !== AssessmentEditMode.Edit ? (
+              {mode !== AssessmentEditMode.Edit && (
                 <Button
                   id="create_assessment_button"
                   disabled={!wizardTabActive}
@@ -1148,36 +1014,6 @@ const AssessmentEdit = ({
                 >
                   {t("buttons.create")}
                 </Button>
-              ) : (
-                <>
-                  <Button
-                    id="save_assessment_button"
-                    disabled={!wizardTabActive}
-                    className="ms-2 btn btn-success px-3"
-                    onClick={() => {
-                      handleUpdateAssessment(false);
-                    }}
-                  >
-                    {t("buttons.save_progress")}
-                  </Button>
-
-                  <Button
-                    id="submit_assessment_button"
-                    disabled={
-                      !(
-                        assessment &&
-                        assessment.result &&
-                        assessment.result.compliance !== null
-                      )
-                    }
-                    className="ms-2 btn btn-success px-3"
-                    onClick={() => {
-                      handleUpdateAssessment(true);
-                    }}
-                  >
-                    {t("buttons.submit")}
-                  </Button>
-                </>
               )}
               <Link
                 className="btn btn-secondary ms-5 px-4"

--- a/src/pages/tests/components/TestPreviewModal.tsx
+++ b/src/pages/tests/components/TestPreviewModal.tsx
@@ -3,6 +3,7 @@ import { TestBinaryParamForm } from "@/pages/assessments/components/tests/TestBi
 import { FaEdit, FaTrash } from "react-icons/fa";
 import type {
   AssessmentTest,
+  AutoGroupTest,
   TestAutoG069,
   TestAutoHttpsCheck,
   TestAutoMD1,
@@ -35,6 +36,8 @@ interface TestPreviewProps {
   ) => void;
   criterionId?: string;
   principleId?: string;
+  autogroups?: AutoGroupTest[];
+  onAutoTestGroup?: (autoGroup: AutoGroupTest) => void;
 }
 
 const TestPreviewModal = ({
@@ -46,6 +49,8 @@ const TestPreviewModal = ({
   onTestChange,
   criterionId,
   principleId,
+  autogroups,
+  onAutoTestGroup,
 }: TestPreviewProps) => {
   const testParams: React.JSX.Element[] = [];
 
@@ -217,7 +222,10 @@ const TestPreviewModal = ({
       <TestAutoValidationForm
         key={`auto-validation-${test.tes}`}
         test={adaptedTest}
-        onAutoGroupTestCall={() => {}}
+        autogroup={autogroups?.find(
+          (item) => item.test_method === testMethodName,
+        )}
+        onAutoGroupTestCall={onAutoTestGroup || (() => {})}
       />,
     );
   } else if (testMethodName === "Auto-Check-AARC-G069-User-Info") {

--- a/src/types/assessment.ts
+++ b/src/types/assessment.ts
@@ -12,7 +12,7 @@ export interface TemplateResponse {
 export interface AssessmentType {
   id: string;
   name: string;
-  description: string;
+  description?: string;
 }
 
 /** Actor type part of TemplateResponse from API */
@@ -445,6 +445,7 @@ export interface AssessmentDetailsResponse {
   id: number;
   shared_to_user: boolean;
   assessment_doc: Assessment;
+  assessment_doc_version?: string;
 }
 
 export interface ObjectListItem {


### PR DESCRIPTION
Integrate assessment builder preview mode into the creation workflow, enabling users to build and complete an assessment interactively.

- Connected Assessment Builder Preview mode with assessment list enabling users to complete published assessments
- Updated Assessment Builder to can receive existing assessment data through props instead of managing its own state
- Removed direct publish controls from assessment builder edit mode

