### PR TITLE
[CAT-1038] - Add Reporter Role Access to Report Page

### DIFF
--- a/src/auth/ProtectedRoute.tsx
+++ b/src/auth/ProtectedRoute.tsx
@@ -12,6 +12,7 @@ import AdminMenu from "@/components/AdminMenu";
 export function ProtectedRoute() {
   // check if the current path leads to an admin-view
   const adminRoute = useLocation().pathname.startsWith("/admin");
+  const reportsRoute = useLocation().pathname === ROUTES.ADMIN.REPORTS;
 
   // load navigate hook to use it to programmaticaly navigate to profile page if needed
   const navigate = useNavigate();
@@ -98,13 +99,21 @@ export function ProtectedRoute() {
     }
   }, [isSuccessRegister, setRegistered, profileData]);
 
-  // check if a non-admin user tries to access an admin view
+  // check if a non-admin user tries to access an admin view (except reports for reporter)
   useEffect(() => {
     if (authenticated && adminRoute && profileData) {
-      if (profileData.user_type.toLowerCase() !== "admin")
+      const userType = profileData.user_type.toLowerCase();
+      const roles = profileData.roles || [];
+
+      if (reportsRoute && roles.includes("reporter")) {
+        return;
+      }
+
+      if (userType !== "admin") {
         navigate(ROUTES.PROFILE.ROOT);
+      }
     }
-  }, [authenticated, adminRoute, profileData, navigate]);
+  }, [authenticated, adminRoute, reportsRoute, profileData, navigate]);
 
   if (authenticated && isSuccess && profileData) {
     return profileData.user_type.toLowerCase() === "admin" ? (
@@ -119,7 +128,7 @@ export function ProtectedRoute() {
     ) : (
       <div className="cat-admin-container d-flex flex-row">
         <div>
-          <UserMenu />
+          <UserMenu roles={profileData.roles} />
         </div>
         <div className="rounded bg-white container-fluid mb-4 flex-grow-1 overflow-x-hidden">
           <Outlet />

--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -1,18 +1,21 @@
 import { useEffect, useState } from "react";
 import { Link, useLocation } from "react-router-dom";
 import { useTranslation } from "react-i18next";
-import { FaBars, FaTimes, FaUsers } from "react-icons/fa";
+import { FaBars, FaFileAlt, FaTimes, FaUsers } from "react-icons/fa";
 import ROUTES from "../routes";
 
 function isSel(path: string, name: string): boolean {
   return path.toLowerCase() === name.toLowerCase();
 }
 
-export default function UserMenu() {
+export default function UserMenu({ roles }: { roles?: string[] }) {
   const userPath = useLocation().pathname.split("/")[1] ?? "";
+  const adminPath = useLocation().pathname.split("/")[2] ?? "";
   const currentPath = useLocation().pathname;
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
   const [isSmallScreen, setIsSmallScreen] = useState(false);
+
+  const isReporter = roles?.includes("reporter") ?? false;
 
   const { t } = useTranslation();
 
@@ -106,7 +109,7 @@ export default function UserMenu() {
                   overflowY: "auto",
                 }}
               >
-                {renderMenuContent({ userPath, t })}
+                {renderMenuContent({ isReporter, adminPath, userPath, t })}
               </div>
             </div>
           </>
@@ -117,15 +120,19 @@ export default function UserMenu() {
 
   return (
     <div className="cat-sidebar-container">
-      {renderMenuContent({ userPath, t })}
+      {renderMenuContent({ isReporter, adminPath, userPath, t })}
     </div>
   );
 }
 
 function renderMenuContent({
+  isReporter,
+  adminPath,
   userPath,
   t,
 }: {
+  isReporter: boolean;
+  adminPath: string;
   userPath: string;
   t: ReturnType<typeof useTranslation>["t"];
 }) {
@@ -142,6 +149,16 @@ function renderMenuContent({
               <FaUsers /> {t("profile")}
             </Link>
           </li>
+          {isReporter && (
+            <li>
+              <Link
+                to={ROUTES.ADMIN.REPORTS}
+                className={`cat-nav-link-item ${isSel(adminPath, "reports") ? "active" : ""}`}
+              >
+                <FaFileAlt /> {t("Reports")}
+              </Link>
+            </li>
+          )}
           <li>
             <Link
               to={ROUTES.VALIDATIONS.ROOT}

--- a/src/pages/admin/reports/Reports.tsx
+++ b/src/pages/admin/reports/Reports.tsx
@@ -191,7 +191,7 @@ function Reports({
           <div>
             <div className={styles["table-container"]}>
               <div className="p-3 pb-0">
-                <h5>{reportData.description}</h5>
+                <h6>{reportData.description}</h6>
               </div>
 
               <div className="px-3">

--- a/src/pages/admin/reports/ReportsContainer.tsx
+++ b/src/pages/admin/reports/ReportsContainer.tsx
@@ -1,4 +1,4 @@
-import { useContext, useState, useEffect } from "react";
+import { useContext, useState, useEffect, useCallback } from "react";
 import { AuthContext } from "@/auth";
 import {
   useGetReportDefinitions,
@@ -40,6 +40,43 @@ function ReportsContainer() {
 
   const generateReportMutation = useGenerateReport(keycloak?.token || "");
 
+  const handleGenerateReportForDefinition = useCallback(
+    async (definitionId: string, filters?: Record<string, string[]>) => {
+      if (!isInitialLoad) {
+        setIsGenerating(true);
+      }
+
+      try {
+        const filterParams: Record<string, string[]> = {};
+        const filtersToUse = filters || selectedFilters;
+
+        Object.entries(filtersToUse).forEach(([filterName, filterValues]) => {
+          if (filterValues.length > 0) {
+            filterParams[filterName] = filterValues;
+          }
+        });
+
+        const result = await generateReportMutation.mutateAsync({
+          reportId: definitionId,
+          reportRequest: {
+            filters: filterParams,
+          },
+        });
+        setReportData(result);
+
+        if (isInitialLoad) {
+          setIsInitialLoad(false);
+        }
+      } catch (error) {
+        toast.error("Failed to generate report");
+        console.error("Error generating report:", error);
+      } finally {
+        setIsGenerating(false);
+      }
+    },
+    [isInitialLoad, selectedFilters, generateReportMutation],
+  );
+
   useEffect(() => {
     if (
       reportDefinitions &&
@@ -54,7 +91,12 @@ function ReportsContainer() {
     if (selectedReportDefinition && !reportData && isInitialLoad) {
       handleGenerateReportForDefinition(selectedReportDefinition);
     }
-  }, [selectedReportDefinition, reportData, isInitialLoad]);
+  }, [
+    selectedReportDefinition,
+    reportData,
+    isInitialLoad,
+    handleGenerateReportForDefinition,
+  ]);
 
   const handleReportDefinitionChange = (definitionId: string) => {
     setSelectedReportDefinition(definitionId);
@@ -65,43 +107,6 @@ function ReportsContainer() {
       handleGenerateReportForDefinition(definitionId, {});
       setSelectedFilters({});
       setAppliedFilters({});
-    }
-  };
-
-  const handleGenerateReportForDefinition = async (
-    definitionId: string,
-    filters?: Record<string, string[]>,
-  ) => {
-    if (!isInitialLoad) {
-      setIsGenerating(true);
-    }
-
-    try {
-      const filterParams: Record<string, string[]> = {};
-      const filtersToUse = filters || selectedFilters;
-
-      Object.entries(filtersToUse).forEach(([filterName, filterValues]) => {
-        if (filterValues.length > 0) {
-          filterParams[filterName] = filterValues;
-        }
-      });
-
-      const result = await generateReportMutation.mutateAsync({
-        reportId: definitionId,
-        reportRequest: {
-          filters: filterParams,
-        },
-      });
-      setReportData(result);
-
-      if (isInitialLoad) {
-        setIsInitialLoad(false);
-      }
-    } catch (error) {
-      toast.error("Failed to generate report");
-      console.error("Error generating report:", error);
-    } finally {
-      setIsGenerating(false);
     }
   };
 

--- a/src/types/profile.ts
+++ b/src/types/profile.ts
@@ -5,6 +5,7 @@ export interface UserProfile {
   orcid_id?: string;
   registered_on: string;
   user_type: string;
+  roles: string[];
   name: string;
   surname: string;
   email: string;


### PR DESCRIPTION
This PR allows users with reporter role and admins to access the Reports page from the admin panel while maintaining restricted access to other admin features, implementing role-based access control for the reports functionality.

- Updated route protection logic to check for reporter role when accessing the reports route
- Added role validation to verify reporter role membership before granting reports access
- Preserved existing redirect logic for non-admin, non-reporter users attempting to access restricted admin features.


