### PR TITLE
[CAT-1069] - Refactor report assessment ID handling to use API-provided data directly

### DIFF
--- a/src/api/services/reports.ts
+++ b/src/api/services/reports.ts
@@ -28,8 +28,8 @@ export interface ReportResponse {
   value_type: string;
   created_by: string;
   created_on: string;
-  rows: string[];
-  columns: string[];
+  rows: (string | { id: string; name: string })[];
+  columns: (string | { id: string; name: string })[];
   data: string[][];
 }
 

--- a/src/auth/AuthProvider.tsx
+++ b/src/auth/AuthProvider.tsx
@@ -11,6 +11,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [registered, setRegistered] = useState(false);
   const [keycloak, setKeycloak] = useState<NullableKeycloak>(null);
   const [userType, setUserType] = useState<string>("");
+  const [roles, setRoles] = useState<string[]>([]);
 
   const refreshUserToken = useCallback(async () => {
     if (!keycloak) {
@@ -41,6 +42,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     refreshUserToken,
     userType,
     setUserType,
+    roles,
+    setRoles,
   };
 
   return (

--- a/src/auth/ProtectedRoute.tsx
+++ b/src/auth/ProtectedRoute.tsx
@@ -25,6 +25,7 @@ export function ProtectedRoute() {
     registered,
     setRegistered,
     setUserType,
+    setRoles,
   } = useContext(AuthContext)!;
 
   const {
@@ -98,6 +99,7 @@ export function ProtectedRoute() {
     if (isSuccessRegister || profileData) {
       setRegistered(true);
       setUserType(profileData?.user_type || "");
+      setRoles(profileData?.roles || []);
     }
   }, [isSuccessRegister, setRegistered, setUserType, profileData]);
 

--- a/src/auth/auth-context.ts
+++ b/src/auth/auth-context.ts
@@ -13,6 +13,8 @@ export interface AuthContextProps {
   refreshUserToken: () => Promise<void>;
   userType: string;
   setUserType: React.Dispatch<React.SetStateAction<string>>;
+  roles: string[];
+  setRoles: React.Dispatch<React.SetStateAction<string[]>>;
 }
 
 export const AuthContext = createContext<AuthContextProps | null>(null);

--- a/src/pages/admin/reports/Reports.tsx
+++ b/src/pages/admin/reports/Reports.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState, useMemo } from "react";
+import { useCallback, useState } from "react";
 import { Link } from "react-router-dom";
 import {
   Container,
@@ -21,7 +21,6 @@ import type {
   ReportDefinition,
   ReportFilter,
 } from "@/api/services/reports";
-import type { AssessmentListItem } from "@/types";
 import { buildRoute } from "@/routes";
 import ROUTES from "@/routes";
 import styles from "./Reports.module.css";
@@ -37,7 +36,6 @@ interface ReportsProps {
   reportFilters: ReportFilter[];
   selectedFilters: Record<string, string[]>;
   appliedFilters: Record<string, string[]>;
-  assessments: AssessmentListItem[];
   onReportDefinitionChange: (definitionId: string) => void;
   onFilterChange: (
     filterName: string,
@@ -60,7 +58,6 @@ function Reports({
   reportFilters,
   selectedFilters,
   appliedFilters,
-  assessments,
   onReportDefinitionChange,
   onFilterChange,
   onApplyFilters,
@@ -68,15 +65,6 @@ function Reports({
   onExportReport,
 }: ReportsProps) {
   const [showFilterDropdown, setShowFilterDropdown] = useState(false);
-
-  // Create assessment name-to-ID lookup map
-  const assessmentNameToIdMap = useMemo(() => {
-    const map = new Map<string, string>();
-    assessments.forEach((assessment) => {
-      map.set(assessment.name, assessment.id);
-    });
-    return map;
-  }, [assessments]);
 
   const isRowAssessment = reportData?.rows_dimension === "assessment";
   const isColumnAssessment = reportData?.columns_dimension === "assessment";
@@ -341,7 +329,8 @@ function Reports({
                         )}
                       </th>
                       {reportData.columns.map((column, index) => {
-                        const assessmentId = assessmentNameToIdMap.get(column);
+                        const assessmentId =
+                          typeof column === "string" ? column : column?.id;
                         const isClickable = isColumnAssessment && assessmentId;
 
                         return isClickable ? (
@@ -351,11 +340,15 @@ function Reports({
                                 asmtId: assessmentId,
                               })}
                             >
-                              {column}
+                              {typeof column === "string"
+                                ? column
+                                : column?.name}
                             </Link>
                           </th>
                         ) : (
-                          <th key={index}>{column}</th>
+                          <th key={index}>
+                            {typeof column === "string" ? column : column?.name}
+                          </th>
                         );
                       })}
                     </tr>
@@ -382,7 +375,8 @@ function Reports({
                       </tr>
                     ) : (
                       reportData.rows.map((row, rowIndex) => {
-                        const assessmentId = assessmentNameToIdMap.get(row);
+                        const assessmentId =
+                          typeof row === "string" ? row : row?.id;
                         const isClickable = isRowAssessment && assessmentId;
 
                         return (
@@ -394,11 +388,13 @@ function Reports({
                                     asmtId: assessmentId,
                                   })}
                                 >
-                                  {row}
+                                  {typeof row === "string" ? row : row?.name}
                                 </Link>
                               </td>
                             ) : (
-                              <td className={styles["row-header"]}>{row}</td>
+                              <td className={styles["row-header"]}>
+                                {typeof row === "string" ? row : row?.name}
+                              </td>
                             )}
                             {reportData.data[rowIndex]?.map(
                               (cellValue, cellIndex) => (

--- a/src/pages/admin/reports/ReportsContainer.tsx
+++ b/src/pages/admin/reports/ReportsContainer.tsx
@@ -6,11 +6,9 @@ import {
   useGetReportFilters,
   useExportReport,
   type ReportResponse,
-  useGetReportAssessments,
 } from "@/api/services/reports";
 import toast from "react-hot-toast";
 import Reports from "./Reports";
-import type { AssessmentListItem } from "@/types";
 
 function ReportsContainer() {
   const { keycloak, registered } = useContext(AuthContext)!;
@@ -25,12 +23,6 @@ function ReportsContainer() {
   const [appliedFilters, setAppliedFilters] = useState<
     Record<string, string[]>
   >({});
-  const [shouldFetchAssessments, setShouldFetchAssessments] = useState(false);
-  const [allAssessments, setAllAssessments] = useState<AssessmentListItem[]>(
-    [],
-  );
-  const [isFetchingAllAssessments, setIsFetchingAllAssessments] =
-    useState(false);
 
   const {
     data: reportDefinitions,
@@ -47,39 +39,8 @@ function ReportsContainer() {
     isRegistered: registered,
   });
 
-  const {
-    data: assessmentsData,
-    fetchNextPage,
-    hasNextPage,
-  } = useGetReportAssessments({
-    size: 5,
-    token: keycloak?.token || "",
-    search: "",
-    isRegistered:
-      registered && shouldFetchAssessments && isFetchingAllAssessments,
-  });
-
   const generateReportMutation = useGenerateReport(keycloak?.token || "");
   const exportReportMutation = useExportReport(keycloak?.token || "");
-
-  // Fetch all assessments with pagination
-  useEffect(() => {
-    if (!assessmentsData || !isFetchingAllAssessments) return;
-
-    let tmpAssessments: AssessmentListItem[] = [];
-    if (assessmentsData?.pages) {
-      assessmentsData.pages.map((page) => {
-        tmpAssessments = [...tmpAssessments, ...page.content];
-      });
-      if (hasNextPage) {
-        fetchNextPage();
-      }
-    }
-
-    setAllAssessments(tmpAssessments);
-    setIsFetchingAllAssessments(false);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [assessmentsData, fetchNextPage, hasNextPage, isFetchingAllAssessments]);
 
   const handleGenerateReportForDefinition = useCallback(
     async (definitionId: string, filters?: Record<string, string[]>) => {
@@ -105,16 +66,6 @@ function ReportsContainer() {
         });
         setReportData(result);
 
-        if (
-          (result.rows_dimension === "assessment" ||
-            result.columns_dimension === "assessment") &&
-          !shouldFetchAssessments
-        ) {
-          setAllAssessments([]);
-          setShouldFetchAssessments(true);
-          setIsFetchingAllAssessments(true);
-        }
-
         if (isInitialLoad) {
           setIsInitialLoad(false);
         }
@@ -125,12 +76,7 @@ function ReportsContainer() {
         setIsGenerating(false);
       }
     },
-    [
-      isInitialLoad,
-      selectedFilters,
-      generateReportMutation,
-      shouldFetchAssessments,
-    ],
+    [isInitialLoad, selectedFilters, generateReportMutation],
   );
 
   useEffect(() => {
@@ -252,7 +198,6 @@ function ReportsContainer() {
       reportFilters={reportFilters || []}
       selectedFilters={selectedFilters}
       appliedFilters={appliedFilters}
-      assessments={allAssessments}
       onReportDefinitionChange={handleReportDefinitionChange}
       onFilterChange={handleFilterChange}
       onApplyFilters={handleApplyFilters}

--- a/src/pages/assessments/AssessmentView.tsx
+++ b/src/pages/assessments/AssessmentView.tsx
@@ -24,15 +24,13 @@ const AssessmentView = ({ isPublic }: { isPublic: boolean }) => {
   const navigate = useNavigate();
   const { t } = useTranslation();
 
-  const { keycloak, registered } = useContext(AuthContext)!;
+  const { keycloak, registered, roles } = useContext(AuthContext)!;
   const { asmtId } = useParams();
 
   const asmtNumID = asmtId !== undefined ? asmtId : "";
 
   const hasFullAssessmentAccess =
-    keycloak?.resourceAccess?.["backend-service"]?.roles?.some((role) =>
-      ["admin", "reporter"].includes(role),
-    ) ?? false;
+    roles?.some((role) => ["admin", "reporter"].includes(role)) ?? false;
 
   const { data: reportAssessmentData } = useGetReportAssessmentById({
     id: asmtNumID,


### PR DESCRIPTION
**⚠️ This PR should not be merged before [CAT-1067](https://github.com/FC4E-CAT/fc4e-cat-api/pull/568) is merged.**

This PR refactors the reports feature to utilize assessment data directly from API responses and centralizes role management in the authentication context

- Removed separate assessment data fetching logic from ReportsContainer 
- Implemented direct assessment ID extraction from report data for navigation links using Link component
- Added roles array to AuthContext for centralized role management
- Updated AssessmentView to use roles from authentication context