### PR TITLE
[CAT-1015] - Implement Settings UI and Functionality for Zenodo and AAI Autocomplete Values

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -923,8 +923,8 @@ a.plain:hover {
 }
 
 .settings-section-header {
-  margin-bottom: 0.8rem;
-  font-size: 0.75rem;
+  margin-bottom: 0.4rem;
+  font-size: 0.9rem;
   font-weight: 600;
   color: #6c757d;
   text-transform: uppercase;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -54,6 +54,8 @@ import TestMethodsSettings from "./pages/admin/settings/TestMethodsSettings";
 import MetricTypesSettings from "./pages/admin/settings/MetricTypesSettings";
 import AlgorithmsSettings from "./pages/admin/settings/AlgorithmsSettings";
 import BenchmarkTypesSettings from "./pages/admin/settings/BenchmarkTypesSettings";
+import AAIAutocompleteSettings from "./pages/admin/settings/AAIAutocompleteSettings";
+import ZenodoSettings from "./pages/admin/settings/ZenodoSettings";
 import AdminDashboard from "./pages/admin/AdminDashboard";
 import { pidSelectionView, themeAbout } from "./config";
 import { handleBackendError } from "./utils";
@@ -397,6 +399,18 @@ function App() {
                 element={<ProtectedRoute />}
               >
                 <Route index element={<BenchmarkTypesSettings />} />
+              </Route>
+              <Route
+                path={ROUTES.ADMIN.SETTINGS.ZENODO}
+                element={<ProtectedRoute />}
+              >
+                <Route index element={<ZenodoSettings />} />
+              </Route>
+              <Route
+                path={ROUTES.ADMIN.SETTINGS.AAI_AUTOCOMPLETE}
+                element={<ProtectedRoute />}
+              >
+                <Route index element={<AAIAutocompleteSettings />} />
               </Route>
               <Route path={ROUTES.LOGOUT} element={<KeycloakLogout />} />
             </Routes>

--- a/src/api/services/registry.ts
+++ b/src/api/services/registry.ts
@@ -25,6 +25,26 @@ import type {
   TestInput,
 } from "@/types/tests";
 
+export interface AdminSetting {
+  id: string;
+  data: {
+    label: string;
+    config?: Record<string, string | null>;
+    description: string;
+    auth?: {
+      mail: string | null;
+      password: string | null;
+    };
+  };
+  enabled: boolean;
+  updated_on: string;
+}
+
+export interface AdminSettingUpdate {
+  enabled: boolean;
+  data?: Partial<AdminSetting["data"]>;
+}
+
 export const useGetAllAlgorithms = ({
   token,
   isRegistered,
@@ -583,6 +603,48 @@ export const useDeletePrinciple = (token: string) => {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["registry-principles"] });
       queryClient.invalidateQueries({ queryKey: ["all-principles"] });
+    },
+    onError: (error: AxiosError) => {
+      return handleBackendError(error);
+    },
+  });
+};
+
+export const useGetAdminSettings = ({
+  token,
+  isRegistered,
+}: {
+  token: string;
+  isRegistered: boolean;
+}) =>
+  useQuery({
+    queryKey: ["admin-settings"],
+    queryFn: async () => {
+      const response =
+        await APIClient(token).get<AdminSetting[]>(`/v1/admin/settings`);
+      return response.data;
+    },
+    enabled: !!token && isRegistered,
+  });
+
+export const useUpdateAdminSetting = (token: string) => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({
+      id,
+      updateData,
+    }: {
+      id: string;
+      updateData: AdminSettingUpdate;
+    }) => {
+      const response = await APIClient(token).put(
+        `/v1/admin/settings/${id}`,
+        updateData,
+      );
+      return response.data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["admin-settings"] });
     },
     onError: (error: AxiosError) => {
       return handleBackendError(error);

--- a/src/pages/admin/AdminDashboard.tsx
+++ b/src/pages/admin/AdminDashboard.tsx
@@ -421,7 +421,9 @@ function AdminDashboard() {
                         </div>
                       </div>
                       <div className={styles["criteria-description"]}>
-                        Failed in {criteria.fail_count} assessments
+                        Failed in <strong>{criteria.fail_count}</strong> of{" "}
+                        <strong>{criteria.used_in_assessments}</strong>{" "}
+                        assessments
                       </div>
                       <div className={styles["criteria-progress-bar"]}>
                         <div

--- a/src/pages/admin/Settings.tsx
+++ b/src/pages/admin/Settings.tsx
@@ -1,7 +1,15 @@
 import React from "react";
 import { Link } from "react-router-dom";
-import { FaCog, FaRuler, FaChartLine, FaCode } from "react-icons/fa";
+import {
+  FaCog,
+  FaRuler,
+  FaChartLine,
+  FaCode,
+  FaSearch,
+  FaUserCog,
+} from "react-icons/fa";
 import { Row, Col, Card } from "react-bootstrap";
+import ROUTES from "@/routes";
 
 const Settings: React.FC = () => {
   const settingsOptions = [
@@ -12,7 +20,7 @@ const Settings: React.FC = () => {
           title: "Test Methods",
           description: "Configure test method types and validation rules",
           icon: <FaCog size={24} className="text-muted me-3" />,
-          path: "/admin/settings/test-methods",
+          path: ROUTES.ADMIN.SETTINGS.TEST_METHODS,
         },
       ],
     },
@@ -23,20 +31,37 @@ const Settings: React.FC = () => {
           title: "Metric Types",
           description: "Configure which metric types are available for metrics",
           icon: <FaRuler size={24} className="text-muted me-3" />,
-          path: "/admin/settings/metric-types",
+          path: ROUTES.ADMIN.SETTINGS.METRIC_TYPES,
         },
         {
           title: "Algorithms",
           description: "Configure which algorithms are available for metrics",
           icon: <FaCode size={24} className="text-muted me-3" />,
-          path: "/admin/settings/algorithms",
+          path: ROUTES.ADMIN.SETTINGS.ALGORITHMS,
         },
         {
           title: "Benchmark Types",
           description:
             "Configure which benchmark types are available for metrics",
           icon: <FaChartLine size={24} className="text-muted me-3" />,
-          path: "/admin/settings/benchmark-types",
+          path: ROUTES.ADMIN.SETTINGS.BENCHMARK_TYPES,
+        },
+      ],
+    },
+    {
+      section: "SYSTEM",
+      items: [
+        {
+          title: "Zenodo",
+          description: "Enable or disable Zenodo integration features",
+          icon: <FaSearch size={24} className="text-muted me-3" />,
+          path: ROUTES.ADMIN.SETTINGS.ZENODO,
+        },
+        {
+          title: "AAI Autocomplete Values",
+          description: "Manage AAI autocomplete values and configurations",
+          icon: <FaUserCog size={24} className="text-muted me-3" />,
+          path: ROUTES.ADMIN.SETTINGS.AAI_AUTOCOMPLETE,
         },
       ],
     },
