### PR TITLE
[CAT-1054] - Zenodo Integration Improvements and UI Enhancements

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1009,3 +1009,43 @@ a.plain:hover {
   box-shadow: 0 2px 4px rgb(0 0 0 / 10%) !important;
   transition: all 0.3s ease !important;
 }
+
+.step-pending-icon {
+  width: 16px;
+  height: 16px;
+  background-color: #f8f9fa;
+  border: 2px solid #dee2e6;
+  border-radius: 50%;
+}
+
+.step-item.completed .step-pending-icon {
+  background-color: #d1e7dd;
+  border-color: #198754;
+}
+
+.step-item.active .step-pending-icon {
+  background-color: #cfe2ff;
+  border-color: #0d6efd;
+}
+
+.step-item.failed .step-pending-icon {
+  background-color: #f8d7da;
+  border-color: #dc3545;
+}
+
+.step-item.completed {
+  opacity: 0.8;
+}
+
+.step-item.active {
+  font-weight: 500;
+  opacity: 1;
+}
+
+.step-item.failed {
+  opacity: 1;
+}
+
+.step-item.pending {
+  opacity: 0.6;
+}

--- a/src/api/services/registry.ts
+++ b/src/api/services/registry.ts
@@ -9,6 +9,7 @@ import type {
   Principle,
   PrincipleInput,
   Pagination,
+  ZenodoAssessmentResponse,
 } from "@/types";
 import {
   useInfiniteQuery,
@@ -651,6 +652,26 @@ export const useUpdateAdminSetting = (token: string) => {
     },
   });
 };
