### PR TITLE
CAT-955 Add config option to display criteria imperatives in editor

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -33,5 +33,6 @@
     "NFDI Infra Staging": "nfdiinfrastaging",
     "Academic Id": "academic-id",
     "Cilogon": "cilogon"
-  }
+  },
+  "display_imperatives": true
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -35,6 +35,8 @@ const themeAppTitle = config.theme?.app_title ?? "CAT";
 
 const pidSelectionView = config.embedded_views?.pid_selection_view || "";
 
+const displayImperatives = config.display_imperatives || false;
+
 // some minimal theme configs
 const themeFooterDisplay = config.theme?.footer?.display ?? true;
 const themeHomeBenefits = config.theme?.home?.display_benefits ?? true;
@@ -67,4 +69,5 @@ export {
   themeAbout,
   pidSelectionView,
   autoSubjectType,
+  displayImperatives,
 };

--- a/src/pages/assessment-builder/AssessmentBuilderPreview.tsx
+++ b/src/pages/assessment-builder/AssessmentBuilderPreview.tsx
@@ -19,7 +19,7 @@ import {
 } from "@/api";
 import { AuthContext } from "@/auth";
 import type { RegistryTest, TestFull } from "@/types/tests";
-import { relMtvMetricTest } from "@/config";
+import { displayImperatives, relMtvMetricTest } from "@/config";
 import toast from "react-hot-toast";
 import styles from "./AssessmentBuilder.module.css";
 import AssessmentBuilderDeleteModal from "./AssessmentBuilderDeleteModal";
@@ -292,6 +292,15 @@ function AssessmentBuilderPreview({
                         ?.criteria[builderState.selectedCriterionIndex]?.name
                     }
                   </span>{" "}
+                  {displayImperatives && (
+                    <span className="ms-1 badge bg-dark">
+                      {
+                        assessment[builderState.selectedPrincipleIndex || 0]
+                          ?.criteria[builderState.selectedCriterionIndex]
+                          ?.imperative
+                      }
+                    </span>
+                  )}
                   {assessment[builderState.selectedPrincipleIndex || 0]
                     ?.criteria[builderState.selectedCriterionIndex]
                     ?.imperative === AssessmentCriterionImperative.MUST ? (

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -7,6 +7,7 @@ export interface Config {
   links?: ConfigLinks;
   g069_providers: Record<string, string>;
   auto_subject_type?: string;
+  display_imperatives?: boolean;
 }
 
 export type ConfigRelationIds = {


### PR DESCRIPTION
## Goal
Give the configuration option per cat deployment to display (on/off) the imperatives on the assessment editor

## Implementation
- New optional configuration parameter added: `{"displayImperatives": false}`

If set to true the imperatives are displayed next to each criterion heading in the editor, example below:
<img width="1388" height="655" alt="image" src="https://github.com/user-attachments/assets/9d04b132-9624-4541-a7ba-832809cbe0e4" />

