### PR TITLE
[CAT-1009] - Fix 401 token invalidation not triggering user logout after role change

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,11 @@
+import { useContext, useMemo } from "react";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import {
   QueryCache,
   QueryClient,
   QueryClientProvider,
 } from "@tanstack/react-query";
-
-import { AuthProvider, ProtectedRoute, KeycloakLogout } from "@/auth";
+import { ProtectedRoute, KeycloakLogout, AuthContext } from "@/auth";
 import { Header, Footer } from "@/components";
 import ROUTES from "@/routes";
 import {
@@ -18,12 +18,10 @@ import {
   ValidationDetails,
   AssessmentBuilder,
 } from "@/pages";
-
 import "@/App.css";
 import Assessments from "@/pages/assessments/Assessments";
 import AssessmentsList from "@/pages/assessments/AssessmentsList";
 import AssessmentEdit from "./pages/assessments/AssessmentEdit";
-
 import { Toaster } from "react-hot-toast";
 import Subjects from "./pages/Subjects";
 import { AssessmentEditMode } from "./types";
@@ -61,17 +59,27 @@ import { pidSelectionView, themeAbout } from "./config";
 import { handleBackendError } from "./utils";
 import axios from "axios";
 
-const queryClient = new QueryClient({
-  queryCache: new QueryCache({
-    onError: (error) => {
-      if (axios.isAxiosError(error)) {
-        handleBackendError(error);
-      }
-    },
-  }),
-});
-
 function App() {
+  const { refreshUserToken } = useContext(AuthContext)!;
+
+  const queryClient = useMemo(
+    () =>
+      new QueryClient({
+        queryCache: new QueryCache({
+          onError: async (error) => {
+            if (axios.isAxiosError(error)) {
+              if (error?.response?.status === 401) {
+                await refreshUserToken();
+                return;
+              }
+              handleBackendError(error);
+            }
+          },
+        }),
+      }),
+    [refreshUserToken],
+  );
+
   return (
     <div className="App">
       <Toaster
@@ -101,323 +109,301 @@ function App() {
           },
         }}
       />
-      <AuthProvider>
-        <QueryClientProvider client={queryClient}>
-          <BrowserRouter basename="/">
-            <Header />
-            <main className="cat-main-view">
-              <Routes>
-                <Route path={ROUTES.HOME} element={<Home />} />
-                {themeAbout && (
-                  <>
-                    <Route path={ROUTES.ABOUT.CAT} element={<AboutCat />} />
-                    <Route
-                      path={ROUTES.ABOUT.INTEROPERABILITY}
-                      element={<Interoperability />}
-                    />
-                    <Route
-                      path={ROUTES.ABOUT.ACCEPTABLE_USE}
-                      element={<AcceptableUse />}
-                    />
-                    <Route path={ROUTES.ABOUT.PRIVACY} element={<Privacy />} />
-                    <Route
-                      path={ROUTES.ABOUT.DISCLAIMER}
-                      element={<Disclaimer />}
-                    />
+      <QueryClientProvider client={queryClient}>
+        <BrowserRouter basename="/">
+          <Header />
+          <main className="cat-main-view">
+            <Routes>
+              <Route path={ROUTES.HOME} element={<Home />} />
+              {themeAbout && (
+                <>
+                  <Route path={ROUTES.ABOUT.CAT} element={<AboutCat />} />
+                  <Route
+                    path={ROUTES.ABOUT.INTEROPERABILITY}
+                    element={<Interoperability />}
+                  />
+                  <Route
+                    path={ROUTES.ABOUT.ACCEPTABLE_USE}
+                    element={<AcceptableUse />}
+                  />
+                  <Route path={ROUTES.ABOUT.PRIVACY} element={<Privacy />} />
+                  <Route
+                    path={ROUTES.ABOUT.DISCLAIMER}
+                    element={<Disclaimer />}
+                  />
 
-                    <Route path={ROUTES.ABOUT.COOKIES} element={<Cookies />} />
-                    <Route path={ROUTES.ABOUT.TERMS} element={<Terms />} />
-                  </>
-                )}
-                {pidSelectionView && (
-                  <Route
-                    path={ROUTES.PID_SELECTION}
-                    element={<PidSelection />}
-                  />
-                )}
+                  <Route path={ROUTES.ABOUT.COOKIES} element={<Cookies />} />
+                  <Route path={ROUTES.ABOUT.TERMS} element={<Terms />} />
+                </>
+              )}
+              {pidSelectionView && (
+                <Route path={ROUTES.PID_SELECTION} element={<PidSelection />} />
+              )}
+              <Route
+                path={ROUTES.ASSESSMENTS.CREATE_WITH_VALIDATION}
+                element={<ProtectedRoute />}
+              >
                 <Route
-                  path={ROUTES.ASSESSMENTS.CREATE_WITH_VALIDATION}
-                  element={<ProtectedRoute />}
-                >
-                  <Route
-                    index
-                    element={
-                      <AssessmentEdit mode={AssessmentEditMode.Create} />
-                    }
-                  />
-                </Route>
-                <Route
-                  path={ROUTES.ASSESSMENTS.IMPORT}
-                  element={<ProtectedRoute />}
-                >
-                  {/* Use AssessmentEdit component with mode = import */}
-                  <Route
-                    index
-                    element={
-                      <AssessmentEdit mode={AssessmentEditMode.Import} />
-                    }
-                  />
-                </Route>
-                <Route
-                  path={ROUTES.ASSESSMENTS.CREATE}
-                  element={<ProtectedRoute />}
-                >
-                  <Route
-                    index
-                    element={
-                      <AssessmentEdit mode={AssessmentEditMode.Create} />
-                    }
-                  />
-                </Route>
-                <Route
-                  path={ROUTES.ASSESSMENTS.VIEW}
-                  element={<ProtectedRoute />}
-                >
-                  {/* Use AssessmentView component with isPublic = false */}
-                  <Route index element={<AssessmentView isPublic={false} />} />
-                </Route>
-                <Route
-                  path={ROUTES.ASSESSMENTS.EDIT}
-                  element={<ProtectedRoute />}
-                >
-                  {/* Use AssessmentEdit component with mode = edit */}
-                  <Route
-                    index
-                    element={<AssessmentEdit mode={AssessmentEditMode.Edit} />}
-                  />
-                </Route>
-                <Route
-                  path={ROUTES.ASSESSMENTS.ASSESS}
-                  element={<Assessments />}
+                  index
+                  element={<AssessmentEdit mode={AssessmentEditMode.Create} />}
                 />
+              </Route>
+              <Route
+                path={ROUTES.ASSESSMENTS.IMPORT}
+                element={<ProtectedRoute />}
+              >
+                {/* Use AssessmentEdit component with mode = import */}
                 <Route
-                  path={ROUTES.ASSESSMENTS.ROOT}
-                  element={<ProtectedRoute />}
-                >
-                  <Route index element={<AssessmentsList />} />
-                </Route>
-                <Route
-                  path={ROUTES.PUBLIC_ASSESSMENTS.ROOT}
-                  element={<AssessmentsList listPublic={true} />}
+                  index
+                  element={<AssessmentEdit mode={AssessmentEditMode.Import} />}
                 />
+              </Route>
+              <Route
+                path={ROUTES.ASSESSMENTS.CREATE}
+                element={<ProtectedRoute />}
+              >
                 <Route
-                  path={ROUTES.PUBLIC_ASSESSMENTS.VIEW}
-                  element={<AssessmentView isPublic={true} />}
+                  index
+                  element={<AssessmentEdit mode={AssessmentEditMode.Create} />}
                 />
+              </Route>
+              <Route
+                path={ROUTES.ASSESSMENTS.VIEW}
+                element={<ProtectedRoute />}
+              >
+                {/* Use AssessmentView component with isPublic = false */}
+                <Route index element={<AssessmentView isPublic={false} />} />
+              </Route>
+              <Route
+                path={ROUTES.ASSESSMENTS.EDIT}
+                element={<ProtectedRoute />}
+              >
+                {/* Use AssessmentEdit component with mode = edit */}
+                <Route
+                  index
+                  element={<AssessmentEdit mode={AssessmentEditMode.Edit} />}
+                />
+              </Route>
+              <Route
+                path={ROUTES.ASSESSMENTS.ASSESS}
+                element={<Assessments />}
+              />
+              <Route
+                path={ROUTES.ASSESSMENTS.ROOT}
+                element={<ProtectedRoute />}
+              >
+                <Route index element={<AssessmentsList />} />
+              </Route>
+              <Route
+                path={ROUTES.PUBLIC_ASSESSMENTS.ROOT}
+                element={<AssessmentsList listPublic={true} />}
+              />
+              <Route
+                path={ROUTES.PUBLIC_ASSESSMENTS.VIEW}
+                element={<AssessmentView isPublic={true} />}
+              />
 
-                <Route path={ROUTES.PROFILE.ROOT} element={<ProtectedRoute />}>
-                  <Route index element={<Profile />} />
-                </Route>
+              <Route path={ROUTES.PROFILE.ROOT} element={<ProtectedRoute />}>
+                <Route index element={<Profile />} />
+              </Route>
+              <Route path={ROUTES.PROFILE.UPDATE} element={<ProtectedRoute />}>
+                <Route index element={<ProfileUpdate />} />
+              </Route>
+              <Route path={ROUTES.ADMIN.USERS} element={<ProtectedRoute />}>
+                <Route index element={<AdminUsers />} />
+              </Route>
+              <Route path={ROUTES.ADMIN.USER_VIEW} element={<ProtectedRoute />}>
+                <Route index element={<ViewUsers />} />
+              </Route>
+              <Route
+                path={ROUTES.VALIDATIONS.REQUEST}
+                element={<ProtectedRoute />}
+              >
+                <Route index element={<RequestValidation />} />
+              </Route>
+              <Route path={ROUTES.SUBJECTS} element={<ProtectedRoute />}>
+                <Route index element={<Subjects />} />
+              </Route>
+              <Route
+                path={ROUTES.VALIDATIONS.ROOT}
+                element={<ProtectedRoute />}
+              >
+                <Route index element={<ValidationList />} />
+              </Route>
+              <Route
+                path={ROUTES.VALIDATIONS.VIEW}
+                element={<ProtectedRoute />}
+              >
+                <Route index element={<ValidationDetails />} />
+              </Route>
+              <Route
+                path={ROUTES.ADMIN.VALIDATIONS}
+                element={<ProtectedRoute />}
+              >
+                <Route index element={<AdminValidations />} />
+              </Route>
+              <Route
+                path={ROUTES.ADMIN.VALIDATION_VIEW}
+                element={<ProtectedRoute />}
+              >
+                <Route index element={<ValidationDetails admin={true} />} />
+              </Route>
+              <Route
+                path={ROUTES.ADMIN.VALIDATION_REJECT}
+                element={<ProtectedRoute />}
+              >
                 <Route
-                  path={ROUTES.PROFILE.UPDATE}
-                  element={<ProtectedRoute />}
-                >
-                  <Route index element={<ProfileUpdate />} />
-                </Route>
-                <Route path={ROUTES.ADMIN.USERS} element={<ProtectedRoute />}>
-                  <Route index element={<AdminUsers />} />
-                </Route>
+                  index
+                  element={<ValidationDetails admin={true} toReject={true} />}
+                />
+              </Route>
+              <Route
+                path={ROUTES.ADMIN.VALIDATION_APPROVE}
+                element={<ProtectedRoute />}
+              >
                 <Route
-                  path={ROUTES.ADMIN.USER_VIEW}
-                  element={<ProtectedRoute />}
-                >
-                  <Route index element={<ViewUsers />} />
-                </Route>
-                <Route
-                  path={ROUTES.VALIDATIONS.REQUEST}
-                  element={<ProtectedRoute />}
-                >
-                  <Route index element={<RequestValidation />} />
-                </Route>
-                <Route path={ROUTES.SUBJECTS} element={<ProtectedRoute />}>
-                  <Route index element={<Subjects />} />
-                </Route>
-                <Route
-                  path={ROUTES.VALIDATIONS.ROOT}
-                  element={<ProtectedRoute />}
-                >
-                  <Route index element={<ValidationList />} />
-                </Route>
-                <Route
-                  path={ROUTES.VALIDATIONS.VIEW}
-                  element={<ProtectedRoute />}
-                >
-                  <Route index element={<ValidationDetails />} />
-                </Route>
-                <Route
-                  path={ROUTES.ADMIN.VALIDATIONS}
-                  element={<ProtectedRoute />}
-                >
-                  <Route index element={<AdminValidations />} />
-                </Route>
-                <Route
-                  path={ROUTES.ADMIN.VALIDATION_VIEW}
-                  element={<ProtectedRoute />}
-                >
-                  <Route index element={<ValidationDetails admin={true} />} />
-                </Route>
-                <Route
-                  path={ROUTES.ADMIN.VALIDATION_REJECT}
-                  element={<ProtectedRoute />}
-                >
-                  <Route
-                    index
-                    element={<ValidationDetails admin={true} toReject={true} />}
-                  />
-                </Route>
-                <Route
-                  path={ROUTES.ADMIN.VALIDATION_APPROVE}
-                  element={<ProtectedRoute />}
-                >
-                  <Route
-                    index
-                    element={
-                      <ValidationDetails admin={true} toApprove={true} />
-                    }
-                  />
-                </Route>
-                <Route
-                  path={ROUTES.ADMIN.MOTIVATIONS.ROOT}
-                  element={<ProtectedRoute />}
-                >
-                  <Route index element={<Motivations />} />
-                </Route>
-                <Route
-                  path={ROUTES.ADMIN.MOTIVATIONS.VIEW}
-                  element={<ProtectedRoute />}
-                >
-                  <Route index element={<MotivationDetails />} />
-                </Route>
-                <Route
-                  path={ROUTES.ADMIN.MOTIVATIONS.MANAGE_CRITERIA}
-                  element={<ProtectedRoute />}
-                >
-                  <Route index element={<MotivationCriteriaPrinciples />} />
-                </Route>
-                <Route
-                  path={ROUTES.ADMIN.MOTIVATIONS.ACTOR_CRITERIA}
-                  element={<ProtectedRoute />}
-                >
-                  <Route index element={<MotivationActorCriteria />} />
-                </Route>
-                <Route
-                  path={ROUTES.ADMIN.MOTIVATIONS.METRICS_TESTS}
-                  element={<ProtectedRoute />}
-                >
-                  <Route index element={<MotivationMetricTests />} />
-                </Route>
-                <Route
-                  path={ROUTES.ADMIN.MOTIVATIONS.TEMPLATES}
-                  element={<ProtectedRoute />}
-                >
-                  <Route index element={<MotivationAssessmentEditor />} />
-                </Route>
-                <Route
-                  path={ROUTES.ADMIN.MOTIVATIONS.ASSESSMENT_BUILDER_VIEW}
-                  element={<ProtectedRoute />}
-                >
-                  <Route index element={<AssessmentBuilder />} />
-                </Route>
-                <Route
-                  path={ROUTES.ADMIN.MOTIVATIONS.ASSESSMENT_BUILDER_EDIT}
-                  element={<ProtectedRoute />}
-                >
-                  <Route index element={<AssessmentBuilder isEditing />} />
-                </Route>
-                <Route
-                  path={ROUTES.ADMIN.PRINCIPLES.ROOT}
-                  element={<ProtectedRoute />}
-                >
-                  <Route index element={<Principles />} />
-                </Route>
-                <Route
-                  path={ROUTES.ADMIN.CRITERIA.ROOT}
-                  element={<ProtectedRoute />}
-                >
-                  <Route index element={<Criteria />} />
-                </Route>
-                <Route
-                  path={ROUTES.ADMIN.TESTS.ROOT}
-                  element={<ProtectedRoute />}
-                >
-                  <Route index element={<Tests />} />
-                </Route>
-                <Route
-                  path={ROUTES.ADMIN.TESTS.CREATE}
-                  element={<ProtectedRoute />}
-                >
-                  <Route index element={<CreateTest />} />
-                </Route>
-                <Route
-                  path={ROUTES.ADMIN.TESTS.EDIT}
-                  element={<ProtectedRoute />}
-                >
-                  <Route index element={<CreateTest />} />
-                </Route>
-                <Route
-                  path={ROUTES.ADMIN.TESTS.CREATE_VERSION}
-                  element={<ProtectedRoute />}
-                >
-                  <Route index element={<CreateTest />} />
-                </Route>
-                <Route
-                  path={ROUTES.ADMIN.ASSESSMENTS}
-                  element={<ProtectedRoute />}
-                >
-                  <Route index element={<AdminAssessments />} />
-                </Route>
-                <Route
-                  path={ROUTES.ADMIN.METRICS.ROOT}
-                  element={<ProtectedRoute />}
-                >
-                  <Route index element={<Metrics />} />
-                </Route>
-                <Route path={ROUTES.LOGIN} element={<ProtectedRoute />}>
-                  <Route index element={<Profile />} />
-                </Route>
-                <Route
-                  path={ROUTES.ADMIN.DASHBOARD}
-                  element={<ProtectedRoute />}
-                >
-                  <Route index element={<AdminDashboard />} />
-                </Route>
-                <Route
-                  path={ROUTES.ADMIN.SETTINGS.ROOT}
-                  element={<ProtectedRoute />}
-                >
-                  <Route index element={<Settings />} />
-                </Route>
-                <Route
-                  path={ROUTES.ADMIN.SETTINGS.TEST_METHODS}
-                  element={<ProtectedRoute />}
-                >
-                  <Route index element={<TestMethodsSettings />} />
-                </Route>
-                <Route
-                  path={ROUTES.ADMIN.SETTINGS.METRIC_TYPES}
-                  element={<ProtectedRoute />}
-                >
-                  <Route index element={<MetricTypesSettings />} />
-                </Route>
-                <Route
-                  path={ROUTES.ADMIN.SETTINGS.ALGORITHMS}
-                  element={<ProtectedRoute />}
-                >
-                  <Route index element={<AlgorithmsSettings />} />
-                </Route>
-                <Route
-                  path={ROUTES.ADMIN.SETTINGS.BENCHMARK_TYPES}
-                  element={<ProtectedRoute />}
-                >
-                  <Route index element={<BenchmarkTypesSettings />} />
-                </Route>
-                <Route path={ROUTES.LOGOUT} element={<KeycloakLogout />} />
-              </Routes>
-            </main>
-            <Footer />
-          </BrowserRouter>
-        </QueryClientProvider>
-      </AuthProvider>
+                  index
+                  element={<ValidationDetails admin={true} toApprove={true} />}
+                />
+              </Route>
+              <Route
+                path={ROUTES.ADMIN.MOTIVATIONS.ROOT}
+                element={<ProtectedRoute />}
+              >
+                <Route index element={<Motivations />} />
+              </Route>
+              <Route
+                path={ROUTES.ADMIN.MOTIVATIONS.VIEW}
+                element={<ProtectedRoute />}
+              >
+                <Route index element={<MotivationDetails />} />
+              </Route>
+              <Route
+                path={ROUTES.ADMIN.MOTIVATIONS.MANAGE_CRITERIA}
+                element={<ProtectedRoute />}
+              >
+                <Route index element={<MotivationCriteriaPrinciples />} />
+              </Route>
+              <Route
+                path={ROUTES.ADMIN.MOTIVATIONS.ACTOR_CRITERIA}
+                element={<ProtectedRoute />}
+              >
+                <Route index element={<MotivationActorCriteria />} />
+              </Route>
+              <Route
+                path={ROUTES.ADMIN.MOTIVATIONS.METRICS_TESTS}
+                element={<ProtectedRoute />}
+              >
+                <Route index element={<MotivationMetricTests />} />
+              </Route>
+              <Route
+                path={ROUTES.ADMIN.MOTIVATIONS.TEMPLATES}
+                element={<ProtectedRoute />}
+              >
+                <Route index element={<MotivationAssessmentEditor />} />
+              </Route>
+              <Route
+                path={ROUTES.ADMIN.MOTIVATIONS.ASSESSMENT_BUILDER_VIEW}
+                element={<ProtectedRoute />}
+              >
+                <Route index element={<AssessmentBuilder />} />
+              </Route>
+              <Route
+                path={ROUTES.ADMIN.MOTIVATIONS.ASSESSMENT_BUILDER_EDIT}
+                element={<ProtectedRoute />}
+              >
+                <Route index element={<AssessmentBuilder isEditing />} />
+              </Route>
+              <Route
+                path={ROUTES.ADMIN.PRINCIPLES.ROOT}
+                element={<ProtectedRoute />}
+              >
+                <Route index element={<Principles />} />
+              </Route>
+              <Route
+                path={ROUTES.ADMIN.CRITERIA.ROOT}
+                element={<ProtectedRoute />}
+              >
+                <Route index element={<Criteria />} />
+              </Route>
+              <Route
+                path={ROUTES.ADMIN.TESTS.ROOT}
+                element={<ProtectedRoute />}
+              >
+                <Route index element={<Tests />} />
+              </Route>
+              <Route
+                path={ROUTES.ADMIN.TESTS.CREATE}
+                element={<ProtectedRoute />}
+              >
+                <Route index element={<CreateTest />} />
+              </Route>
+              <Route
+                path={ROUTES.ADMIN.TESTS.EDIT}
+                element={<ProtectedRoute />}
+              >
+                <Route index element={<CreateTest />} />
+              </Route>
+              <Route
+                path={ROUTES.ADMIN.TESTS.CREATE_VERSION}
+                element={<ProtectedRoute />}
+              >
+                <Route index element={<CreateTest />} />
+              </Route>
+              <Route
+                path={ROUTES.ADMIN.ASSESSMENTS}
+                element={<ProtectedRoute />}
+              >
+                <Route index element={<AdminAssessments />} />
+              </Route>
+              <Route
+                path={ROUTES.ADMIN.METRICS.ROOT}
+                element={<ProtectedRoute />}
+              >
+                <Route index element={<Metrics />} />
+              </Route>
+              <Route path={ROUTES.LOGIN} element={<ProtectedRoute />}>
+                <Route index element={<Profile />} />
+              </Route>
+              <Route path={ROUTES.ADMIN.DASHBOARD} element={<ProtectedRoute />}>
+                <Route index element={<AdminDashboard />} />
+              </Route>
+              <Route
+                path={ROUTES.ADMIN.SETTINGS.ROOT}
+                element={<ProtectedRoute />}
+              >
+                <Route index element={<Settings />} />
+              </Route>
+              <Route
+                path={ROUTES.ADMIN.SETTINGS.TEST_METHODS}
+                element={<ProtectedRoute />}
+              >
+                <Route index element={<TestMethodsSettings />} />
+              </Route>
+              <Route
+                path={ROUTES.ADMIN.SETTINGS.METRIC_TYPES}
+                element={<ProtectedRoute />}
+              >
+                <Route index element={<MetricTypesSettings />} />
+              </Route>
+              <Route
+                path={ROUTES.ADMIN.SETTINGS.ALGORITHMS}
+                element={<ProtectedRoute />}
+              >
+                <Route index element={<AlgorithmsSettings />} />
+              </Route>
+              <Route
+                path={ROUTES.ADMIN.SETTINGS.BENCHMARK_TYPES}
+                element={<ProtectedRoute />}
+              >
+                <Route index element={<BenchmarkTypesSettings />} />
+              </Route>
+              <Route path={ROUTES.LOGOUT} element={<KeycloakLogout />} />
+            </Routes>
+          </main>
+          <Footer />
+        </BrowserRouter>
+      </QueryClientProvider>
     </div>
   );
 }