+
+export const useGetZenodoAssessment = ({
+  id,
+  token,
+  isRegistered,
+}: {
+  id: string;
+  token: string;
+  isRegistered: boolean;
+}) =>
+  useQuery({
+    queryKey: ["zenodo-assessment", id],
+    queryFn: async () => {
+      const response = await APIClient(token).get<ZenodoAssessmentResponse>(
+        `/v2/zenodo/assessment/${id}`,
+      );
+      return response.data;
+    },
+    enabled: !!token && isRegistered && id !== "" && id !== undefined,
+  });
 
 export const usePublishToZenodo = (token: string) => {
   return useMutation({

--- a/src/assets/locales/en.json
+++ b/src/assets/locales/en.json
@@ -321,6 +321,7 @@
     "tip_zenodo_disabled": "Only published assessments can be uploaded to Zenodo",
     "tip_zenodo_published": "View Zenodo publication details",
     "zenodo_modal_title": "Publish to Zenodo",
+    "zenodo_modal_title_published": "Published to Zenodo",
     "zenodo_already_published": "Already Published to Zenodo",
     "zenodo_already_published_message": "This assessment has already been published to the Zenodo repository.",
     "zenodo_publish_confirmation": "Are you sure you want to publish this assessment to the Zenodo repository?",

--- a/src/pages/admin/AdminAssessments.tsx
+++ b/src/pages/admin/AdminAssessments.tsx
@@ -8,7 +8,6 @@ import {
   FaEyeSlash,
   FaCopy,
   FaTrash,
-  FaSearch,
 } from "react-icons/fa";
 import {
   Alert,
@@ -161,20 +160,21 @@ function AdminAssessments() {
   }, [opts, refetch]);
 
   const [asmtNumID, setAsmtNumID] = useState<string>("");
-  const qAssessment = useGetAdminAssessment({
-    id: asmtNumID,
-    token: keycloak?.token || "",
-    isRegistered: registered || false,
-  });
+  const { data: qAssessment, refetch: refetchAssessment } =
+    useGetAdminAssessment({
+      id: asmtNumID,
+      token: keycloak?.token || "",
+      isRegistered: registered || false,
+    });
 
   useEffect(() => {
-    if (qAssessment.data && shouldDownloadAssessmentJSON) {
+    if (qAssessment && shouldDownloadAssessmentJSON) {
       const jsonString = `data:text/json;chatset=utf-8,${encodeURIComponent(
-        JSON.stringify(qAssessment.data.assessment_doc, null, 2),
+        JSON.stringify(qAssessment.assessment_doc, null, 2),
       )}`;
       const link = document.createElement("a");
       link.href = jsonString;
-      link.download = `${qAssessment.data.assessment_doc.id}.json`;
+      link.download = `${qAssessment.assessment_doc.id}.json`;
 
       link.click();
       setShouldDownloadAssessmentJSON(false);
@@ -201,10 +201,7 @@ function AdminAssessments() {
 
   const handlePublishToZenodo = async (assessmentId: string) => {
     try {
-      const assessment = qAssessment.data?.assessment_doc;
-
-      console.log("assessment::", assessment);
-
+      const assessment = qAssessment?.assessment_doc;
       const assessmentStats = gatherStats(assessment);
 
       const pdfDoc = (
@@ -227,22 +224,29 @@ function AdminAssessments() {
         .mutateAsync({ id: assessmentId, file })
         .catch((err) => {
           alert.current = {
-            message: t("page_assessment_list.toast_zenodo_fail"),
+            message: err.message || t("page_assessment_list.toast_zenodo_fail"),
           };
           throw err;
         })
-        .then(() => {
+        .then((data) => {
           alert.current = {
-            message: t("page_assessment_list.toast_zenodo_success"),
+            message:
+              data.message || t("page_assessment_list.toast_zenodo_success"),
           };
           refetch();
         });
 
-      toast.promise(promise, {
-        loading: t("page_assessment_list.toast_zenodo_progress"),
-        success: () => `${alert.current.message}`,
-        error: () => `${alert.current.message}`,
-      });
+      toast.promise(
+        promise,
+        {
+          loading: t("page_assessment_list.toast_zenodo_progress"),
+          success: () => `${alert.current.message}`,
+          error: () => `${alert.current.message}`,
+        },
+        {
+          duration: 4000,
+        },
+      );
     } catch (error) {
       console.error("Error publishing to Zenodo:", error);
       toast.error(t("page_assessment_list.toast_zenodo_fail"));
@@ -288,12 +292,13 @@ function AdminAssessments() {
   };
 
   const handleZenodoOpenModal = (item: AssessmentListItem) => {
+    setAsmtNumID(item.id);
     setZenodoModalConfig({
       show: true,
       name: item.name,
       id: item.id,
       isPublished: item.zenodo_published,
-      zenodoUrl: item.zenodo_file_url,
+      zenodoUrl: item.zenodo_deposit_url,
     });
   };
 
@@ -324,6 +329,7 @@ function AdminAssessments() {
         id={zenodoModalConfig.id}
         isPublished={zenodoModalConfig.isPublished}
         zenodoUrl={zenodoModalConfig.zenodoUrl}
+        zenodoState={qAssessment?.zenodo_publication_state}
         onHide={() => {
           setZenodoModalConfig({
             show: false,
@@ -334,6 +340,7 @@ function AdminAssessments() {
           });
         }}
         onPublish={handlePublishToZenodo}
+        onRefetch={refetchAssessment}
       />
       <DeleteModal
         show={deleteModalConfig.show}
@@ -619,18 +626,22 @@ function AdminAssessments() {
                                 </Tooltip>
                               }
                             >
-                              <Button
-                                id={`zenodo-button-${item.id}`}
-                                className={`btn btn-light btn-sm m-1 ${!item.published ? "disabled opacity-50" : ""}`}
-                                onClick={() => {
-                                  if (item.published) {
-                                    setAsmtNumID(item.id);
-                                    handleZenodoOpenModal(item);
-                                  }
-                                }}
-                              >
-                                <FaSearch />
-                              </Button>
+                              <span>
+                                <Button
+                                  id={`zenodo-button-${item.id}`}
+                                  className={`btn btn-light btn-sm m-1 ${!item.published ? "disabled opacity-50" : ""}`}
+                                  onClick={() => {
+                                    if (item.published) {
+                                      handleZenodoOpenModal(item);
+                                    }
+                                  }}
+                                >
+                                  <img
+                                    src="/zenodo.svg"
+                                    style={{ height: "1rem" }}
+                                  />
+                                </Button>
+                              </span>
                             </OverlayTrigger>
                           )}
                           <OverlayTrigger

--- a/src/pages/admin/Settings.tsx
+++ b/src/pages/admin/Settings.tsx
@@ -1,13 +1,6 @@
 import React from "react";
 import { Link } from "react-router-dom";
-import {
-  FaCog,
-  FaRuler,
-  FaChartLine,
-  FaCode,
-  FaSearch,
-  FaUserCog,
-} from "react-icons/fa";
+import { FaCog, FaRuler, FaChartLine, FaCode, FaUserCog } from "react-icons/fa";
 import { Row, Col, Card } from "react-bootstrap";
 import ROUTES from "@/routes";
 
@@ -54,7 +47,13 @@ const Settings: React.FC = () => {
         {
           title: "Zenodo",
           description: "Enable or disable Zenodo integration features",
-          icon: <FaSearch size={24} className="text-muted me-3" />,
+          icon: (
+            <img
+              className="me-3"
+              src="/zenodo.svg"
+              style={{ height: "1.5rem" }}
+            />
+          ),
           path: ROUTES.ADMIN.SETTINGS.ZENODO,
         },
         {

--- a/src/pages/admin/settings/ZenodoSettings.tsx
+++ b/src/pages/admin/settings/ZenodoSettings.tsx
@@ -1,7 +1,7 @@
 import { useContext, useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { Row, Col, Form, Button, InputGroup } from "react-bootstrap";
-import { FaSearch, FaEye, FaEyeSlash } from "react-icons/fa";
+import { FaEye, FaEyeSlash } from "react-icons/fa";
 import { AuthContext } from "@/auth";
 import {
   useGetAdminSettings,
@@ -10,6 +10,7 @@ import {
 import ROUTES from "@/routes";
 import toast from "react-hot-toast";
 import { useTranslation } from "react-i18next";
+import type { AxiosError } from "axios";
 
 interface ZenodoFormData {
   enabled: boolean;
@@ -83,8 +84,12 @@ function ZenodoSettings() {
 
       toast.success("Zenodo settings updated successfully!");
       return true;
-    } catch (error) {
-      toast.error("Failed to update Zenodo settings. Please try again.");
+    } catch (err) {
+      const error = (err as AxiosError<{ message?: string }>)?.response?.data
+        ?.message;
+      toast.error(
+        error || "Failed to update Zenodo settings. Please try again.",
+      );
       console.error("Error updating Zenodo settings:", error);
       return false;
     } finally {
@@ -137,7 +142,7 @@ function ZenodoSettings() {
           <div className="test-method-settings-item d-flex justify-content-between gap-3">
             <div>
               <div className="d-flex align-items-center gap-2">
-                <FaSearch size={16} />
+                <img src="/zenodo.svg" style={{ height: "1.2rem" }} />
                 <h6 className="mb-0">Enable Zenodo Integration</h6>
               </div>
               <span className="text-muted small">

--- a/src/pages/assessments/AssessmentsList.tsx
+++ b/src/pages/assessments/AssessmentsList.tsx
@@ -108,9 +108,6 @@ function AssessmentsList({ listPublic = false }: AssessmentListProps) {
   const { keycloak, registered, userType } = useContext(AuthContext)!;
   const [shouldDownloadAssessmentJSON, setShouldDownloadAssessmentJSON] =
     useState(false);
-  const [isPublishedToZenodo, setIsPublishedToZenodo] = useState<
-    boolean | undefined
-  >();
 
   const isIdentified = userType === "Identified";
 
@@ -212,7 +209,7 @@ function AssessmentsList({ listPublic = false }: AssessmentListProps) {
   });
 
   const [asmtNumID, setAsmtNumID] = useState<string>("");
-  const qAssessment = useGetAssessment({
+  const { data: qAssessment, refetch: refetchAssessment } = useGetAssessment({
     id: asmtNumID,
     token: keycloak?.token || "",
     isRegistered: registered || false,
@@ -220,13 +217,13 @@ function AssessmentsList({ listPublic = false }: AssessmentListProps) {
   });
 
   useEffect(() => {
-    if (qAssessment.data && shouldDownloadAssessmentJSON) {
+    if (qAssessment && shouldDownloadAssessmentJSON) {
       const jsonString = `data:text/json;chatset=utf-8,${encodeURIComponent(
-        JSON.stringify(qAssessment.data.assessment_doc, null, 2),
+        JSON.stringify(qAssessment.assessment_doc, null, 2),
       )}`;
       const link = document.createElement("a");
       link.href = jsonString;
-      link.download = `${qAssessment.data.assessment_doc.id}.json`;
+      link.download = `${qAssessment.assessment_doc.id}.json`;
 
       link.click();
       setShouldDownloadAssessmentJSON(false);
@@ -280,7 +277,7 @@ function AssessmentsList({ listPublic = false }: AssessmentListProps) {
 
   const handlePublishToZenodo = async (assessmentId: string) => {
     try {
-      const assessment = qAssessment.data?.assessment_doc;
+      const assessment = qAssessment?.assessment_doc;
 
       const assessmentStats = gatherStats(assessment);
 
@@ -304,28 +301,29 @@ function AssessmentsList({ listPublic = false }: AssessmentListProps) {
         .mutateAsync({ id: assessmentId, file })
         .catch((err) => {
           alert.current = {
-            message: t("page_assessment_list.toast_zenodo_fail"),
+            message: err.message || t("page_assessment_list.toast_zenodo_fail"),
           };
           throw err;
         })
-        .then(() => {
+        .then((data) => {
           alert.current = {
-            message: t("page_assessment_list.toast_zenodo_success"),
+            message:
+              data.message || t("page_assessment_list.toast_zenodo_success"),
           };
           refetch();
-          setIsPublishedToZenodo(true);
-          setZenodoModalConfig({
-            ...zenodoModalConfig,
-            show: false,
-            isPublished: true,
-          });
         });
 
-      toast.promise(promise, {
-        loading: t("page_assessment_list.toast_zenodo_progress"),
-        success: () => `${alert.current.message}`,
-        error: () => `${alert.current.message}`,
-      });
+      toast.promise(
+        promise,
+        {
+          loading: t("page_assessment_list.toast_zenodo_progress"),
+          success: () => `${alert.current.message}`,
+          error: () => `${alert.current.message}`,
+        },
+        {
+          duration: 4000,
+        },
+      );
     } catch (error) {
       console.error("Error publishing to Zenodo:", error);
       toast.error(t("page_assessment_list.toast_zenodo_fail"));
@@ -379,12 +377,13 @@ function AssessmentsList({ listPublic = false }: AssessmentListProps) {
   };
 
   const handleZenodoOpenModal = (item: AssessmentListItem) => {
+    setAsmtNumID(item.id);
     setZenodoModalConfig({
       show: true,
       name: item.name,
       id: item.id,
-      isPublished: isPublishedToZenodo || item.zenodo_published,
-      zenodoUrl: item.zenodo_file_url,
+      isPublished: item.zenodo_published,
+      zenodoUrl: item.zenodo_deposit_url,
     });
   };
 
@@ -453,6 +452,7 @@ function AssessmentsList({ listPublic = false }: AssessmentListProps) {
         id={zenodoModalConfig.id}
         isPublished={zenodoModalConfig.isPublished}
         zenodoUrl={zenodoModalConfig.zenodoUrl}
+        zenodoState={qAssessment?.zenodo_publication_state}
         onHide={() => {
           setZenodoModalConfig({
             show: false,
@@ -463,6 +463,7 @@ function AssessmentsList({ listPublic = false }: AssessmentListProps) {
           });
         }}
         onPublish={handlePublishToZenodo}
+        onRefetch={refetchAssessment}
       />
       <DeleteModal
         show={deleteModalConfig.show}
@@ -854,9 +855,8 @@ function AssessmentsList({ listPublic = false }: AssessmentListProps) {
                     </div>
                   </Card.Body>
 
-                  <Card.Footer className="bg-transparent border-1">
-                    {/* First Row: Assessment Management Actions */}
-                    <div className="d-flex justify-content-end gap-2 flex-wrap mb-3">
+                  <Card.Footer className="bg-transparent border-0 mt-1">
+                    <div className="d-flex justify-content-end gap-3 flex-wrap">
                       <OverlayTrigger
                         placement="top"
                         overlay={
@@ -967,8 +967,16 @@ function AssessmentsList({ listPublic = false }: AssessmentListProps) {
                       )}
                     </div>
 
-                    {/* Second Row: Publishing & Sharing Actions */}
-                    <div className="d-flex justify-content-end gap-2 flex-wrap">
+                    <div
+                      style={{
+                        height: "1px",
+                        backgroundColor: "#eee",
+                        width: "100%",
+                        margin: "0.8rem 0",
+                      }}
+                    />
+
+                    <div className="d-flex justify-content-end gap-3 flex-wrap">
                       {!listPublic && (
                         <>
                           {item.published ? (
@@ -976,7 +984,7 @@ function AssessmentsList({ listPublic = false }: AssessmentListProps) {
                               placement="top"
                               overlay={
                                 <Tooltip id="tip-unpublish">
-                                  {isPublishedToZenodo || item.zenodo_published
+                                  {item.zenodo_published
                                     ? t("tip_unpublish_assessment_disabled")
                                     : t("tip_unpublish_assessment")}
                                 </Tooltip>
@@ -985,12 +993,9 @@ function AssessmentsList({ listPublic = false }: AssessmentListProps) {
                               <span>
                                 <Button
                                   id={`unpublish-button-${item.id}`}
-                                  className={`btn btn-light btn-sm ${isPublishedToZenodo || item.zenodo_published ? "disabled opacity-50" : ""}`}
+                                  className={`btn btn-light btn-sm ${item.zenodo_published ? "disabled opacity-50" : ""}`}
                                   onClick={() => {
-                                    if (
-                                      isPublishedToZenodo ||
-                                      item.zenodo_published
-                                    ) {
+                                    if (item.zenodo_published) {
                                       return;
                                     }
                                     setPublishModalConfig({
@@ -1046,8 +1051,7 @@ function AssessmentsList({ listPublic = false }: AssessmentListProps) {
                                     ? t(
                                         "page_assessment_list.tip_zenodo_disabled",
                                       )
-                                    : isPublishedToZenodo ||
-                                        item.zenodo_published
+                                    : item.zenodo_published
                                       ? t(
                                           "page_assessment_list.tip_zenodo_published",
                                         )
@@ -1061,13 +1065,12 @@ function AssessmentsList({ listPublic = false }: AssessmentListProps) {
                                   className={`btn btn-light btn-sm ${!item.published ? "disabled opacity-50" : ""}`}
                                   onClick={() => {
                                     if (item.published) {
-                                      setAsmtNumID(item.id);
                                       handleZenodoOpenModal(item);
                                     }
                                   }}
                                 >
                                   <img
-                                    src="zenodo.svg"
+                                    src="/zenodo.svg"
                                     style={{ height: "1rem" }}
                                   />
                                 </Button>

--- a/src/pages/assessments/components/ZenodoModal.tsx
+++ b/src/pages/assessments/components/ZenodoModal.tsx
@@ -1,7 +1,18 @@
-import { useState } from "react";
-import { Modal, Button, Alert, Spinner } from "react-bootstrap";
-import { FaExternalLinkAlt, FaSearch } from "react-icons/fa";
+import { useState, useEffect } from "react";
+import { Modal, Button, Alert, Spinner, ProgressBar } from "react-bootstrap";
+import { FaExternalLinkAlt, FaCheck, FaTimes } from "react-icons/fa";
 import { useTranslation } from "react-i18next";
+import { useGetZenodoAssessment } from "@/api/services/registry";
+import { AuthContext } from "@/auth";
+import { useContext } from "react";
+
+type ZenodoState =
+  | "PROCESS_INIT"
+  | "DEPOSIT_CREATED"
+  | "FILE_UPLOADED_TO_DEPOSIT"
+  | "DEPOSIT_PUBLISHED"
+  | "PROCESS_COMPLETED"
+  | "PROCESS_FAILED";
 
 interface ZenodoModalProps {
   show: boolean;
@@ -9,8 +20,10 @@ interface ZenodoModalProps {
   id: string;
   isPublished: boolean;
   zenodoUrl?: string;
+  zenodoState?: string | undefined;
   onHide: () => void;
   onPublish: (id: string) => Promise<void>;
+  onRefetch?: () => void;
 }
 
 function ZenodoModal({
@@ -19,35 +32,168 @@ function ZenodoModal({
   id,
   isPublished,
   zenodoUrl,
+  zenodoState,
   onHide,
   onPublish,
+  onRefetch,
 }: ZenodoModalProps) {
   const { t } = useTranslation();
+  const { keycloak, registered } = useContext(AuthContext)!;
   const [isPublishing, setIsPublishing] = useState(false);
+
+  const { data: zenodoAssessment } = useGetZenodoAssessment({
+    id,
+    token: keycloak?.token || "",
+    isRegistered: registered || false,
+  });
+
+  useEffect(() => {
+    let interval: NodeJS.Timeout;
+
+    if (
+      show &&
+      zenodoState !== "PROCESS_COMPLETED" &&
+      zenodoState !== "PROCESS_FAILED" &&
+      onRefetch
+    ) {
+      interval = setInterval(() => {
+        onRefetch();
+      }, 1000); // Poll every 2 seconds
+    }
+
+    return () => {
+      if (interval) {
+        clearInterval(interval);
+      }
+    };
+  }, [show, zenodoState, onRefetch]);
+
+  const isInProgressState = (state: string): boolean => {
+    return [
+      "PROCESS_INIT",
+      "DEPOSIT_CREATED",
+      "FILE_UPLOADED_TO_DEPOSIT",
+      "DEPOSIT_PUBLISHED",
+    ].includes(state);
+  };
+
+  // Reset publishing state when process fails
+  useEffect(() => {
+    if (zenodoState === "PROCESS_FAILED" && isPublishing) {
+      setIsPublishing(false);
+    }
+  }, [zenodoState, isPublishing]);
 
   const handlePublish = async () => {
     setIsPublishing(true);
     try {
       await onPublish(id);
-      onHide();
     } catch (error) {
       console.error("Error publishing to Zenodo:", error);
-    } finally {
       setIsPublishing(false);
     }
+  };
+
+  const getStepStatus = (stepState: ZenodoState) => {
+    // If we're publishing but no zenodo_publication_state yet, show first step as active
+    if (isPublishing && !zenodoState) {
+      return stepState === "PROCESS_INIT" ? "active" : "pending";
+    }
+
+    if (!zenodoState) return "pending";
+
+    const stateOrder = [
+      "PROCESS_INIT",
+      "DEPOSIT_CREATED",
+      "FILE_UPLOADED_TO_DEPOSIT",
+      "DEPOSIT_PUBLISHED",
+      "PROCESS_COMPLETED",
+    ];
+    const currentIndex = stateOrder.indexOf(zenodoState);
+    const stepIndex = stateOrder.indexOf(stepState);
+
+    if (zenodoState === "PROCESS_FAILED") return "failed";
+    if (stepIndex < currentIndex) return "completed";
+    if (stepIndex === currentIndex) return "active";
+    return "pending";
+  };
+
+  const renderStepIcon = (status: string, isFinalStep: boolean = false) => {
+    switch (status) {
+      case "completed":
+        return (
+          <FaCheck className={isFinalStep ? "text-success" : "text-primary"} />
+        );
+      case "active":
+        return (
+          <Spinner
+            as="span"
+            animation="border"
+            size="sm"
+            className="text-primary"
+          />
+        );
+      case "failed":
+        return <FaTimes className="text-danger" />;
+      default:
+        return <div className="step-pending-icon"></div>;
+    }
+  };
+
+  const getProgressPercentage = () => {
+    // If we're publishing but no zenodo_publication_state yet, show minimal progress
+    if (isPublishing && !zenodoState) return 10;
+
+    if (!zenodoState) return 0;
+
+    const stateOrder = [
+      "PROCESS_INIT",
+      "DEPOSIT_CREATED",
+      "FILE_UPLOADED_TO_DEPOSIT",
+      "DEPOSIT_PUBLISHED",
+      "PROCESS_COMPLETED",
+    ];
+    const currentIndex = stateOrder.indexOf(zenodoState);
+
+    if (zenodoState === "PROCESS_FAILED") return 100;
+    if (zenodoState === "PROCESS_COMPLETED") return 100;
+
+    return Math.max(0, (currentIndex / (stateOrder.length - 1)) * 100);
   };
 
   return (
     <Modal show={show} onHide={onHide} centered>
       <Modal.Header closeButton>
         <Modal.Title>
-          <FaSearch className="me-2" />
-          {t("page_assessment_list.zenodo_modal_title")}
+          <img
+            className="me-2 mb-1"
+            src="/zenodo.svg"
+            style={{ height: "1.4rem" }}
+          />
+          {isPublished
+            ? t("page_assessment_list.zenodo_modal_title_published")
+            : t("page_assessment_list.zenodo_modal_title")}
         </Modal.Title>
       </Modal.Header>
       <Modal.Body>
-        <div className="mb-3">
-          <strong>{t("fields.name")}:</strong> {name}
+        <div className="mb-3 d-flex align-items-center justify-content-between gap-1">
+          <span>
+            <strong>{t("fields.name")}:</strong> {name}
+          </span>
+          {zenodoAssessment?.image_url && zenodoAssessment?.target_url && (
+            <a
+              href={zenodoAssessment.target_url}
+              target="_blank"
+              rel="noopener noreferrer"
+              title={`DOI: ${zenodoAssessment.doi}`}
+            >
+              <img
+                src={zenodoAssessment.image_url}
+                alt={`DOI Badge: ${zenodoAssessment.doi}`}
+                style={{ height: "18px" }}
+              />
+            </a>
+          )}
         </div>
 
         {isPublished ? (
@@ -74,36 +220,171 @@ function ZenodoModal({
           </Alert>
         ) : (
           <>
-            <p
-              style={{
-                fontSize: "1.1rem",
-                lineHeight: "1.3",
-              }}
-            >
-              {t("page_assessment_list.zenodo_publish_confirmation")}
-            </p>
-            <Alert variant="warning" className="mb-1">
-              <small>
-                <strong>
-                  {t("page_assessment_list.zenodo_warning_title")}
-                </strong>{" "}
-                {t("page_assessment_list.zenodo_warning_message")}
-              </small>
-            </Alert>
+            {(zenodoState &&
+              (isInProgressState(zenodoState) ||
+                zenodoState === "PROCESS_FAILED")) ||
+            isPublishing ? (
+              <>
+                <div className="mb-3">
+                  <h6 className="mb-1">Publishing Progress</h6>
+                  <ProgressBar now={getProgressPercentage()} className="mb-3" />
+
+                  <div className="steps-container">
+                    <div
+                      className={`step-item d-flex align-items-center mb-2 ${getStepStatus("PROCESS_INIT")}`}
+                    >
+                      {renderStepIcon(getStepStatus("PROCESS_INIT"))}
+                      <span
+                        className={`ms-2 ${["completed", "active"].includes(getStepStatus("PROCESS_INIT")) ? "text-primary" : ""}`}
+                      >
+                        Initializing Process
+                      </span>
+                    </div>
+
+                    <div
+                      className={`step-item d-flex align-items-center mb-2 ${getStepStatus("DEPOSIT_CREATED")}`}
+                    >
+                      {renderStepIcon(getStepStatus("DEPOSIT_CREATED"))}
+                      <span
+                        className={`ms-2 ${["completed", "active"].includes(getStepStatus("DEPOSIT_CREATED")) ? "text-primary" : ""}`}
+                      >
+                        Creating Zenodo Deposit
+                      </span>
+                    </div>
+
+                    <div
+                      className={`step-item d-flex align-items-center mb-2 ${getStepStatus("FILE_UPLOADED_TO_DEPOSIT")}`}
+                    >
+                      {renderStepIcon(
+                        getStepStatus("FILE_UPLOADED_TO_DEPOSIT"),
+                      )}
+                      <span
+                        className={`ms-2 ${["completed", "active"].includes(getStepStatus("FILE_UPLOADED_TO_DEPOSIT")) ? "text-primary" : ""}`}
+                      >
+                        Uploading Assessment File
+                      </span>
+                    </div>
+
+                    <div
+                      className={`step-item d-flex align-items-center mb-2 ${getStepStatus("DEPOSIT_PUBLISHED")}`}
+                    >
+                      {renderStepIcon(getStepStatus("DEPOSIT_PUBLISHED"))}
+                      <span
+                        className={`ms-2 ${["completed", "active"].includes(getStepStatus("DEPOSIT_PUBLISHED")) ? "text-primary" : ""}`}
+                      >
+                        Publishing to Repository
+                      </span>
+                    </div>
+
+                    <div
+                      className={`step-item d-flex align-items-center mb-2 ${
+                        zenodoState === "PROCESS_COMPLETED"
+                          ? "completed"
+                          : zenodoState === "PROCESS_FAILED"
+                            ? "failed"
+                            : "pending"
+                      }`}
+                    >
+                      {zenodoState === "PROCESS_COMPLETED" ? (
+                        <FaCheck className="text-success" />
+                      ) : zenodoState === "PROCESS_FAILED" ? (
+                        <FaTimes className="text-danger" />
+                      ) : (
+                        <div className="step-pending-icon"></div>
+                      )}
+                      <span
+                        className={`ms-2 ${
+                          zenodoState === "PROCESS_COMPLETED"
+                            ? "text-success fw-bold"
+                            : zenodoState === "PROCESS_FAILED"
+                              ? "text-danger fw-bold"
+                              : ""
+                        }`}
+                      >
+                        {zenodoState === "PROCESS_COMPLETED"
+                          ? "Successfully Published!"
+                          : zenodoState === "PROCESS_FAILED"
+                            ? "Publishing Failed"
+                            : "Finalizing..."}
+                      </span>
+                    </div>
+                  </div>
+
+                  {zenodoState === "PROCESS_FAILED" && (
+                    <Alert variant="danger" className="mt-3">
+                      <small>
+                        <strong>Error:</strong> Publishing to Zenodo failed.
+                        Please try again later.
+                      </small>
+                    </Alert>
+                  )}
+
+                  {zenodoState === "PROCESS_COMPLETED" && zenodoUrl && (
+                    <Alert variant="success" className="mt-3">
+                      <Alert.Heading className="h6">
+                        🎉 Successfully Published!
+                      </Alert.Heading>
+                      <p className="mb-2">
+                        Your assessment has been successfully published to
+                        Zenodo.
+                      </p>
+                      <div className="d-flex gap-2 flex-wrap">
+                        <a
+                          href={zenodoUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="btn btn-outline-success btn-sm"
+                        >
+                          <FaExternalLinkAlt className="me-2" />
+                          {t("page_assessment_list.view_on_zenodo")}
+                        </a>
+                      </div>
+                    </Alert>
+                  )}
+                </div>
+              </>
+            ) : (
+              <>
+                <p
+                  style={{
+                    fontSize: "1.1rem",
+                    lineHeight: "1.3",
+                  }}
+                >
+                  Are you sure you want to request publishing this assessment to
+                  the Zenodo repository?
+                </p>
+                <Alert variant="warning" className="mb-1">
+                  <small>
+                    <strong>
+                      {t("page_assessment_list.zenodo_warning_title")}
+                    </strong>{" "}
+                    {t("page_assessment_list.zenodo_warning_message")}
+                  </small>
+                </Alert>
+              </>
+            )}
           </>
         )}
       </Modal.Body>
       <Modal.Footer>
-        <Button variant="secondary" onClick={onHide} disabled={isPublishing}>
+        <Button
+          variant="secondary"
+          onClick={onHide}
+          disabled={Boolean(zenodoState && isInProgressState(zenodoState))}
+        >
           {t("buttons.close")}
         </Button>
-        {!isPublished && (
+        {!isPublished && zenodoState !== "PROCESS_COMPLETED" && (
           <Button
-            variant="success"
+            variant={zenodoState === "PROCESS_FAILED" ? "warning" : "success"}
             onClick={handlePublish}
-            disabled={isPublishing}
+            disabled={
+              isPublishing ||
+              Boolean(zenodoState && isInProgressState(zenodoState))
+            }
           >
-            {isPublishing ? (
+            {isPublishing || (zenodoState && isInProgressState(zenodoState)) ? (
               <>
                 <Spinner
                   as="span"
@@ -112,10 +393,14 @@ function ZenodoModal({
                   role="status"
                   className="me-2"
                 />
-                {t("page_assessment_list.toast_zenodo_progress")}
+                Processing Request...
               </>
             ) : (
-              <>{t("page_assessment_list.zenodo_publish_button")}</>
+              <>
+                {zenodoState === "PROCESS_FAILED"
+                  ? "Retry Publishing to Zenodo"
+                  : "Request to Publish to Zenodo"}
+              </>
             )}
           </Button>
         )}

--- a/src/types/assessment.ts
+++ b/src/types/assessment.ts
@@ -437,7 +437,7 @@ export interface AssessmentListItem {
   versions: AssessmentListItem[];
   zenodo_published: boolean;
   zenodo_deposit_id: string;
-  zenodo_file_url: string;
+  zenodo_deposit_url: string;
 }
 
 export type AsmtEligibilityResponse = ResponsePage<ActorOrgAsmtType[]>;
@@ -451,6 +451,7 @@ export interface AssessmentDetailsResponse {
   shared_to_user: boolean;
   assessment_doc: Assessment;
   assessment_doc_version?: string;
+  zenodo_publication_state?: string;
 }
 
 export interface ObjectListItem {

--- a/src/types/registry.ts
+++ b/src/types/registry.ts
@@ -23,3 +23,15 @@ export interface RegistryMetric {
 }
 
 export type RegistryMetricResponse = ResponsePage<RegistryMetric[]>;
+
+export interface ZenodoAssessmentResponse {
+  assessmentId: string;
+  depositId: string;
+  published_at: string;
+  uploaded_at: string;
+  is_published: boolean;
+  zenodo_state: string;
+  doi: string;
+  image_url: string;
+  target_url: string;
+}


### PR DESCRIPTION
**⚠️ This PR should not be merged before [CAT-1053](https://github.com/FC4E-CAT/fc4e-cat-api/pull/560) and [CAT-1055](https://github.com/FC4E-CAT/fc4e-cat-api/pull/562) are merged.**

This PR enhances the Zenodo integration system by implementing a comprehensive multi-step publishing workflow, introducing dynamic DOI badge displays, and reorganizing the user interface across all assessment management features.

- Implemented multi-step publishing wizard with status polling for real-time updates
- Added DOI number display with Zenodo badge using image and target URL fields
- Updated to use zenodo_deposit_url field instead of zenodo_file_url for proper linking
- Enhanced settings panel with connection validation displaying proper message for connection
- Extended admin assessment management to include Zenodo publishing capabilities
- Reorganized action buttons for assessments list with visual separation between management and publishing actions