### PR TITLE
[CAT-1039] - Implement CSV Export Functionality for Reports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@hookform/error-message": "^2.0.1",
         "@react-pdf/renderer": "^4.3.0",
         "@tanstack/react-query": "^5.85.0",
-        "axios": "^1.11.0",
+        "axios": "^1.12.2",
         "bootstrap": "^5.3.7",
         "i18next": "^25.3.4",
         "keycloak-js": "^26.2.0",
@@ -2505,9 +2505,9 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
-      "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
+      "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@hookform/error-message": "^2.0.1",
     "@react-pdf/renderer": "^4.3.0",
     "@tanstack/react-query": "^5.85.0",
-    "axios": "^1.11.0",
+    "axios": "^1.12.2",
     "bootstrap": "^5.3.7",
     "i18next": "^25.3.4",
     "keycloak-js": "^26.2.0",

--- a/src/api/services/reports.ts
+++ b/src/api/services/reports.ts
@@ -79,6 +79,34 @@ export const useGenerateReport = (token: string) => {
   });
 };
 
+export const useExportReport = (token: string) => {
+  return useMutation({
+    mutationFn: async ({
+      reportId,
+      reportData,
+    }: {
+      reportId: string;
+      reportData: ReportResponse;
+    }) => {
+      const response = await APIClient(token).post(
+        `/v1/reports/export/${reportId}`,
+        reportData,
+        {
+          responseType: "blob",
+          headers: {
+            Accept: "text/csv",
+          },
+        },
+      );
+
+      return {
+        data: response.data,
+        headers: response.headers,
+      };
+    },
+  });
+};
+
 export const useGetReportFilters = ({
   reportDefinitionId,
   token,

--- a/src/pages/admin/reports/Reports.tsx
+++ b/src/pages/admin/reports/Reports.tsx
@@ -28,6 +28,7 @@ interface ReportsProps {
   reportData: ReportResponse | null;
   isLoadingDefinitions: boolean;
   isGenerating: boolean;
+  isExporting: boolean;
   definitionsError: unknown;
   reportFilters: ReportFilter[];
   selectedFilters: Record<string, string[]>;
@@ -40,6 +41,7 @@ interface ReportsProps {
   ) => void;
   onApplyFilters: () => void;
   onClearAllFilters: () => void;
+  onExportReport: () => void;
 }
 
 function Reports({
@@ -48,6 +50,7 @@ function Reports({
   reportData,
   isLoadingDefinitions,
   isGenerating,
+  isExporting,
   definitionsError,
   reportFilters,
   selectedFilters,
@@ -56,6 +59,7 @@ function Reports({
   onFilterChange,
   onApplyFilters,
   onClearAllFilters,
+  onExportReport,
 }: ReportsProps) {
   const [showFilterDropdown, setShowFilterDropdown] = useState(false);
 
@@ -159,17 +163,23 @@ function Reports({
               <OverlayTrigger
                 placement="top"
                 overlay={
-                  <Tooltip id="tip-export-pdf">Export report as PDF</Tooltip>
+                  <Tooltip id="tip-export-pdf">
+                    Export report as CSV file
+                  </Tooltip>
                 }
               >
                 <Button
                   className={styles["export-button"]}
-                  disabled={isGenerating || !reportData}
-                  onClick={() => {}}
+                  disabled={isGenerating || isExporting || !reportData}
+                  onClick={onExportReport}
                   size="sm"
                   variant="secondary"
                 >
-                  <FaDownload />
+                  {isExporting ? (
+                    <Spinner as="span" size="sm" />
+                  ) : (
+                    <FaDownload />
+                  )}
                 </Button>
               </OverlayTrigger>
             </div>

--- a/src/pages/admin/reports/ReportsContainer.tsx
+++ b/src/pages/admin/reports/ReportsContainer.tsx
@@ -4,6 +4,7 @@ import {
   useGetReportDefinitions,
   useGenerateReport,
   useGetReportFilters,
+  useExportReport,
   type ReportResponse,
 } from "@/api/services/reports";
 import toast from "react-hot-toast";
@@ -39,6 +40,7 @@ function ReportsContainer() {
   });
 
   const generateReportMutation = useGenerateReport(keycloak?.token || "");
+  const exportReportMutation = useExportReport(keycloak?.token || "");
 
   const handleGenerateReportForDefinition = useCallback(
     async (definitionId: string, filters?: Record<string, string[]>) => {
@@ -144,6 +146,50 @@ function ReportsContainer() {
     }
   };
 
+  const handleExportReport = async () => {
+    if (!selectedReportDefinition || !reportData) {
+      toast.error("No report data available for export");
+      return;
+    }
+
+    // Reset any previous mutation state
+    exportReportMutation.reset();
+
+    try {
+      const response = await exportReportMutation.mutateAsync({
+        reportId: selectedReportDefinition,
+        reportData: reportData,
+      });
+
+      // Extract filename from Content-Disposition header
+      const contentDisposition = response.headers["content-disposition"];
+
+      let filename = `CAT_report_${reportData.rows_dimension}_${reportData.columns_dimension}.csv`;
+
+      if (contentDisposition) {
+        filename = contentDisposition
+          ?.split("filename=")[1]
+          ?.split(";")[0]
+          ?.replace(/"/g, "")
+          ?.trim();
+      }
+
+      const url = window.URL.createObjectURL(response.data);
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = filename;
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      window.URL.revokeObjectURL(url);
+
+      toast.success("Report exported successfully");
+    } catch (error) {
+      console.error("Error exporting report:", error);
+      toast.error("Failed to export report");
+    }
+  };
+
   return (
     <Reports
       reportDefinitions={reportDefinitions || []}
@@ -151,6 +197,7 @@ function ReportsContainer() {
       reportData={reportData}
       isLoadingDefinitions={isLoadingDefinitions}
       isGenerating={isGenerating}
+      isExporting={exportReportMutation.isPending}
       definitionsError={definitionsError}
       reportFilters={reportFilters || []}
       selectedFilters={selectedFilters}
@@ -159,6 +206,7 @@ function ReportsContainer() {
       onFilterChange={handleFilterChange}
       onApplyFilters={handleApplyFilters}
       onClearAllFilters={handleClearAllFilters}
+      onExportReport={handleExportReport}
     />
   );
 }


### PR DESCRIPTION
**⚠️ This PR should not be merged before [CAT-1037](https://github.com/FC4E-CAT/fc4e-cat-api/pull/556) is merged.**

This PR adds comprehensive CSV export functionality to the Reports page, enabling users to download report data as CSV files.

- Implemented CSV export endpoint integration using POST /v1/reports/generate/{id}/export with blob response handling and CSV media-type headers.
- Implemented automatic file download functionality using blob URL creation 
- Added filename generation logic with fallback mechanism
- Enhanced error handling and user feedback with toast notifications for export success and failure states
