### PR TITLE
[CAT-997] - New Validated User receives 403 during creating assessment

### DIFF
--- a/src/auth/AuthProvider.tsx
+++ b/src/auth/AuthProvider.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useCallback } from "react";
 import {
   AuthContext,
   type AuthContextProps,
@@ -11,6 +11,25 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [registered, setRegistered] = useState(false);
   const [keycloak, setKeycloak] = useState<NullableKeycloak>(null);
 
+  const refreshUserToken = useCallback(async () => {
+    if (!keycloak) {
+      return Promise.reject(new Error("Keycloak instance not available"));
+    }
+
+    try {
+      // Force token refresh with minValidity of -1 to ensure fresh token. This forces refresh regardless of current token validity
+      const refreshed = await keycloak.updateToken(-1);
+
+      if (refreshed) {
+        setKeycloak(keycloak);
+      }
+      return Promise.resolve();
+    } catch (error) {
+      console.error("Token refresh failed:", error);
+      return Promise.reject(error);
+    }
+  }, [keycloak, setKeycloak]);
+
   const authContextValue: AuthContextProps = {
     authenticated,
     setAuthenticated,
@@ -18,6 +37,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     setRegistered,
     keycloak,
     setKeycloak,
+    refreshUserToken,
   };
 
   return (

--- a/src/auth/auth-context.ts
+++ b/src/auth/auth-context.ts
@@ -10,6 +10,7 @@ export interface AuthContextProps {
   setRegistered: React.Dispatch<React.SetStateAction<boolean>>;
   keycloak: NullableKeycloak;
   setKeycloak: React.Dispatch<React.SetStateAction<NullableKeycloak>>;
+  refreshUserToken: () => Promise<void>;
 }
 
 export const AuthContext = createContext<AuthContextProps | null>(null);

--- a/src/pages/Subjects.tsx
+++ b/src/pages/Subjects.tsx
@@ -34,6 +34,7 @@ import toast from "react-hot-toast";
 import { useLocation } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { idToColor } from "@/utils/admin";
+import { useGetProfile } from "@/api";
 
 // Modes under which SubjectModal operates
 const SubjectModalMode = {
@@ -303,7 +304,7 @@ function Subjects() {
   const doCreate = searchParams.has("create");
 
   // mutation hook for creating a new subject
-  const { keycloak } = useContext(AuthContext)!;
+  const { keycloak, registered, refreshUserToken } = useContext(AuthContext)!;
 
   const [opts, setOpts] = useState<SubjectState>({
     page: 1,
@@ -348,6 +349,37 @@ function Subjects() {
       setSubjectModalConfig((prevConfig) => ({ ...prevConfig, show: true }));
     }
   }, [doCreate]);
+
+  const { data: profileData } = useGetProfile({
+    token: keycloak?.token || "",
+    isRegistered: registered,
+  });
+
+  console.log("profileData", profileData);
+
+  useEffect(() => {
+    const checkAndRefreshToken = async () => {
+      if (profileData && keycloak?.token) {
+        const userRoles = profileData?.roles || [];
+        const hasValidRole = userRoles?.some(
+          (role: string) =>
+            role.toLowerCase()?.includes("validated") ||
+            role.toLowerCase()?.includes("admin"),
+        );
+
+        if (!hasValidRole) {
+          try {
+            console.log("refreshUserToken called from Subjects page");
+            await refreshUserToken();
+          } catch (error) {
+            console.error("Failed to refresh token:", error);
+          }
+        }
+      }
+    };
+
+    checkAndRefreshToken();
+  }, [profileData, keycloak?.token, refreshUserToken]);
 
   const handleCreateSubject = (item: Subject) => {
     const promise = mutationCreateSubject

--- a/src/pages/assessments/AssessmentEdit.tsx
+++ b/src/pages/assessments/AssessmentEdit.tsx
@@ -85,7 +85,7 @@ const AssessmentEdit = ({
   const { t } = useTranslation();
   const [reqFields, setReqFields] = useState<string[]>([]);
   const [activeTab, setActiveTab] = useState(1);
-  const { keycloak, registered } = useContext(AuthContext)!;
+  const { keycloak, registered, refreshUserToken } = useContext(AuthContext)!;
   const [assessment, setAssessment] = useState<Assessment>();
   const [actor, setActor] = useState<{ id: string; name: string }>();
   const [organisation, setOrganisation] = useState<{
@@ -109,6 +109,8 @@ const AssessmentEdit = ({
     text: "",
     show: false,
   });
+
+  console.log("keycloak:", keycloak);
 
   // state to show/hide group_testing_modal
   const [groupTestModalConfig, setGroupTestModalConfig] =
@@ -144,6 +146,30 @@ const AssessmentEdit = ({
     token: keycloak?.token || "",
     isRegistered: registered,
   });
+
+  // Check user role and refresh token if needed on component mount
+  useEffect(() => {
+    const checkAndRefreshToken = async () => {
+      if (qProfile?.data && keycloak?.token) {
+        const userRoles = qProfile.data?.roles || [];
+        const hasValidRole = userRoles?.some(
+          (role: string) =>
+            role.toLowerCase()?.includes("validated") ||
+            role.toLowerCase()?.includes("admin"),
+        );
+
+        if (!hasValidRole) {
+          try {
+            await refreshUserToken();
+          } catch (error) {
+            console.error("Failed to refresh token:", error);
+          }
+        }
+      }
+    };
+
+    checkAndRefreshToken();
+  }, [qProfile.data, keycloak?.token, refreshUserToken]);
 
   const asmtNumID = asmtId !== undefined ? asmtId : "";
 

--- a/src/types/profile.ts
+++ b/src/types/profile.ts
@@ -10,6 +10,7 @@ export interface UserProfile {
   email: string;
   updated_on: string;
   banned: boolean;
+  roles: string[];
 }
 
 export interface UserView {


### PR DESCRIPTION
This PR fixes 403 Forbidden errors for newly validated users creating assessments due to stale Keycloak tokens containing outdated role information. We have implemented proactive token refresh logic that detects insufficient permissions on component mount and automatically updates tokens with current user roles, eliminating the need for manual page refresh.

- Implemented refreshUserToken function in AuthProvider to force token refresh from Keycloak
- Added proactive permission validation in AssessmentEdit.tsx and Subjects.tsx components that checks user roles on component mount and triggers token refresh if needed