### PR TITLE
[CAT-1016] - Update Zenodo Settings UI with Password Visibility Toggle and Improve Toggle Button Styling

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -986,3 +986,26 @@ a.plain:hover {
   background-color: #007bff;
   border-color: #007bff;
 }
+
+.system-settings-items-list {
+  padding: 0.8rem;
+  margin-bottom: 1rem;
+  margin-left: 0.8rem;
+  background-color: #f8f9fa;
+  border: 1px solid #e9ecef;
+  border-radius: 8px;
+}
+
+.system-settings-items-list:hover {
+  background-color: #f1f3f4;
+  border-color: #dee2e6;
+  box-shadow: 0 2px 4px rgb(0 0 0 / 5%);
+}
+
+.system-settings-items-list .test-method-settings-item .form-check-input {
+  width: 3.4rem !important;
+  height: 1.5rem !important;
+  border-radius: 1rem !important;
+  box-shadow: 0 2px 4px rgb(0 0 0 / 10%) !important;
+  transition: all 0.3s ease !important;
+}

--- a/src/pages/admin/settings/AAIAutocompleteSettings.tsx
+++ b/src/pages/admin/settings/AAIAutocompleteSettings.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useContext, useEffect, useState } from "react";
+import { useContext, useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { Button, Form, Spinner, Row, Col } from "react-bootstrap";
 import { FaUserCog } from "react-icons/fa";
@@ -117,30 +117,31 @@ function AAIAutocompleteSettings() {
       </div>
 
       <Row className="mb-4">
-        <Col lg={6}>
+        <Col lg={6} className="system-settings-items-list">
           {aaiSettings.map((setting) => (
-            <Fragment key={setting.id}>
-              <div className="test-method-settings-item d-flex justify-content-between gap-5 my-1">
-                <div>
-                  <div className="d-flex align-items-center gap-2">
-                    <FaUserCog size={16} />
-                    <h6 className="mb-0">{setting.data.label}</h6>
-                  </div>
-                  <span className="text-muted small">
-                    {setting.data.description || "No description available"}
-                  </span>
+            <div
+              className="test-method-settings-item d-flex justify-content-between gap-5 my-1"
+              key={setting.id}
+            >
+              <div>
+                <div className="d-flex align-items-center gap-2">
+                  <FaUserCog size={16} />
+                  <h6 className="mb-0">Enable Registration</h6>
                 </div>
-                <div>
-                  <Form.Check
-                    type="switch"
-                    id={`switch-${setting.id}`}
-                    checked={enabledSettings[setting.id] || false}
-                    onChange={() => handleToggleSetting(setting.id)}
-                    className="test-method-switch"
-                  />
-                </div>
+                <span className="text-muted small">
+                  {setting.data.description || "No description available"}
+                </span>
               </div>
-            </Fragment>
+              <div>
+                <Form.Check
+                  type="switch"
+                  id={`switch-${setting.id}`}
+                  checked={enabledSettings[setting.id] || false}
+                  onChange={() => handleToggleSetting(setting.id)}
+                  className="test-method-switch"
+                />
+              </div>
+            </div>
           ))}
         </Col>
       </Row>

--- a/src/pages/admin/settings/ZenodoSettings.tsx
+++ b/src/pages/admin/settings/ZenodoSettings.tsx
@@ -1,7 +1,7 @@
 import { useContext, useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
-import { Row, Col, Form, Button } from "react-bootstrap";
-import { FaSearch } from "react-icons/fa";
+import { Row, Col, Form, Button, InputGroup } from "react-bootstrap";
+import { FaSearch, FaEye, FaEyeSlash } from "react-icons/fa";
 import { AuthContext } from "@/auth";
 import {
   useGetAdminSettings,
@@ -21,6 +21,8 @@ interface ZenodoFormData {
 function ZenodoSettings() {
   const [isUpdating, setIsUpdating] = useState(false);
   const [showApiKeyError, setShowApiKeyError] = useState(false);
+  const [showApiKey, setShowApiKey] = useState(false);
+  const [showPassword, setShowPassword] = useState(false);
   const [formData, setFormData] = useState<ZenodoFormData>({
     enabled: false,
     zenodoApiKey: "",
@@ -130,8 +132,8 @@ function ZenodoSettings() {
         </h2>
       </div>
 
-      <Row className="d-flex flex-column-reverse flex-lg-row justify-content-lg-between gy-5">
-        <Col lg={6}>
+      <Row className="d-flex flex-column-reverse flex-lg-row justify-content-lg-between">
+        <Col lg={6} className="system-settings-items-list">
           <div className="test-method-settings-item d-flex justify-content-between gap-3">
             <div>
               <div className="d-flex align-items-center gap-2">
@@ -165,26 +167,47 @@ function ZenodoSettings() {
                 >
                   Zenodo API Key <span className="text-danger">*</span>
                 </Form.Label>
-                <Form.Control
-                  id="zenodo-api-key"
-                  type="password"
-                  placeholder="Enter your Zenodo API key"
-                  value={formData.zenodoApiKey}
-                  onChange={(e) => {
-                    e.stopPropagation();
-                    e.preventDefault();
-                    handleInputChange("zenodoApiKey", e.target.value);
-                  }}
-                  disabled={isUpdating || formData.enabled}
-                  isInvalid={showApiKeyError}
-                  autoComplete="new-password"
-                  data-form-type="other"
-                  data-lpignore="true"
-                />
+                <InputGroup>
+                  <Form.Control
+                    id="zenodo-api-key"
+                    type={showApiKey ? "text" : "password"}
+                    placeholder="Enter your Zenodo API key"
+                    value={formData.zenodoApiKey}
+                    onChange={(e) => {
+                      e.stopPropagation();
+                      e.preventDefault();
+                      handleInputChange("zenodoApiKey", e.target.value);
+                    }}
+                    disabled={isUpdating || formData.enabled}
+                    isInvalid={showApiKeyError}
+                    autoComplete="new-password"
+                    data-form-type="other"
+                    data-lpignore="true"
+                    style={{
+                      borderColor: "#dee2e6",
+                    }}
+                    onFocus={(e) => {
+                      e.target.style.boxShadow = "none";
+                      e.target.style.borderColor = "#dee2e6";
+                    }}
+                  />
+                  <Button
+                    variant="outline-secondary"
+                    onClick={() => setShowApiKey(!showApiKey)}
+                    disabled={isUpdating}
+                    style={{
+                      borderColor: "#dee2e6",
+                      borderLeft: "none",
+                      height: "32.5px",
+                      display: "flex",
+                      alignItems: "center",
+                    }}
+                  >
+                    {showApiKey ? <FaEyeSlash /> : <FaEye />}
+                  </Button>
+                </InputGroup>
                 {showApiKeyError && (
-                  <Form.Control.Feedback type="invalid">
-                    Required
-                  </Form.Control.Feedback>
+                  <Form.Text className="text-danger">Required</Form.Text>
                 )}
               </div>
 
@@ -206,6 +229,13 @@ function ZenodoSettings() {
                   autoComplete="off"
                   data-form-type="other"
                   data-lpignore="true"
+                  style={{
+                    borderColor: "#dee2e6",
+                  }}
+                  onFocus={(e) => {
+                    e.target.style.boxShadow = "none";
+                    e.target.style.borderColor = "#dee2e6";
+                  }}
                 />
               </div>
 
@@ -216,21 +246,44 @@ function ZenodoSettings() {
                 >
                   Zenodo Password
                 </Form.Label>
-                <Form.Control
-                  id="zenodo-password"
-                  type="password"
-                  placeholder="Enter your Zenodo account password"
-                  value={formData.zenodoPassword}
-                  onChange={(e) => {
-                    e.stopPropagation();
-                    e.preventDefault();
-                    handleInputChange("zenodoPassword", e.target.value);
-                  }}
-                  disabled={isUpdating || formData.enabled}
-                  autoComplete="new-password"
-                  data-form-type="other"
-                  data-lpignore="true"
-                />
+                <InputGroup>
+                  <Form.Control
+                    id="zenodo-password"
+                    type={showPassword ? "text" : "password"}
+                    placeholder="Enter your Zenodo account password"
+                    value={formData.zenodoPassword}
+                    onChange={(e) => {
+                      e.stopPropagation();
+                      e.preventDefault();
+                      handleInputChange("zenodoPassword", e.target.value);
+                    }}
+                    disabled={isUpdating || formData.enabled}
+                    autoComplete="new-password"
+                    data-form-type="other"
+                    data-lpignore="true"
+                    style={{
+                      borderColor: "#dee2e6",
+                    }}
+                    onFocus={(e) => {
+                      e.target.style.boxShadow = "none";
+                      e.target.style.borderColor = "#dee2e6";
+                    }}
+                  />
+                  <Button
+                    variant="outline-secondary"
+                    onClick={() => setShowPassword(!showPassword)}
+                    disabled={isUpdating}
+                    style={{
+                      borderColor: "#dee2e6",
+                      borderLeft: "none",
+                      height: "32.5px",
+                      display: "flex",
+                      alignItems: "center",
+                    }}
+                  >
+                    {showPassword ? <FaEyeSlash /> : <FaEye />}
+                  </Button>
+                </InputGroup>
               </div>
             </Form>
           </div>


### PR DESCRIPTION
This PR enhances the Zenodo settings form with password visibility toggles for sensitive fields and improves toggle button styling for better visibility in disabled state.

- Added show/hide toggle buttons for API Key and Password fields with the relevant icons
- Enhanced toggle button size and style for better visibility
