### PR TITLE
[CAT-1014] - Add "Most Common Failed Criteria" section to Admin Dashboard

### DIFF
--- a/src/api/services/statistics.ts
+++ b/src/api/services/statistics.ts
@@ -1,5 +1,6 @@
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useInfiniteQuery } from "@tanstack/react-query";
 import { APIClient } from "@/api";
+import type { Pagination } from "@/types";
 
 export interface UserStatistics {
   total_users: number;
@@ -25,6 +26,27 @@ export interface ValidationStatistics {
   rejected_validations: number;
 }
 
+export interface MostFailedCriteria {
+  id: string;
+  cri: string;
+  label: string;
+  fail_count: number;
+  failure_percentage: number;
+  used_in_assessments: number;
+}
+
+export interface MostFailedCriteriaResponse {
+  size_of_page: number;
+  number_of_page: number;
+  total_elements: number;
+  total_pages: number;
+  links: Array<{
+    href: string;
+    rel: string;
+  }>;
+  content: MostFailedCriteria[];
+}
+
 export interface AdminStatistics {
   user_statistics: UserStatistics;
   assessment_statistics: AssessmentStatistics;
@@ -48,4 +70,34 @@ export const useGetAdminStatistics = ({
     },
     enabled: !!token && isRegistered,
     refetchInterval: 30000,
+  });
+
+export const useGetMostFailedCriteria = ({
+  size,
+  token,
+  isRegistered,
+}: {
+  size?: number;
+  token?: string;
+  isRegistered?: boolean;
+}) =>
+  useInfiniteQuery({
+    queryKey: ["most-failed-criteria"],
+    queryFn: async ({ pageParam = 1 }) => {
+      const response = await APIClient(token).get<MostFailedCriteriaResponse>(
+        `/v1/admin/statistics/criteria/most-failed?size=${size}&page=${pageParam}`,
+      );
+      return response.data;
+    },
+    initialPageParam: 1,
+    getNextPageParam: (lastPage) => {
+      const pageMeta = lastPage as Pagination;
+      if (pageMeta.number_of_page < pageMeta.total_pages) {
+        return pageMeta.number_of_page + 1;
+      } else {
+        return undefined;
+      }
+    },
+    retry: false,
+    enabled: !!token && isRegistered,
   });

--- a/src/pages/admin/AdminDashboard.module.css
+++ b/src/pages/admin/AdminDashboard.module.css
@@ -55,6 +55,10 @@
   background-color: #fd7e14;
 }
 
+.section-header .fa-exclamation-circle {
+  background-color: #ef4444;
+}
+
 .stats-list {
   display: flex;
   flex-direction: column;
@@ -139,7 +143,100 @@
   box-shadow: 0 2px 4px rgb(0 0 0 / 10%) !important;
 }
 
