### PR TITLE
[CAT-1064] - Resolve criterion re-addition issues with edit warnings and imperative values

### DIFF
--- a/src/pages/assessment-builder/AssessmentBuilder.tsx
+++ b/src/pages/assessment-builder/AssessmentBuilder.tsx
@@ -144,6 +144,7 @@ function AssessmentBuilder({
     fetchNextPage: criteriaFetchNextPage,
     hasNextPage: criteriaHaveNextPage,
     isFetchingNextPage: criteriaAreFetchingNextPage,
+    refetch: refetchCriteria,
   } = useGetAllCriteria({
     size: 20,
     token: keycloak?.token || "",
@@ -594,6 +595,7 @@ function AssessmentBuilder({
                 allCriteria={allCriteria}
                 hasUnsavedChanges={hasUnsavedChanges}
                 isEditing={isEditing}
+                refetchCriteria={refetchCriteria}
               />
             </div>
           </div>
@@ -745,6 +747,7 @@ function AssessmentBuilder({
                     }
                     motivationCriteriaMutation={motivationCriteriaMutation}
                     refetchAssessmentData={refetchAssessmentData}
+                    refetchCriteria={refetchCriteria}
                   />
                 )}
                 {builderState.entityMode === "principle" && (

--- a/src/pages/assessment-builder/AssessmentBuilderCriteria.tsx
+++ b/src/pages/assessment-builder/AssessmentBuilderCriteria.tsx
@@ -43,6 +43,7 @@ function AssessmentBuilderCriteria({
   criterionId,
   motivationCriteriaMutation,
   refetchAssessmentData,
+  refetchCriteria,
   setBuilderState,
 }: {
   assessment: AssessmentPrinciple[];
@@ -57,6 +58,7 @@ function AssessmentBuilderCriteria({
     mutateAsync: (data: { mtvId: string }) => Promise<{ content: Criterion[] }>;
   };
   refetchAssessmentData: () => void;
+  refetchCriteria: () => void;
   setBuilderState: React.Dispatch<React.SetStateAction<AssessmentBuilderState>>;
 }) {
   const { keycloak, registered } = useContext(AuthContext)!;
@@ -449,30 +451,18 @@ function AssessmentBuilderCriteria({
     }
 
     if (formMode === "select" && selectedRegistryCriterionId) {
-      const selectedCriterionPid = allCriteria.find(
+      const selectedCriterion = allCriteria.find(
         (criterion) => criterion.cri === selectedRegistryCriterionId,
-      )?.id;
+      );
 
-      if (principleTag) {
-        formattedPriCri = formatDataToAssignPrincipleToCriterion({
-          principleId: principleTag || "",
-          criterionId: selectedCriterionPid || "",
-          allMotivationCriteria: allMotivationCriteria,
-        });
-
-        try {
-          await assignPrincipleToCriterion.mutateAsync(formattedPriCri);
-        } catch (error) {
-          console.error("Assign principle to criterion failed:", error);
-          throw error;
-        }
-      }
+      const imperativeId =
+        typeof selectedCriterion?.imperative === "string"
+          ? selectedCriterion.imperative
+          : selectedCriterion?.imperative?.id || "";
 
       criImp.push({
-        criterion_id: selectedCriterionPid || "",
-        imperative_id:
-          criterionForm?.imperative ||
-          (imperatives.length > 0 ? imperatives[0].id : ""),
+        criterion_id: selectedCriterion?.id || "",
+        imperative_id: imperativeId,
       });
     }
 
@@ -532,10 +522,13 @@ function AssessmentBuilderCriteria({
             };
           });
         }
+
         await assignCriteriaToActorMutation.mutateAsync(criImp);
       } catch (error) {
         console.error("Assign criteria to actor failed:", error);
         throw error;
+      } finally {
+        refetchCriteria();
       }
     }
   };

--- a/src/pages/assessment-builder/AssessmentBuilderStructure.tsx
+++ b/src/pages/assessment-builder/AssessmentBuilderStructure.tsx
@@ -38,6 +38,7 @@ function AssessmentBuilderStructure({
   allCriteria,
   hasUnsavedChanges,
   isEditing,
+  refetchCriteria,
 }: {
   mtvId: string;
   actId: string;
@@ -51,6 +52,7 @@ function AssessmentBuilderStructure({
   allCriteria: Criterion[];
   hasUnsavedChanges?: boolean;
   isEditing?: boolean;
+  refetchCriteria: () => void;
 }) {
   const { keycloak, registered } = useContext(AuthContext)!;
   const { t } = useTranslation();
@@ -239,6 +241,7 @@ function AssessmentBuilderStructure({
 
           return newAssessment;
         });
+        refetchCriteria();
       }
     } catch (error) {
       console.error("Remove criterion-principle failed:", error);

--- a/src/pages/assessment-builder/utils/assessmentBuilderUtils.ts
+++ b/src/pages/assessment-builder/utils/assessmentBuilderUtils.ts
@@ -661,7 +661,11 @@ export const canEditCriterion = ({
   const currentMotivation = usedByMotivations?.find(
     (motivation) => motivation.id === mtvId,
   );
-  if (currentMotivation && currentMotivation.first_actor_assignment === actId) {
+  if (
+    currentMotivation &&
+    (currentMotivation.first_actor_assignment === actId ||
+      currentMotivation.first_actor_assignment == null)
+  ) {
     return true;
   }
 


### PR DESCRIPTION
This PR fixes two issues when re-adding previously removed criteria to a motivation. 
The first issue showed an incorrect "Editing disabled - Used by other motivations" warning for criteria that had been removed from the current motivation, which was resolved by updating the permission logic and adding proper data refresh after deletion.
The second issue caused the imperative value to reset incorrectly when re-adding criteria. This was fixed by ensuring the correct imperative data is retrieved from the selected criterion when adding it to a motivation.