--- a/src/auth/AuthProvider.tsx
+++ b/src/auth/AuthProvider.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useCallback } from "react";
 import {
   AuthContext,
   type AuthContextProps,
@@ -11,6 +11,25 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [registered, setRegistered] = useState(false);
   const [keycloak, setKeycloak] = useState<NullableKeycloak>(null);
 
+  const refreshUserToken = useCallback(async () => {
+    if (!keycloak) {
+      return Promise.reject(new Error("Keycloak instance not available"));
+    }
+
+    try {
+      // Force token refresh with minValidity of -1 to ensure fresh token. This forces refresh regardless of current token validity
+      const refreshed = await keycloak.updateToken(-1);
+
+      if (refreshed) {
+        setKeycloak(keycloak);
+      }
+      return Promise.resolve();
+    } catch (error) {
+      console.error("Token refresh failed:", error);
+      return Promise.reject(error);
+    }
+  }, [keycloak, setKeycloak]);
+
   const authContextValue: AuthContextProps = {
     authenticated,
     setAuthenticated,
@@ -18,6 +37,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     setRegistered,
     keycloak,
     setKeycloak,
+    refreshUserToken,
   };
 
   return (

--- a/src/auth/auth-context.ts
+++ b/src/auth/auth-context.ts
@@ -10,6 +10,7 @@ export interface AuthContextProps {
   setRegistered: React.Dispatch<React.SetStateAction<boolean>>;
   keycloak: NullableKeycloak;
   setKeycloak: React.Dispatch<React.SetStateAction<NullableKeycloak>>;
+  refreshUserToken: () => Promise<void>;
 }
 
 export const AuthContext = createContext<AuthContextProps | null>(null);

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,11 +4,14 @@ import App from "./App.tsx";
 import "bootstrap/dist/css/bootstrap.min.css";
 import "./index.css";
 import "./i18n";
+import { AuthProvider } from "./auth/AuthProvider.tsx";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   // Restricted mode is temporarily disabled because it causes issues with keycloak-js
   // see here: https://github.com/react-keycloak/react-keycloak/issues/93
   // <React.StrictMode>
-  <App />,
+  <AuthProvider>
+    <App />
+  </AuthProvider>,
   // </React.StrictMode>,
 );


### PR DESCRIPTION
This PR implements global 401 error handling in React Query to automatically refresh expired tokens when users receive unauthorized responses, preventing them from getting stuck with invalid tokens after role changes.

- Added global 401 error handler that attempts token refresh when receiving unauthorized responses
- Updated application structure to access authentication context for token refresh functionality
