### PR TITLE
[CAT-1043] - Hide options from identified user

### DIFF
--- a/src/api/services/subjects.ts
+++ b/src/api/services/subjects.ts
@@ -20,6 +20,7 @@ export const useGetSubjects = ({
       );
       return response.data;
     },
+    retry: false,
     enabled: !!token && isRegistered,
   });
 

--- a/src/auth/AuthProvider.tsx
+++ b/src/auth/AuthProvider.tsx
@@ -10,6 +10,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [authenticated, setAuthenticated] = useState(false);
   const [registered, setRegistered] = useState(false);
   const [keycloak, setKeycloak] = useState<NullableKeycloak>(null);
+  const [userType, setUserType] = useState<string>("");
 
   const refreshUserToken = useCallback(async () => {
     if (!keycloak) {
@@ -38,6 +39,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     keycloak,
     setKeycloak,
     refreshUserToken,
+    userType,
+    setUserType,
   };
 
   return (

--- a/src/auth/ProtectedRoute.tsx
+++ b/src/auth/ProtectedRoute.tsx
@@ -24,6 +24,7 @@ export function ProtectedRoute() {
     setKeycloak,
     registered,
     setRegistered,
+    setUserType,
   } = useContext(AuthContext)!;
 
   const {
@@ -96,8 +97,9 @@ export function ProtectedRoute() {
   useEffect(() => {
     if (isSuccessRegister || profileData) {
       setRegistered(true);
+      setUserType(profileData?.user_type || "");
     }
-  }, [isSuccessRegister, setRegistered, profileData]);
+  }, [isSuccessRegister, setRegistered, setUserType, profileData]);
 
   // check if a non-admin user tries to access an admin view (except reports for reporter)
   useEffect(() => {

--- a/src/auth/auth-context.ts
+++ b/src/auth/auth-context.ts
@@ -11,6 +11,8 @@ export interface AuthContextProps {
   keycloak: NullableKeycloak;
   setKeycloak: React.Dispatch<React.SetStateAction<NullableKeycloak>>;
   refreshUserToken: () => Promise<void>;
+  userType: string;
+  setUserType: React.Dispatch<React.SetStateAction<string>>;
 }
 
 export const AuthContext = createContext<AuthContextProps | null>(null);

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -38,10 +38,12 @@ function Profile() {
       {copySuccess ? t("copied") : t("copy")}
     </Tooltip>
   );
-  // check if the user has details
-  const hasDetails =
-    (userProfile?.name && userProfile?.surname && userProfile?.name) ||
+
+  const shouldShowActions =
+    (userProfile?.name && userProfile?.surname && userProfile?.email) ||
     userProfile?.user_type === "Admin";
+
+  const isIdentified = userProfile?.user_type === "Identified";
 
   if (keycloak?.token && authenticated) {
     return (
@@ -128,7 +130,7 @@ function Profile() {
               <div className="row py-3 mt-4">
                 <h4>{t("validation_requests")}</h4>
                 <section className="col-9 disabled">
-                  {!hasDetails && (
+                  {!shouldShowActions && (
                     <div
                       id={"validation-alert-warning"}
                       className="alert alert-warning"
@@ -137,7 +139,7 @@ function Profile() {
                       <FaLock /> {t("page_profile.validation_requests_alert")}
                     </div>
                   )}
-                  {hasDetails && (
+                  {shouldShowActions && (
                     <>
                       <div>
                         {t("page_profile.validation_requests_subtitle")}
@@ -162,61 +164,68 @@ function Profile() {
                   )}
                 </section>
               </div>
-              <div className="row border-top py-3 mt-4">
-                <h4>{t("assessments")}</h4>
-                <section id="assessments_section" className="col-9 disabled">
-                  {(userProfile?.user_type === "Validated" ||
-                    userProfile?.user_type === "Admin") && (
-                    <>
-                      <div>{t("page_profile.assessments_subtitle")}</div>
-                      <div className="mt-4">
-                        <Link
-                          id="view_assessments_button"
-                          to={ROUTES.ASSESSMENTS.ROOT}
-                          className="btn btn-light border-black"
-                        >
-                          {t("buttons.view_list")}
-                        </Link>
-                        <Link
-                          id="create_assessment_button"
-                          to={ROUTES.ASSESSMENTS.CREATE}
-                          className="btn btn-light border-black mx-3"
-                        >
-                          <FaPlus /> {t("buttons.create_new")}
-                        </Link>
-                      </div>
-                    </>
-                  )}
-                </section>
-              </div>
-              <div className="row border-top py-3 mt-4">
-                <h4>{t("subjects")}</h4>
+              {shouldShowActions && !isIdentified && (
+                <>
+                  <div className="row border-top py-3 mt-4">
+                    <h4>{t("assessments")}</h4>
+                    <section
+                      id="assessments_section"
+                      className="col-9 disabled"
+                    >
+                      {(userProfile?.user_type === "Validated" ||
+                        userProfile?.user_type === "Admin") && (
+                        <>
+                          <div>{t("page_profile.assessments_subtitle")}</div>
+                          <div className="mt-4">
+                            <Link
+                              id="view_assessments_button"
+                              to={ROUTES.ASSESSMENTS.ROOT}
+                              className="btn btn-light border-black"
+                            >
+                              {t("buttons.view_list")}
+                            </Link>
+                            <Link
+                              id="create_assessment_button"
+                              to={ROUTES.ASSESSMENTS.CREATE}
+                              className="btn btn-light border-black mx-3"
+                            >
+                              <FaPlus /> {t("buttons.create_new")}
+                            </Link>
+                          </div>
+                        </>
+                      )}
+                    </section>
+                  </div>
 
-                <section id="subjects_section" className="col-9 disabled">
-                  {(userProfile?.user_type === "Validated" ||
-                    userProfile?.user_type === "Admin") && (
-                    <>
-                      <div>{t("page_profile.subjects_subtitle")}</div>
-                      <div className="mt-4">
-                        <Link
-                          id="view_subjects_button"
-                          to={ROUTES.SUBJECTS}
-                          className="btn btn-light border-black"
-                        >
-                          {t("buttons.view_list")}
-                        </Link>
-                        <Link
-                          id="create_subject_button"
-                          to={`${ROUTES.SUBJECTS}?create`}
-                          className="btn btn-light border-black mx-3"
-                        >
-                          <FaPlus /> {t("buttons.create_new")}
-                        </Link>
-                      </div>
-                    </>
-                  )}
-                </section>
-              </div>
+                  <div className="row border-top py-3 mt-4">
+                    <h4>{t("subjects")}</h4>
+                    <section id="subjects_section" className="col-9 disabled">
+                      {(userProfile?.user_type === "Validated" ||
+                        userProfile?.user_type === "Admin") && (
+                        <>
+                          <div>{t("page_profile.subjects_subtitle")}</div>
+                          <div className="mt-4">
+                            <Link
+                              id="view_subjects_button"
+                              to={ROUTES.SUBJECTS}
+                              className="btn btn-light border-black"
+                            >
+                              {t("buttons.view_list")}
+                            </Link>
+                            <Link
+                              id="create_subject_button"
+                              to={`${ROUTES.SUBJECTS}?create`}
+                              className="btn btn-light border-black mx-3"
+                            >
+                              <FaPlus /> {t("buttons.create_new")}
+                            </Link>
+                          </div>
+                        </>
+                      )}
+                    </section>
+                  </div>
+                </>
+              )}
             </div>
           </div>
         </div>

--- a/src/pages/Subjects.tsx
+++ b/src/pages/Subjects.tsx
@@ -289,6 +289,9 @@ function Subjects() {
   });
 
   const { t } = useTranslation();
+  const { keycloak, userType } = useContext(AuthContext)!;
+
+  const isIdentified = userType === "Identified";
 
   // create the tooltips
   const tooltipEdit = (
@@ -304,9 +307,6 @@ function Subjects() {
   const location = useLocation();
   const searchParams = new URLSearchParams(location.search);
   const doCreate = searchParams.has("create");
-
-  // mutation hook for creating a new subject
-  const { keycloak } = useContext(AuthContext)!;
 
   const [opts, setOpts] = useState<SubjectState>({
     page: 1,
@@ -439,22 +439,24 @@ function Subjects() {
             <p className="lead cat-view-lead">Manage your own subjects.</p>
           </h2>
         </div>
-        <div className="col-md-auto cat-heading-right">
-          <Button
-            variant="warning"
-            className="cat-button-create-new"
-            onClick={() =>
-              setSubjectModalConfig({
-                id: -1,
-                mode: SubjectModalMode.Create,
-                show: true,
-              })
-            }
-          >
-            <FaPlus className="me-2" />
-            {t("buttons.create_new")}
-          </Button>
-        </div>
+        {!isIdentified && (
+          <div className="col-md-auto cat-heading-right">
+            <Button
+              variant="warning"
+              className="cat-button-create-new"
+              onClick={() =>
+                setSubjectModalConfig({
+                  id: -1,
+                  mode: SubjectModalMode.Create,
+                  show: true,
+                })
+              }
+            >
+              <FaPlus className="me-2" />
+              {t("buttons.create_new")}
+            </Button>
+          </div>
+        )}
       </div>
       <div className="py-2 px-2">
         {subjects.length > 0 ? (
@@ -498,42 +500,44 @@ function Subjects() {
                   </Card.Body>
 
                   <Card.Footer className="bg-transparent border-1">
-                    <div className="d-flex justify-content-end gap-2">
-                      <OverlayTrigger placement="top" overlay={tooltipEdit}>
-                        <Button
-                          id={`edit-button-${item.id}`}
-                          className="btn btn-light btn-sm"
-                          onClick={() => {
-                            if (item.id) {
-                              setSubjectModalConfig({
-                                id: item.id,
-                                mode: SubjectModalMode.Update,
-                                show: true,
-                              });
-                            }
-                          }}
-                        >
-                          <FaEdit />
-                        </Button>
-                      </OverlayTrigger>
-                      <OverlayTrigger placement="top" overlay={tooltipDelete}>
-                        <Button
-                          id={`delete-button-${item.id}`}
-                          className="btn btn-light btn-sm"
-                          onClick={() => {
-                            if (item.id) {
-                              setSubjectModalConfig({
-                                id: item.id,
-                                mode: SubjectModalMode.Delete,
-                                show: true,
-                              });
-                            }
-                          }}
-                        >
-                          <FaTimes />
-                        </Button>
-                      </OverlayTrigger>
-                    </div>
+                    {!isIdentified && (
+                      <div className="d-flex justify-content-end gap-2">
+                        <OverlayTrigger placement="top" overlay={tooltipEdit}>
+                          <Button
+                            id={`edit-button-${item.id}`}
+                            className="btn btn-light btn-sm"
+                            onClick={() => {
+                              if (item.id) {
+                                setSubjectModalConfig({
+                                  id: item.id,
+                                  mode: SubjectModalMode.Update,
+                                  show: true,
+                                });
+                              }
+                            }}
+                          >
+                            <FaEdit />
+                          </Button>
+                        </OverlayTrigger>
+                        <OverlayTrigger placement="top" overlay={tooltipDelete}>
+                          <Button
+                            id={`delete-button-${item.id}`}
+                            className="btn btn-light btn-sm"
+                            onClick={() => {
+                              if (item.id) {
+                                setSubjectModalConfig({
+                                  id: item.id,
+                                  mode: SubjectModalMode.Delete,
+                                  show: true,
+                                });
+                              }
+                            }}
+                          >
+                            <FaTimes />
+                          </Button>
+                        </OverlayTrigger>
+                      </div>
+                    )}
                   </Card.Footer>
                 </Card>
               </Col>

--- a/src/pages/assessments/AssessmentsList.tsx
+++ b/src/pages/assessments/AssessmentsList.tsx
@@ -90,7 +90,10 @@ interface PublishModalConfig {
 }
 
 function AssessmentsList({ listPublic = false }: AssessmentListProps) {
-  const { keycloak, registered } = useContext(AuthContext)!;
+  const { keycloak, registered, userType } = useContext(AuthContext)!;
+
+  const isIdentified = userType === "Identified";
+
   // get the extra url parameters when in public list mode from url
   const urlParams = new URLSearchParams(location.search);
   const actorName = urlParams.get("actor-name");
@@ -325,7 +328,7 @@ function AssessmentsList({ listPublic = false }: AssessmentListProps) {
           </h2>
         </div>
         <div className="col-md-auto cat-heading-right">
-          {!listPublic && (
+          {!listPublic && !isIdentified && (
             <>
               <Link
                 to={ROUTES.ASSESSMENTS.CREATE}

--- a/src/pages/validations/ValidationList.tsx
+++ b/src/pages/validations/ValidationList.tsx
@@ -1,5 +1,5 @@
 import { useContext, useState, useEffect } from "react";
-import { useGetValidationList } from "@/api";
+import { useGetProfile, useGetValidationList } from "@/api";
 import { AuthContext } from "@/auth";
 import type { ValidationResponse } from "@/types";
 import { Link } from "react-router-dom";
@@ -40,6 +40,15 @@ function ValidationList() {
   const { t } = useTranslation();
 
   const { keycloak, registered } = useContext(AuthContext)!;
+
+  const { data: profileData } = useGetProfile({
+    token: keycloak?.token || "",
+    isRegistered: registered,
+  });
+
+  const shouldShowActions =
+    (profileData?.name && profileData?.surname && profileData?.email) ||
+    profileData?.user_type === "Admin";
 
   const [opts, setOpts] = useState<ValidationState>({
     sortBy: "",
@@ -85,14 +94,16 @@ function ValidationList() {
             </p>
           </h2>
         </div>
-        <div className="col-md-auto cat-heading-right">
-          <Link
-            to={ROUTES.VALIDATIONS.REQUEST}
-            className="btn btn-warning mx-2"
-          >
-            <FaPlus className="m2" /> {t("buttons.create_new")}
-          </Link>
-        </div>
+        {shouldShowActions && (
+          <div className="col-md-auto cat-heading-right">
+            <Link
+              to={ROUTES.VALIDATIONS.REQUEST}
+              className="btn btn-warning mx-2"
+            >
+              <FaPlus className="m2" /> {t("buttons.create_new")}
+            </Link>
+          </div>
+        )}
       </div>
 
       <div className="py-2 px-2 ">


### PR DESCRIPTION
This PR restricts access to core functionality for users with "Identified" role to ensure proper permission management.

- Updated UserMenu component to conditionally hide Validations, Assessments, and Subjects navigation links for identified users
- Modified Profile page to prevent identified users from accessing create/view/import actions
- Implemented role-based action button hiding in Subjects component, and conditionally rendering edit/delete buttons
- Updated AssessmentsList component with role-based access control to hide all action buttons for identified users
