### PR TITLE
[CAT-1019] - Implement Reports Table Display and Functionality

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -56,6 +56,7 @@ import AlgorithmsSettings from "./pages/admin/settings/AlgorithmsSettings";
 import BenchmarkTypesSettings from "./pages/admin/settings/BenchmarkTypesSettings";
 import AAIAutocompleteSettings from "./pages/admin/settings/AAIAutocompleteSettings";
 import ZenodoSettings from "./pages/admin/settings/ZenodoSettings";
+import ReportsContainer from "./pages/admin/reports/ReportsContainer";
 import AdminDashboard from "./pages/admin/AdminDashboard";
 import { pidSelectionView, themeAbout } from "./config";
 import { handleBackendError } from "./utils";
@@ -411,6 +412,9 @@ function App() {
                 element={<ProtectedRoute />}
               >
                 <Route index element={<AAIAutocompleteSettings />} />
+              </Route>
+              <Route path={ROUTES.ADMIN.REPORTS} element={<ProtectedRoute />}>
+                <Route index element={<ReportsContainer />} />
               </Route>
               <Route path={ROUTES.LOGOUT} element={<KeycloakLogout />} />
             </Routes>

--- a/src/api/services/reports.ts
+++ b/src/api/services/reports.ts
@@ -1,0 +1,58 @@
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { APIClient } from "../client";
+
+export interface ReportDefinition {
+  id: string;
+  label: string;
+  description: string;
+  value_type: string;
+  row_dimension: string;
+  column_dimension: string;
+}
+
+export interface ReportRequest {
+  reportDefinitionId: string;
+}
+
+export interface ReportResponse {
+  label: string;
+  description: string;
+  rows_dimension: string;
+  columns_dimension: string;
+  value_type: string;
+  created_by: string;
+  created_on: string;
+  rows: string[];
+  columns: string[];
+  data: string[][];
+}
+
+export const useGetReportDefinitions = ({
+  token,
+  isRegistered,
+}: {
+  token: string;
+  isRegistered: boolean;
+}) =>
+  useQuery({
+    queryKey: ["report-definitions"],
+    queryFn: async () => {
+      const response = await APIClient(token).get<ReportDefinition[]>(
+        "/v1/reports/definitions",
+      );
+      return response.data;
+    },
+    enabled: !!token && isRegistered,
+  });
+
+export const useGenerateReport = (token: string) => {
+  return useMutation({
+    mutationFn: async (reportRequest: ReportRequest) => {
+      const response = await APIClient(token).post<ReportResponse>(
+        "/v1/reports",
+        reportRequest,
+      );
+      return response.data;
+    },
+  });
+};

--- a/src/auth/ProtectedRoute.tsx
+++ b/src/auth/ProtectedRoute.tsx
@@ -112,7 +112,7 @@ export function ProtectedRoute() {
         <div>
           <AdminMenu />
         </div>
-        <div className="bg-white container-fluid mb-4 flex-grow-1">
+        <div className="bg-white container-fluid mb-4 flex-grow-1 overflow-x-hidden">
           <Outlet />
         </div>
       </div>
@@ -121,7 +121,7 @@ export function ProtectedRoute() {
         <div>
           <UserMenu />
         </div>
-        <div className="rounded bg-white container-fluid mb-4 flex-grow-1">
+        <div className="rounded bg-white container-fluid mb-4 flex-grow-1 overflow-x-hidden">
           <Outlet />
         </div>
       </div>

--- a/src/components/AdminMenu.tsx
+++ b/src/components/AdminMenu.tsx
@@ -11,6 +11,7 @@ import {
   FaBars,
   FaTimes,
   FaChartBar,
+  FaFileAlt,
 } from "react-icons/fa";
 import { FaClipboardQuestion, FaFileCircleCheck } from "react-icons/fa6";
 import { Link, useLocation } from "react-router-dom";
@@ -179,6 +180,14 @@ function renderMenuContent(
               className={`cat-nav-link-item ${isSel(adminPath, "dashboard") ? "active" : ""}`}
             >
               <FaChartBar /> {t("Dashboard")}
+            </Link>
+          </li>
+          <li>
+            <Link
+              to={ROUTES.ADMIN.REPORTS}
+              className={`cat-nav-link-item ${isSel(adminPath, "reports") ? "active" : ""}`}
+            >
+              <FaFileAlt /> {t("Reports")}
             </Link>
           </li>
           <li>

--- a/src/pages/admin/AdminDashboard.module.css
+++ b/src/pages/admin/AdminDashboard.module.css
@@ -24,6 +24,7 @@
 }
 
 .section-header svg {
+  flex-shrink: 0;
   width: 32px;
   height: 32px;
   padding: 8px;

--- a/src/pages/admin/AdminDashboard.tsx
+++ b/src/pages/admin/AdminDashboard.tsx
@@ -110,7 +110,7 @@ function AdminDashboard() {
   const validationStats = statistics?.validation_statistics;
 
   return (
-    <div className="container-fluid">
+    <div>
       <div className="cat-view-heading-block row">
         <div className="col">
           <h2 className="cat-view-heading text-muted">
@@ -122,7 +122,7 @@ function AdminDashboard() {
         </div>
       </div>
 
-      <Row className="mt-1">
+      <Row className="mt-1 px-2">
         {/* Role-Based Status */}
         <Col lg={3} md={6} className="mb-4">
           <div className={styles["dashboard-section"]}>
@@ -396,7 +396,7 @@ function AdminDashboard() {
         </Col>
       </Row>
 
-      <Row className="mt-4">
+      <Row className="mt-4 px-2">
         <Col lg={12} className="mb-4">
           <div className={styles["most-failed-section"]}>
             <div className={styles["section-header"]}>

--- a/src/pages/admin/reports/Reports.module.css
+++ b/src/pages/admin/reports/Reports.module.css
@@ -1,0 +1,97 @@
+.table-container {
+  overflow: hidden !important;
+  background: white;
+  border: 1px solid #dee2e6;
+  border-radius: 0.375rem;
+  box-shadow: 0 1px 3px rgb(0 0 0 / 10%);
+}
+
+.form-container {
+  max-width: 500px;
+}
+
+.table-responsive {
+  padding: 2rem 1rem 1rem;
+  overflow: auto hidden !important;
+}
+
+.report-table {
+  width: auto !important;
+  margin-bottom: 0.5rem !important;
+  font-size: 0.875rem !important;
+  table-layout: auto !important;
+}
+
+.report-table th {
+  width: auto !important;
+  padding: 1rem 0.75rem !important;
+  font-size: 0.8rem !important;
+  font-weight: 600 !important;
+  text-align: center !important;
+  white-space: nowrap !important;
+  background-color: #f8f9fa !important;
+  border: 1px solid #dee2e6 !important;
+}
+
+.report-table td {
+  width: auto !important;
+  padding: 0.75rem !important;
+  vertical-align: middle;
+  text-align: center;
+  white-space: nowrap !important;
+  border: 1px solid #dee2e6;
+}
+
+.report-table .row-header {
+  width: auto !important;
+  max-width: 200px !important;
+  padding: 1rem;
+  padding-right: 0.25rem;
+  font-weight: 600;
+  text-align: left;
+  white-space: nowrap;
+  background-color: #f8f9fa;
+}
+
+.status-badge {
+  display: inline-block;
+  min-width: 60px;
+  padding: 0.25rem 0.5rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-align: center;
+  text-transform: uppercase;
+  border-radius: 0.4rem;
+}
+
+.status-pass {
+  color: #0f5132;
+  background-color: #d1e7dd;
+}
+
+.status-fail {
+  color: #842029;
+  background-color: #f8d7da;
+}
+
+.status-na {
+  color: #41464b;
+  background-color: #e2e3e5;
+}
+
+.status-in-progress {
+  color: #856404;
+  background-color: #fff3cd;
+}
+
+.export-button {
+  color: white !important;
+  background-color: #6b7280 !important;
+  border-color: #6b7280 !important;
+}
+
+.export-button:hover {
+  color: white !important;
+  background-color: #4b5563 !important;
+  border-color: #4b5563 !important;
+}

--- a/src/pages/admin/reports/Reports.tsx
+++ b/src/pages/admin/reports/Reports.tsx
@@ -1,0 +1,212 @@
+import {
+  Container,
+  Row,
+  Col,
+  Form,
+  Table,
+  Spinner,
+  Alert,
+  Button,
+  OverlayTrigger,
+  Tooltip,
+} from "react-bootstrap";
+import { FaDownload } from "react-icons/fa";
+import type { ReportResponse, ReportDefinition } from "@/api/services/reports";
+import styles from "./Reports.module.css";
+
+interface ReportsProps {
+  reportDefinitions: ReportDefinition[];
+  selectedReportDefinition: string;
+  reportData: ReportResponse | null;
+  isLoadingDefinitions: boolean;
+  isGenerating: boolean;
+  definitionsError: unknown;
+  onReportDefinitionChange: (definitionId: string) => void;
+}
+
+function Reports({
+  reportDefinitions,
+  selectedReportDefinition,
+  reportData,
+  isLoadingDefinitions,
+  isGenerating,
+  definitionsError,
+  onReportDefinitionChange,
+}: ReportsProps) {
+  const getStatusClass = (cellValue: string) => {
+    const value = cellValue.toLowerCase().trim();
+
+    if (!value) {
+      return styles["status-na"];
+    }
+
+    if (value === "pass") {
+      return styles["status-pass"];
+    } else if (value === "fail") {
+      return styles["status-fail"];
+    } else if (value === "in progress" || value === "in-progress") {
+      return styles["status-in-progress"];
+    } else if (value === "n/a" || value === "na") {
+      return styles["status-na"];
+    }
+    // Default to N/A for unknown values
+    else {
+      return styles["status-na"];
+    }
+  };
+
+  const getDisplayValue = (cellValue: string) => {
+    const value = cellValue.trim();
+    if (!value) {
+      return "N/A";
+    }
+    const lowerValue = value.toLowerCase();
+    const knownStatuses = ["pass", "fail", "in progress", "n/a"];
+    if (!knownStatuses.includes(lowerValue)) {
+      return "N/A";
+    }
+    return cellValue;
+  };
+
+  if (isLoadingDefinitions) {
+    return (
+      <Container fluid className="py-4">
+        <div className="text-center">
+          <Spinner animation="border" role="status">
+            <span className="visually-hidden">Loading...</span>
+          </Spinner>
+          <p className="mt-2">Loading report definitions...</p>
+        </div>
+      </Container>
+    );
+  }
+
+  if (definitionsError) {
+    return (
+      <Container fluid className="py-4">
+        <Alert variant="danger">
+          Error loading report definitions. Please try again later.
+        </Alert>
+      </Container>
+    );
+  }
+
+  return (
+    <div>
+      <div className="cat-view-heading-block row border-bottom mb-3">
+        <div className="col">
+          <h2 className="cat-view-heading text-muted">
+            Reports
+            <p className="lead cat-view-lead mb-0">Generate and view reports</p>
+          </h2>
+        </div>
+      </div>
+
+      <div className="mb-4 px-2">
+        <div className={styles["form-container"]}>
+          <Form.Group>
+            <Form.Label className="fw-semibold fs-5 mb-1">
+              Select a Report
+            </Form.Label>
+            <div className="d-flex align-items-center">
+              <Form.Select
+                value={selectedReportDefinition}
+                onChange={(e) => onReportDefinitionChange(e.target.value)}
+                disabled={isGenerating}
+                className="me-3"
+              >
+                {reportDefinitions.map((definition) => (
+                  <option key={definition.id} value={definition.id}>
+                    {definition.label}
+                  </option>
+                ))}
+              </Form.Select>
+              <OverlayTrigger
+                placement="top"
+                overlay={
+                  <Tooltip id="tip-export-pdf">Export report as PDF</Tooltip>
+                }
+              >
+                <Button
+                  className={styles["export-button"]}
+                  disabled={isGenerating || !reportData}
+                  onClick={() => {}}
+                  size="sm"
+                  variant="secondary"
+                >
+                  <FaDownload />
+                </Button>
+              </OverlayTrigger>
+            </div>
+          </Form.Group>
+        </div>
+      </div>
+
+      {isGenerating && (
+        <Row className="my-5">
+          <Col className="d-flex justify-content-center align-items-center">
+            <Spinner animation="border" className="me-2" />
+            <h5 className="mt-1">Generating report...</h5>
+          </Col>
+        </Row>
+      )}
+
+      {reportData && (
+        <Row className="px-2">
+          <Col>
+            <div className={styles["table-container"]}>
+              <div className="p-3 pb-0">
+                <h5>{reportData.description}</h5>
+              </div>
+
+              <div className="px-3">
+                <span className="badge bg-info me-2">
+                  Rows: {reportData.rows_dimension}
+                </span>
+                <span className="badge bg-info me-2">
+                  Columns: {reportData.columns_dimension}
+                </span>
+                <span className="badge bg-info">
+                  Value Type: {reportData.value_type}
+                </span>
+              </div>
+
+              <div className={styles["table-responsive"]}>
+                <Table className={styles["report-table"]}>
+                  <thead>
+                    <tr>
+                      <th></th>
+                      {reportData.columns.map((column, index) => (
+                        <th key={index}>{column}</th>
+                      ))}
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {reportData.rows.map((row, rowIndex) => (
+                      <tr key={rowIndex}>
+                        <td className={styles["row-header"]}>{row}</td>
+                        {reportData.data[rowIndex]?.map(
+                          (cellValue, cellIndex) => (
+                            <td key={cellIndex}>
+                              <span
+                                className={`${styles["status-badge"]} ${getStatusClass(cellValue)}`}
+                              >
+                                {getDisplayValue(cellValue)}
+                              </span>
+                            </td>
+                          ),
+                        )}
+                      </tr>
+                    ))}
+                  </tbody>
+                </Table>
+              </div>
+            </div>
+          </Col>
+        </Row>
+      )}
+    </div>
+  );
+}
+
+export default Reports;

--- a/src/pages/admin/reports/ReportsContainer.tsx
+++ b/src/pages/admin/reports/ReportsContainer.tsx
@@ -1,0 +1,91 @@
+import { useContext, useState, useEffect } from "react";
+import { AuthContext } from "@/auth";
+import {
+  useGetReportDefinitions,
+  useGenerateReport,
+  type ReportResponse,
+} from "@/api/services/reports";
+import toast from "react-hot-toast";
+import Reports from "./Reports";
+
+function ReportsContainer() {
+  const { keycloak, registered } = useContext(AuthContext)!;
+  const [selectedReportDefinition, setSelectedReportDefinition] =
+    useState<string>("");
+  const [reportData, setReportData] = useState<ReportResponse | null>(null);
+  const [isGenerating, setIsGenerating] = useState(false);
+  const [isInitialLoad, setIsInitialLoad] = useState(true);
+
+  const {
+    data: reportDefinitions,
+    isLoading: isLoadingDefinitions,
+    error: definitionsError,
+  } = useGetReportDefinitions({
+    token: keycloak?.token || "",
+    isRegistered: registered,
+  });
+
+  const generateReportMutation = useGenerateReport(keycloak?.token || "");
+
+  useEffect(() => {
+    if (
+      reportDefinitions &&
+      reportDefinitions.length > 0 &&
+      !selectedReportDefinition
+    ) {
+      setSelectedReportDefinition(reportDefinitions[0].id);
+    }
+  }, [reportDefinitions, selectedReportDefinition]);
+
+  useEffect(() => {
+    if (selectedReportDefinition && !reportData && isInitialLoad) {
+      handleGenerateReportForDefinition(selectedReportDefinition);
+    }
+  }, [selectedReportDefinition, reportData, isInitialLoad]);
+
+  const handleReportDefinitionChange = (definitionId: string) => {
+    setSelectedReportDefinition(definitionId);
+    setReportData(null);
+    setIsInitialLoad(false);
+
+    if (definitionId) {
+      handleGenerateReportForDefinition(definitionId);
+    }
+  };
+
+  const handleGenerateReportForDefinition = async (definitionId: string) => {
+    if (!isInitialLoad) {
+      setIsGenerating(true);
+    }
+
+    try {
+      const result = await generateReportMutation.mutateAsync({
+        reportDefinitionId: definitionId,
+      });
+      setReportData(result);
+
+      if (isInitialLoad) {
+        setIsInitialLoad(false);
+      }
+    } catch (error) {
+      toast.error("Failed to generate report");
+      console.error("Error generating report:", error);
+    } finally {
+      setIsGenerating(false);
+    }
+  };
+
+  return (
+    <Reports
+      reportDefinitions={reportDefinitions || []}
+      selectedReportDefinition={selectedReportDefinition}
+      reportData={reportData}
+      isLoadingDefinitions={isLoadingDefinitions}
+      isGenerating={isGenerating}
+      definitionsError={definitionsError}
+      onReportDefinitionChange={handleReportDefinitionChange}
+    />
+  );
+}
+
+export default ReportsContainer;

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -43,6 +43,7 @@ const ROUTES = {
     VALIDATION_REJECT: "/admin/validations/:id/reject",
     VALIDATION_APPROVE: "/admin/validations/:id/approve",
     ASSESSMENTS: "/admin/assessments",
+    REPORTS: "/admin/reports",
     SETTINGS: {
       ROOT: "/admin/settings",
       TEST_METHODS: "/admin/settings/test-methods",


### PR DESCRIPTION
**⚠️ This PR should not be merged before [CAT-1017](https://github.com/FC4E-CAT/fc4e-cat-api/pull/551) is merged.**

This PR adds a reports feature with table display for selecting report types and viewing results in a structured matrix format.

- Implemented report generation with dropdown selection
- Added reports navigation section with role-based access control for admin role
- Created responsive table showing data relationships with auto-sizing
- Added PDF export UI button with custom-styled button and tooltip