@@ -63,7 +88,7 @@ const Settings: React.FC = () => {
               {section.items.map((item, itemIndex) => (
                 <Col key={itemIndex} lg={3} md={12}>
                   <Link className="text-decoration-none" to={item.path}>
-                    <Card className="mb-3 settings-section-card">
+                    <Card className="mb-2 settings-section-card">
                       <Card.Body>
                         <div className="d-flex align-items-center mb-2">
                           {item.icon}

--- a/src/pages/admin/settings/AAIAutocompleteSettings.tsx
+++ b/src/pages/admin/settings/AAIAutocompleteSettings.tsx
@@ -1,0 +1,161 @@
+import { Fragment, useContext, useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { Button, Form, Spinner, Row, Col } from "react-bootstrap";
+import { FaUserCog } from "react-icons/fa";
+import { AuthContext } from "@/auth";
+import {
+  useGetAdminSettings,
+  useUpdateAdminSetting,
+  type AdminSetting,
+} from "@/api/services/registry";
+import ROUTES from "@/routes";
+import toast from "react-hot-toast";
+import { useTranslation } from "react-i18next";
+
+function AAIAutocompleteSettings() {
+  const navigate = useNavigate();
+  const { keycloak, registered } = useContext(AuthContext)!;
+  const [aaiSettings, setAaiSettings] = useState<AdminSetting[]>([]);
+  const [enabledSettings, setEnabledSettings] = useState<{
+    [key: string]: boolean;
+  }>({});
+  const [loading, setLoading] = useState(true);
+
+  const { t } = useTranslation();
+
+  const { data: settings, isLoading } = useGetAdminSettings({
+    token: keycloak?.token || "",
+    isRegistered: registered,
+  });
+
+  const updateSettingMutation = useUpdateAdminSetting(keycloak?.token || "");
+
+  useEffect(() => {
+    if (settings && !loading) {
+      return;
+    }
+
+    if (settings) {
+      const aaiSetting = settings.filter(
+        (setting) => setting.data.label === "Registration",
+      );
+
+      setAaiSettings(aaiSetting);
+
+      const initialEnabledState: { [key: string]: boolean } = {};
+      aaiSetting.forEach((setting) => {
+        initialEnabledState[setting.id] = setting.enabled ?? false;
+      });
+      setEnabledSettings(initialEnabledState);
+      setLoading(false);
+    }
+  }, [settings, loading]);
+
+  const handleToggleSetting = async (settingId: string) => {
+    const newEnabledState = !enabledSettings[settingId];
+
+    try {
+      setEnabledSettings((prev) => ({
+        ...prev,
+        [settingId]: newEnabledState,
+      }));
+
+      await updateSettingMutation.mutateAsync({
+        id: settingId,
+        updateData: {
+          data: {
+            config: {
+              ["api.cat.user.info.update.from.token"]: null,
+            },
+          },
+          enabled: newEnabledState,
+        },
+      });
+
+      toast.success(
+        `AAI Autocomplete Values ${newEnabledState ? "enabled" : "disabled"} successfully`,
+      );
+    } catch (error) {
+      setEnabledSettings((prev) => ({
+        ...prev,
+        [settingId]: !newEnabledState,
+      }));
+
+      toast.error(
+        "Failed to update AAI Autocomplete setting. Please try again.",
+      );
+      console.error("Error updating AAI Autocomplete setting:", error);
+    }
+  };
+
+  if (isLoading || loading) {
+    return (
+      <div
+        className="d-flex justify-content-center align-items-center"
+        style={{ minHeight: "60vh" }}
+      >
+        <div className="text-center">
+          <Spinner animation="border" variant="primary" />
+          <p className="mt-2 text-muted">
+            Loading AAI Autocomplete settings...
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="cat-view-heading-block">
+      <div className="col mb-4">
+        <h2 className="text-muted cat-view-heading">
+          AAI Autocomplete Values Settings
+          <p className="lead cat-view-lead">
+            Configure automatic completion of user information from AAI
+            registration data
+          </p>
+        </h2>
+      </div>
+
+      <Row className="mb-4">
+        <Col lg={6}>
+          {aaiSettings.map((setting) => (
+            <Fragment key={setting.id}>
+              <div className="test-method-settings-item d-flex justify-content-between gap-5 my-1">
+                <div>
+                  <div className="d-flex align-items-center gap-2">
+                    <FaUserCog size={16} />
+                    <h6 className="mb-0">{setting.data.label}</h6>
+                  </div>
+                  <span className="text-muted small">
+                    {setting.data.description || "No description available"}
+                  </span>
+                </div>
+                <div>
+                  <Form.Check
+                    type="switch"
+                    id={`switch-${setting.id}`}
+                    checked={enabledSettings[setting.id] || false}
+                    onChange={() => handleToggleSetting(setting.id)}
+                    className="test-method-switch"
+                  />
+                </div>
+              </div>
+            </Fragment>
+          ))}
+        </Col>
+      </Row>
+
+      <Button
+        className="mt-4"
+        variant="secondary"
+        onClick={() => {
+          navigate(ROUTES.ADMIN.SETTINGS.ROOT);
+        }}
+      >
+        {t("buttons.back")}
+      </Button>
+    </div>
+  );
+}
+
+export default AAIAutocompleteSettings;

--- a/src/pages/admin/settings/ZenodoSettings.tsx
+++ b/src/pages/admin/settings/ZenodoSettings.tsx
@@ -1,0 +1,253 @@
+import { useContext, useState, useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import { Row, Col, Form, Button } from "react-bootstrap";
+import { FaSearch } from "react-icons/fa";
+import { AuthContext } from "@/auth";
+import {
+  useGetAdminSettings,
+  useUpdateAdminSetting,
+} from "@/api/services/registry";
+import ROUTES from "@/routes";
+import toast from "react-hot-toast";
+import { useTranslation } from "react-i18next";
+
+interface ZenodoFormData {
+  enabled: boolean;
+  zenodoApiKey: string;
+  zenodoEmail: string;
+  zenodoPassword: string;
+}
+
+function ZenodoSettings() {
+  const [isUpdating, setIsUpdating] = useState(false);
+  const [showApiKeyError, setShowApiKeyError] = useState(false);
+  const [formData, setFormData] = useState<ZenodoFormData>({
+    enabled: false,
+    zenodoApiKey: "",
+    zenodoEmail: "",
+    zenodoPassword: "",
+  });
+  const { keycloak, registered } = useContext(AuthContext)!;
+  const navigate = useNavigate();
+
+  const { t } = useTranslation();
+
+  const { data: settings } = useGetAdminSettings({
+    token: keycloak?.token || "",
+    isRegistered: registered,
+  });
+
+  const updateSettingMutation = useUpdateAdminSetting(keycloak?.token || "");
+
+  const zenodoSetting = settings?.find(
+    (setting) => setting.data.label === "Zenodo",
+  );
+
+  // Initialize form data when settings are loaded
+  useEffect(() => {
+    if (zenodoSetting) {
+      setFormData({
+        enabled: zenodoSetting.enabled,
+        zenodoApiKey: zenodoSetting.data.config?.["zenodo.api.key"] || "",
+        zenodoEmail: zenodoSetting.data.auth?.mail || "",
+        zenodoPassword: zenodoSetting.data.auth?.password || "",
+      });
+    }
+  }, [zenodoSetting]);
+
+  const saveSettings = async (updatedData: ZenodoFormData) => {
+    if (!zenodoSetting) return false;
+
+    setIsUpdating(true);
+
+    try {
+      const updateData = {
+        enabled: updatedData.enabled,
+        data: {
+          config: {
+            "zenodo.api.key": updatedData.zenodoApiKey.trim() || null,
+          },
+          auth: {
+            mail: updatedData.zenodoEmail.trim() || null,
+            password: updatedData.zenodoPassword.trim() || null,
+          },
+        },
+      };
+
+      await updateSettingMutation.mutateAsync({
+        id: zenodoSetting.id,
+        updateData,
+      });
+
+      toast.success("Zenodo settings updated successfully!");
+      return true;
+    } catch (error) {
+      toast.error("Failed to update Zenodo settings. Please try again.");
+      console.error("Error updating Zenodo settings:", error);
+      return false;
+    } finally {
+      setIsUpdating(false);
+    }
+  };
+
+  const handleToggleChange = async (enabled: boolean) => {
+    if (enabled && !formData.zenodoApiKey.trim()) {
+      setShowApiKeyError(true);
+      toast.error("Please enter a Zenodo API Key before enabling integration");
+      return;
+    }
+
+    setShowApiKeyError(false);
+    const updatedData = { ...formData, enabled };
+    setFormData(updatedData);
+
+    const success = await saveSettings(updatedData);
+    if (!success) {
+      setFormData((prev) => ({ ...prev, enabled: !enabled }));
+    }
+  };
+
+  const handleInputChange = (
+    field: keyof Omit<ZenodoFormData, "enabled">,
+    value: string,
+  ) => {
+    const updatedData = { ...formData, [field]: value };
+    setFormData(updatedData);
+
+    if (field === "zenodoApiKey") {
+      setShowApiKeyError(false);
+    }
+  };
+
+  return (
+    <div className="cat-view-heading-block">
+      <div className="col mb-4">
+        <h2 className="text-muted cat-view-heading">
+          Zenodo Settings
+          <p className="lead cat-view-lead">
+            {zenodoSetting?.data.description}
+          </p>
+        </h2>
+      </div>
+
+      <Row className="d-flex flex-column-reverse flex-lg-row justify-content-lg-between gy-5">
+        <Col lg={6}>
+          <div className="test-method-settings-item d-flex justify-content-between gap-3">
+            <div>
+              <div className="d-flex align-items-center gap-2">
+                <FaSearch size={16} />
+                <h6 className="mb-0">Enable Zenodo Integration</h6>
+              </div>
+              <span className="text-muted small">
+                When enabled, assessments can be published to Zenodo repository
+              </span>
+            </div>
+            <div>
+              <Form.Check
+                type="switch"
+                id="zenodo-enable-switch"
+                checked={formData.enabled}
+                onChange={(e) => handleToggleChange(e.target.checked)}
+                disabled={isUpdating}
+                className="test-method-switch"
+                autoComplete="off"
+                data-lpignore="true"
+              />
+            </div>
+          </div>
+
+          <div className="mb-4">
+            <Form autoComplete="off" data-lpignore="true">
+              <div className="my-2">
+                <Form.Label
+                  htmlFor="zenodo-api-key"
+                  className="fw-semibold mb-0"
+                >
+                  Zenodo API Key <span className="text-danger">*</span>
+                </Form.Label>
+                <Form.Control
+                  id="zenodo-api-key"
+                  type="password"
+                  placeholder="Enter your Zenodo API key"
+                  value={formData.zenodoApiKey}
+                  onChange={(e) => {
+                    e.stopPropagation();
+                    e.preventDefault();
+                    handleInputChange("zenodoApiKey", e.target.value);
+                  }}
+                  disabled={isUpdating || formData.enabled}
+                  isInvalid={showApiKeyError}
+                  autoComplete="new-password"
+                  data-form-type="other"
+                  data-lpignore="true"
+                />
+                {showApiKeyError && (
+                  <Form.Control.Feedback type="invalid">
+                    Required
+                  </Form.Control.Feedback>
+                )}
+              </div>
+
+              <div className="mb-2">
+                <Form.Label htmlFor="zenodo-email" className="fw-semibold mb-0">
+                  Zenodo Email
+                </Form.Label>
+                <Form.Control
+                  id="zenodo-email"
+                  type="text"
+                  placeholder="Enter your Zenodo account email"
+                  value={formData.zenodoEmail}
+                  onChange={(e) => {
+                    e.stopPropagation();
+                    e.preventDefault();
+                    handleInputChange("zenodoEmail", e.target.value);
+                  }}
+                  disabled={isUpdating || formData.enabled}
+                  autoComplete="off"
+                  data-form-type="other"
+                  data-lpignore="true"
+                />
+              </div>
+
+              <div className="mb-2">
+                <Form.Label
+                  htmlFor="zenodo-password"
+                  className="fw-semibold mb-0"
+                >
+                  Zenodo Password
+                </Form.Label>
+                <Form.Control
+                  id="zenodo-password"
+                  type="password"
+                  placeholder="Enter your Zenodo account password"
+                  value={formData.zenodoPassword}
+                  onChange={(e) => {
+                    e.stopPropagation();
+                    e.preventDefault();
+                    handleInputChange("zenodoPassword", e.target.value);
+                  }}
+                  disabled={isUpdating || formData.enabled}
+                  autoComplete="new-password"
+                  data-form-type="other"
+                  data-lpignore="true"
+                />
+              </div>
+            </Form>
+          </div>
+        </Col>
+      </Row>
+
+      <Button
+        className="mt-4"
+        variant="secondary"
+        onClick={() => {
+          navigate(ROUTES.ADMIN.SETTINGS.ROOT);
+        }}
+      >
+        {t("buttons.back")}
+      </Button>
+    </div>
+  );
+}
+
+export default ZenodoSettings;

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -49,6 +49,8 @@ const ROUTES = {
       METRIC_TYPES: "/admin/settings/metric-types",
       ALGORITHMS: "/admin/settings/algorithms",
       BENCHMARK_TYPES: "/admin/settings/benchmark-types",
+      ZENODO: "/admin/settings/zenodo",
+      AAI_AUTOCOMPLETE: "/admin/settings/aai-autocomplete",
     },
     MOTIVATIONS: {
       ROOT: "/admin/motivations",


### PR DESCRIPTION
This PR implements admin settings functionality for Zenodo integration and AAI autocomplete values, allowing an admin to easily set up and control these settings.

- Added Zenodo and AAI Autocomplete Values to settings section
- Implemented Zenodo settings page with toggle, API key validation, and form fields for email/password configuration
- Created AAI Autocomplete settings page with toggle interface for enabling/disabling user data auto-completion
- Added API integration hooks useGetAdminSettings for /v1/admin/settings endpoint