-/* Responsive adjustments */
+.most-failed-section {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  padding: 1.5rem;
+  background: #fff;
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  box-shadow: 0 1px 3px rgb(0 0 0 / 10%);
+  transition: all 0.2s ease;
+}
+
+.most-failed-section:hover {
+  box-shadow: 0 4px 12px rgb(0 0 0 / 15%);
+}
+
+.failed-criteria-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 1.5rem 1rem;
+  margin-top: 1rem;
+}
+
+.failed-criteria-item {
+  position: relative;
+  padding: 1.2rem;
+  background: #fef2f2;
+  border-radius: 8px;
+  transition: all 0.2s ease;
+}
+
+.failed-criteria-item:hover {
+  background: #fee2e2;
+  box-shadow: 0 2px 8px rgb(0 0 0 / 10%);
+}
+
+.criteria-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  margin-bottom: 0.2rem;
+}
+
+.criteria-title {
+  display: -webkit-box;
+  padding-right: 1rem;
+  margin-bottom: 0.1rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
+  font-size: 1rem;
+  font-weight: 600;
+  line-height: 1.3;
+  color: #111827;
+  -webkit-box-orient: vertical;
+}
+
+.criteria-percentage {
+  font-size: 1.1rem;
+  font-weight: 700;
+  line-height: 1;
+  color: #ef4444;
+}
+
+.criteria-description {
+  margin-bottom: 0.8rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  line-height: 1.4;
+  color: #6b7280;
+}
+
+.criteria-progress-bar {
+  width: 100%;
+  height: 6px;
+  overflow: hidden;
+  background-color: white;
+  border-radius: 3px;
+}
+
+.criteria-progress-fill {
+  height: 100%;
+  background-color: #ef4444;
+  border-radius: 3px;
+  transition: width 0.3s ease;
+}
+
+@media (width <= 1200px) {
+  .failed-criteria-grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
 @media (width <= 768px) {
   .dashboard-section {
     padding: 1rem;
@@ -147,5 +244,32 @@
 
   .stat-value {
     font-size: 1.5rem;
+  }
+
+  .failed-criteria-grid {
+    grid-template-columns: 1fr;
+    gap: 0.75rem;
+  }
+
+  .failed-criteria-item {
+    padding: 1rem;
+  }
+
+  .criteria-title {
+    font-size: 0.875rem;
+  }
+
+  .criteria-percentage {
+    font-size: 1.25rem;
+  }
+
+  .most-failed-section {
+    padding: 1rem;
+  }
+}
+
+@media (width <= 480px) {
+  .failed-criteria-grid {
+    grid-template-columns: 1fr;
   }
 }

--- a/src/pages/admin/AdminDashboard.tsx
+++ b/src/pages/admin/AdminDashboard.tsx
@@ -1,4 +1,4 @@
-import { useContext } from "react";
+import { useContext, useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import { Row, Col, Spinner } from "react-bootstrap";
 import {
@@ -24,17 +24,49 @@ import {
   FaEyeSlash,
 } from "react-icons/fa";
 import { AuthContext } from "@/auth";
-import { useGetAdminStatistics } from "@/api/services/statistics";
+import {
+  useGetAdminStatistics,
+  useGetMostFailedCriteria,
+  type MostFailedCriteria,
+} from "@/api/services/statistics";
 import ROUTES from "@/routes";
 import styles from "./AdminDashboard.module.css";
 
 function AdminDashboard() {
   const { keycloak, registered } = useContext(AuthContext)!;
 
+  const [mostFailedCriteria, setMostFailedCriteria] = useState<
+    MostFailedCriteria[]
+  >([]);
+
   const { data: statistics, isLoading } = useGetAdminStatistics({
     token: keycloak?.token || "",
     isRegistered: registered,
   });
+
+  const {
+    data: mostFailedData,
+    fetchNextPage: mostFailedFetchNextPage,
+    hasNextPage: mostFailedHasNextPage,
+  } = useGetMostFailedCriteria({
+    size: 5,
+    token: keycloak?.token || "",
+    isRegistered: registered,
+  });
+
+  useEffect(() => {
+    let tmpCriteria: MostFailedCriteria[] = [];
+
+    if (mostFailedData?.pages) {
+      mostFailedData.pages.map((page) => {
+        tmpCriteria = [...tmpCriteria, ...page.content];
+      });
+      if (mostFailedHasNextPage) {
+        mostFailedFetchNextPage();
+      }
+    }
+    setMostFailedCriteria(tmpCriteria);
+  }, [mostFailedData, mostFailedHasNextPage, mostFailedFetchNextPage]);
 
   if (isLoading) {
     return (
@@ -84,13 +116,13 @@ function AdminDashboard() {
           <h2 className="cat-view-heading text-muted">
             Admin Dashboard
             <p className="lead cat-view-lead">
-              System statistics and administrative controls
+              Platform insights and administrative controls
             </p>
           </h2>
         </div>
       </div>
 
-      <Row className="mt-4">
+      <Row className="mt-1">
         {/* Role-Based Status */}
         <Col lg={3} md={6} className="mb-4">
           <div className={styles["dashboard-section"]}>
@@ -360,6 +392,53 @@ function AdminDashboard() {
                 </div>
               )}
             </div>
+          </div>
+        </Col>
+      </Row>
+
+      <Row className="mt-4">
+        <Col lg={12} className="mb-4">
+          <div className={styles["most-failed-section"]}>
+            <div className={styles["section-header"]}>
+              <FaExclamationCircle
+                className={`me-2 ${styles["fa-exclamation-circle"]}`}
+              />
+              <h5 className="mb-0">Most Common Failed Criteria</h5>
+            </div>
+            <div className={styles["failed-criteria-grid"]}>
+              {mostFailedCriteria?.length
+                ? mostFailedCriteria.map((criteria, index) => (
+                    <div key={index} className={styles["failed-criteria-item"]}>
+                      <div className={styles["criteria-header"]}>
+                        <div
+                          className={styles["criteria-title"]}
+                          title={criteria.label}
+                        >
+                          {criteria.cri} - {criteria.label}
+                        </div>
+                        <div className={styles["criteria-percentage"]}>
+                          {criteria.failure_percentage}%
+                        </div>
+                      </div>
+                      <div className={styles["criteria-description"]}>
+                        Failed in {criteria.fail_count} assessments
+                      </div>
+                      <div className={styles["criteria-progress-bar"]}>
+                        <div
+                          className={styles["criteria-progress-fill"]}
+                          style={{ width: `${criteria.failure_percentage}%` }}
+                        />
+                      </div>
+                    </div>
+                  ))
+                : null}
+            </div>
+
+            {mostFailedCriteria?.length === 0 && (
+              <div className="w-100 text-center text-muted mt-4">
+                <p>No failed criteria data available</p>
+              </div>
+            )}
           </div>
         </Col>
       </Row>


### PR DESCRIPTION
This PR adds a new section named "Most Common Failed Criteria" in the Admin Dashboard to help administrators identify frequently failing compliance criteria.

- Added new "Most Common Failed Criteria" section with responsive 4-column layout and visual progress bars showing failure rates
- Implemented pagination using useInfiniteQuery to automatically fetch and aggregate all failed criteria data from the API